### PR TITLE
fix default sa name in example app

### DIFF
--- a/examples/simple-app-git/1.yml
+++ b/examples/simple-app-git/1.yml
@@ -4,7 +4,7 @@ metadata:
   name: simple-app
   namespace: default
 spec:
-  serviceAccountName: defaut-ns-sa
+  serviceAccountName: default-ns-sa
   fetch:
   - git:
       url: https://github.com/k14s/k8s-simple-app-example


### PR DESCRIPTION
Just discovered misspelled serviceAccountName while trying it out.