### PR TITLE
Add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+labels: carvel-triage,bug
+---
+
+**What steps did you take:**
+[A clear and concise description steps that can be used to reproduce the problem.]
+
+**What happened:**
+[A small description of the issue]
+
+**What did you expect:**
+[A description of what was expected]
+
+**Anything else you would like to add:**
+[Additional information that will assist in solving the issue.]
+
+**Environment:**
+
+- kapp Controller version (execute `kubectl get deployment -n kapp-controller kapp-controller -o yaml` and the annotation is `kbld.k14s.io/images`):
+- Kubernetes version (use `kubectl version`)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for kapp controller
+labels: carvel-triage,enhancement
+---
+
+**Describe the problem/challenge you have**
+[A description of the current challenge that you are experiencing.]
+
+
+**Describe the solution you'd like**
+[A clear and concise description of what you want to happen. If applicable a visual representation of the UX.]
+
+
+**Anything else you would like to add:**
+[Additional information that will assist in solving the issue.]

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,0 +1,6 @@
+---
+name: Other issue or question
+about: Free form issue or question
+labels: carvel-triage
+---
+


### PR DESCRIPTION
In this pull request, we add the issue templates for Github to standardize the issue creation for all the carvel products