### PR TITLE
Update Hardcoded Repo Name in Workflow

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       with:
-        path: src/github.com/k14s/kapp-controller
+        path: src/github.com/${{ github.repository }}
     - name: Run Tests
       run: |
         set -e -x


### PR DESCRIPTION
Updating checkout step to use `${{ github.repository }}` for its path to help with transitioning to new org. Should be aliased, but might be nice to avoid confusion if someone is reviewing CI process.