### PR TITLE
Use latest release for deployment examples

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,9 +5,9 @@ Grab the latest copy of YAML from the [Releases page](https://github.com/k14s/ka
 Example:
 
 ```bash
-$ kapp deploy -a kc -f https://github.com/k14s/kapp-controller/releases/download/v0.6.0/release.yml
+$ kapp deploy -a kc -f https://github.com/k14s/kapp-controller/releases/latest/download/release.yml
 or
-$ kubectl apply -f https://github.com/k14s/kapp-controller/releases/download/v0.6.0/release.yml
+$ kubectl apply -f https://github.com/k14s/kapp-controller/releases/latest/download/release.yml
 ```
 
 **Note**: As of v0.6.0+, kapp-controller requires each App CR to specify a dedicated service account. This enables kapp-controller to be used _securely_ by users with different levels of privelege (namespace admin vs cluster admin) within the same cluster. If you want to configure kapp-controller to allow cluster admin level access for any user of App CR (not recommended!) you can _temporarily_ use `release-dangerous-allow-shared-sa.yml`. We are planning to remove this configuration in next few releases.


### PR DESCRIPTION
TL;DR
=====
- Stop pointing to an outdated version of kapp-controller in the example
  installation; use latest

Detail
======
Github exposes the latest release at a dedicated endpoint that won't go
stale over time, so this seems more suitable than pinning to a given
release in the installation documentation.