### PR TITLE
Replace master branch references with 'develop'

### DIFF
--- a/docs/app-spec.md
+++ b/docs/app-spec.md
@@ -115,7 +115,7 @@ spec:
         # ignores comments that ytt doesn't recognize
         # (optional; default=false)
         ignoreUnknownComments: true
-        # forces strict mode https://github.com/k14s/ytt/blob/master/docs/strict.md
+        # forces strict mode https://github.com/k14s/ytt/blob/develop/docs/strict.md
         # (optional; default=false)
         strict: true
         # specify additional files, including data values (optional)

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -6,13 +6,13 @@ You can use `kubectl` (or another tool) to deploy the YAML examples below. We've
 
 - Start by [installing](install.md) kapp-controller onto your cluster
 
-- Install [examples/default-ns-rbac.yml](https://github.com/k14s/kapp-controller/blob/master/examples/rbac/default-ns.yml). It creates `default-ns-sa` service account that allows to change any resource within `default` namespace. This will be used by App CR below.
+- Install [examples/default-ns-rbac.yml](https://github.com/k14s/kapp-controller/blob/develop/examples/rbac/default-ns.yml). It creates `default-ns-sa` service account that allows to change any resource within `default` namespace. This will be used by App CR below.
 
 ```bash
-$ kapp deploy -a default-ns-rbac -f https://github.com/k14s/kapp-controller/blob/master/examples/rbac/default-ns.yml
+$ kapp deploy -a default-ns-rbac -f https://github.com/k14s/kapp-controller/blob/develop/examples/rbac/default-ns.yml
 ```
 
-- Install [examples/simple-app-git/1.yml](https://github.com/k14s/kapp-controller/blob/master/examples/simple-app-git/1.yml) App CR. It specifies how to fetch, template, and deploy our example application.
+- Install [examples/simple-app-git/1.yml](https://github.com/k14s/kapp-controller/blob/develop/examples/simple-app-git/1.yml) App CR. It specifies how to fetch, template, and deploy our example application.
 
 ```bash
 $ kapp deploy -a simple-app -f https://raw.githubusercontent.com/k14s/kapp-controller/master/examples/simple-app-git/1.yml


### PR DESCRIPTION
TL;DR
=====
- Fixed stale links pointing to the non-existent `master` branch

Detail
======
Some of the docs included references to the `master` branch, which
appears to have been removed in lieu of `develop`. This simply updates
references to enable someone to walk through the examples in the
documentation verbatim.