### PR TITLE
make loglevel configurable

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -57,7 +57,8 @@ func main() {
 	flag.Parse()
 
 	level := uberzap.NewAtomicLevel()
-	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
+	logLevelErr := level.UnmarshalText([]byte(logLevel))
+	if logLevelErr != nil {
 		level.SetLevel(zapcore.InfoLevel)
 	}
 	logf.SetLogger(zap.New(func(o *zap.Options) {
@@ -67,6 +68,10 @@ func main() {
 
 	entryLog := log.WithName("entrypoint")
 	entryLog.Info("kapp-controller", "version", Version)
+
+	if logLevelErr != nil {
+		entryLog.Error(logLevelErr, "unable to unmarshal log level", "loglevel", logLevel)
+	}
 
 	entryLog.Info("setting up manager")
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"flag"
-	"go.uber.org/zap/zapcore"
 	"os"
 
 	// Pprof related
@@ -17,6 +16,7 @@ import (
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
 	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -53,7 +53,7 @@ func main() {
 	flag.BoolVar(&allowSharedServiceAccount, "dangerous-allow-shared-service-account",
 		false, "If set to true, allow use of shared service account instead of per-app service accounts")
 	flag.BoolVar(&enablePprof, "dangerous-enable-pprof", false, "If set to true, enable pprof on "+pprofListenAddr)
-	flag.StringVar(&logLevel, "loglevel", zapcore.InfoLevel.String(), "Set log level from one of the available options: debug/info/warn/error/dpanic/panic/fatal")
+	flag.StringVar(&logLevel, "log-level", zapcore.InfoLevel.String(), "Set log level from one of the available options: debug/info/warn/error/dpanic/panic/fatal")
 	flag.Parse()
 
 	level := uberzap.NewAtomicLevel()
@@ -71,6 +71,7 @@ func main() {
 
 	if logLevelErr != nil {
 		entryLog.Error(logLevelErr, "unable to unmarshal log level", "loglevel", logLevel)
+		os.Exit(1)
 	}
 
 	entryLog.Info("setting up manager")

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -53,7 +53,7 @@ func main() {
 	flag.BoolVar(&allowSharedServiceAccount, "dangerous-allow-shared-service-account",
 		false, "If set to true, allow use of shared service account instead of per-app service accounts")
 	flag.BoolVar(&enablePprof, "dangerous-enable-pprof", false, "If set to true, enable pprof on "+pprofListenAddr)
-	flag.StringVar(&logLevel, "loglevel", zapcore.InfoLevel.String(), "Log level: debug/info/warn/error/dpanic/panic/fatal")
+	flag.StringVar(&logLevel, "loglevel", zapcore.InfoLevel.String(), "Set log level from one of the available options: debug/info/warn/error/dpanic/panic/fatal")
 	flag.Parse()
 
 	level := uberzap.NewAtomicLevel()

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
+	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/tools v0.0.0-20190926165942-a8d5d34286bd // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect


### PR DESCRIPTION
Hi,
This PR makes the loglevel of the kapp-controller configurable via an argument `loglevel`. Supported loglevels are: debug, info, warn, error, dpanic, panic, fatal. The default is info. 