### PR TITLE
Add ability for users to configure trusted custom ca certs

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -37,7 +37,7 @@ jobs:
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)
 
-        ./hack/deploy.sh
+        ./hack/deploy-test.sh
 
         export KAPPCTRL_E2E_NAMESPACE=kappctrl-test
         kubectl create ns $KAPPCTRL_E2E_NAMESPACE

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y git openssh-client && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 2000 kapp-controller && useradd -r -u 1000 --create-home -g kapp-controller kapp-controller
+RUN chmod g+w /etc/ssl/certs/ca-certificates.crt && chgrp kapp-controller /etc/ssl/certs/ca-certificates.crt
 USER kapp-controller
 
 # Name it kapp-controller to identify it easier in process tree

--- a/config-test/config-map.yml
+++ b/config-test/config-map.yml
@@ -1,0 +1,38 @@
+#@ load("@ytt:data", "data")
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kapp-controller-config
+  namespace: #@ data.values.namespace
+  annotations:
+    kapp.k14s.io/change-group: "kapp-controller.carvel.dev/config"
+data:
+  #! Must match the second cert in the cert chain in kapp-controller/test/e2e/assets/self-signed-https-server.yml
+  caCerts: |
+    -----BEGIN CERTIFICATE-----
+    MIIEXTCCAsWgAwIBAgIQDqAvoGhrmyB/EvhjT/efWzANBgkqhkiG9w0BAQsFADA4
+    MQwwCgYDVQQGEwNVU0ExFjAUBgNVBAoTDUNsb3VkIEZvdW5kcnkxEDAOBgNVBAMT
+    B2Jvc2gtY2EwHhcNMjAxMjIzMTY1OTAxWhcNMjExMjIzMTY1OTAxWjA4MQwwCgYD
+    VQQGEwNVU0ExFjAUBgNVBAoTDUNsb3VkIEZvdW5kcnkxEDAOBgNVBAMTB2Jvc2gt
+    Y2EwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCsMTj5yHLez8jzONu1
+    tv+u0dqzt8UdWCtUtHCDkIiNJIcB3PkGG7x/LvZ0bMydWeFcBq0g15tfG6N6vHnF
+    4p2E9nSe0XjEEnxEkmtdpoFVPZdHTBgc6H5LOMshPH1ARWpuvBnDb87oVinIZBaf
+    7BjhUQcRoGtsomk/R9Ke9FB4rMZUfuY/7CC8lDyP5Y02VeTAUimK6/WfDh3VPB3e
+    vQfXKJY0Ba5s43fIdudV+fcuKDut01oKmiBL6IHLRSrZKta5mg4fgimst6nJ4xvU
+    SWqYWS4yMxf6pOrTHPjbKUqXqbK4Reh+oQoE12WJZ3NvXr1GoDzt1xzTNzUpUVws
+    nQm5Fo9H07mkjKeu8gOrOBQ2FqaK+eZ5FFNV7kToVQj2KVTEbLLcTrF454jhsoSd
+    EOlqVUjtfxGz0dGEuy+IgMvSSjtky7eI08jdBWMiOThQvR3n0Q6TXF/wBwCEfgDa
+    4eVeziaUGPXUsefR2+2ZCQ6Z31SmtUGECciCKmKtZTekKCUCAwEAAaNjMGEwDgYD
+    VR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFDwRpmIKYZvr
+    lKqROus2Ae6gSKkDMB8GA1UdIwQYMBaAFDwRpmIKYZvrlKqROus2Ae6gSKkDMA0G
+    CSqGSIb3DQEBCwUAA4IBgQA/LX15Qb7v/og06XB27TPl9StGBiewrb0WdHEz9H16
+    eN926TwxWKUr6QcbGg6UbNfLUfMC3VicCDMTQCSNhBTUXm+4pKcJsTyM9/Sk/e4U
+    5+l3FTgxXs+3mEoYJy16QlkU1XDr1q6Myo9Kc38d1yUW9OPxBV4Ur3+12uk5ElSC
+    jZu7l+ox2FLds1TmYBhRR/2Jdbm5aoamh4FVpkmDgGedjERREymvnOIMkhWyUfWE
+    L8Sxa2d8427cBieiEP4foLgjWKr2+diCDrBymU/pz/ZMRRpvUc2uFV005/vmDedK
+    xQACQ8ZWBYWzNCV4C0Y5AS1PETxbocZ09Yw6K1XyVveEp8aQ/ROMkAUOObhMD45W
+    GZNwewGU/V7kclDgMwq6R1VXr5R7NtK9V96vi6ZaujoJKvF1PFpZ/IHWcfFkpVoy
+    Fu8L5PIkg4weBW+87kp+CCseEXPUplpqQCAnmVJdvilK6vgKc7T+vzbET8LNw7NX
+    mHOVA3CR2w+yUhN4uiCI1aY=
+    -----END CERTIFICATE-----

--- a/config-test/order-overlay.yml
+++ b/config-test/order-overlay.yml
@@ -1,0 +1,9 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "kapp-controller"}})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/change-rule: "upsert after upserting kapp-controller.carvel.dev/config"

--- a/hack/deploy-test.sh
+++ b/hack/deploy-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+./hack/build.sh && ytt -f config/ -f config-test/ | kbld -f- | kapp deploy -a kc -f- -c -y
+

--- a/pkg/config/global/configurer.go
+++ b/pkg/config/global/configurer.go
@@ -1,0 +1,92 @@
+package global
+
+import (
+	"fmt"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	configMapName   = "kapp-controller-config"
+	caCertsKey      = "caCerts"
+	systemCertsFile = "/etc/ssl/certs/ca-certificates.crt"
+)
+
+type GlobalConfigurer struct {
+	namespace string
+	client    kubernetes.Interface
+}
+
+func NewGlobalConfigurer() (*GlobalConfigurer, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConf := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	namespace, _, err := kubeConf.Namespace()
+	if err != nil {
+		return nil, fmt.Errorf("Getting namespace: %s", err)
+	}
+
+	restConfig := config.GetConfigOrDie()
+	coreClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Buidling client: %s", err)
+	}
+
+	return &GlobalConfigurer{
+		namespace: namespace,
+		client:    coreClient,
+	}, nil
+}
+
+func (gc *GlobalConfigurer) Configure() error {
+	configMap, err := gc.configMap()
+	if err != nil {
+		return fmt.Errorf("Fetching config map: %s", err)
+	}
+
+	if configMap == nil {
+		return nil
+	}
+
+	err = gc.addTrustedCerts(configMap.Data[caCertsKey])
+	if err != nil {
+		return fmt.Errorf("Adding trusted certs: %s", err)
+	}
+
+	return nil
+}
+
+func (gc *GlobalConfigurer) addTrustedCerts(certChain string) (err error) {
+	if certChain == "" {
+		return nil
+	}
+
+	var file *os.File
+	file, err = os.OpenFile(systemCertsFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return fmt.Errorf("Opening certs file: %s", err)
+	}
+
+	_, err = file.Write([]byte("\n" + certChain))
+	if err != nil {
+		_ = file.Close()
+		return err
+	}
+
+	return file.Close()
+}
+
+func (gc *GlobalConfigurer) configMap() (*v1.ConfigMap, error) {
+	configMap, err := gc.client.CoreV1().ConfigMaps(gc.namespace).Get(configMapName, metav1.GetOptions{})
+
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	return configMap, err
+}

--- a/test/e2e/assets/self-signed-https-server.yml
+++ b/test/e2e/assets/self-signed-https-server.yml
@@ -1,0 +1,248 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: https-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: https-server
+  name: https-svc
+spec:
+  selector:
+    app: self-signed-https-server
+  ports:
+  - port: 80
+    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: self-signed-https-server
+  namespace: https-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app:  self-signed-https-server
+  template:
+    metadata:
+      labels:
+        app: self-signed-https-server
+    spec:
+      containers:
+      - name: self-signed-https-server
+        image: nginx
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /www/data
+          name: data
+        - mountPath: /etc/nginx
+          readOnly: true
+          name: nginx-conf
+        - mountPath: /etc/ssl
+          readOnly: true
+          name: nginx-certs
+      volumes:
+      - name: data
+        configMap:
+          name: nginx-data
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+      - name: nginx-certs
+        secret:
+          secretName: nginx-certs
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: https-server
+data:
+  nginx.conf: |
+    events {
+      worker_connections  1024;  ## Default: 1024
+    }
+
+    http {
+      server {
+        listen 80;
+
+        ssl on;
+        ssl_certificate /etc/ssl/https-server.crt;
+        ssl_certificate_key /etc/ssl/https-server.key;
+        server_name https-svc.default.svc.cluster.local;
+
+        location / {
+          root /www/data;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-data
+  namespace: https-server
+data:
+  deployment.yml: |
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: default
+      name: simple-app
+    spec:
+      ports:
+      - port: 80
+        targetPort: 80
+      selector:
+        simple-app: ""
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      namespace: default
+      name: simple-app
+    spec:
+      selector:
+        matchLabels:
+          simple-app: ""
+      template:
+        metadata:
+          labels:
+            simple-app: ""
+        spec:
+          containers:
+          - name: simple-app
+            image: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
+            env:
+            - name: HELLO_MSG
+              value: stranger
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-certs
+  namespace: https-server
+type: Opaque
+stringData:
+  # Certs and key in this secret generated for `https-svc.https-server.svc.cluster.local` using the bosh cli.
+  # The second cert in the `https-server.crt` cert chain must match the ca cert in config-test/config-map.yml
+  # or tests will fail.
+
+  # Bosh cli config used:
+  #
+  # ---
+  # variables:
+  # - name: ca_cert
+  #   type: certificate
+  #   options:
+  #     is_ca: true
+  #     common_name: generated-ca
+  # - name: server_certs
+  #   type: certificate
+  #   options:
+  #     ca: ca_cert
+  #     common_name: https-svc.https-server.svc.cluster.local
+
+  https-server.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIEkTCCAvmgAwIBAgIRAO4xi9GPlZ4tE6/8NSyJFHYwDQYJKoZIhvcNAQELBQAw
+    ODEMMAoGA1UEBhMDVVNBMRYwFAYDVQQKEw1DbG91ZCBGb3VuZHJ5MRAwDgYDVQQD
+    Ewdib3NoLWNhMB4XDTIwMTIyMzE2NTkwMloXDTIxMTIyMzE2NTkwMlowWTEMMAoG
+    A1UEBhMDVVNBMRYwFAYDVQQKEw1DbG91ZCBGb3VuZHJ5MTEwLwYDVQQDEyhodHRw
+    cy1zdmMuaHR0cHMtc2VydmVyLnN2Yy5jbHVzdGVyLmxvY2FsMIIBojANBgkqhkiG
+    9w0BAQEFAAOCAY8AMIIBigKCAYEAm+H+Qys3UqstleDpEKDtKf3PIaob8QlhZiK+
+    z9HGZamo1RDeQx4t7zM2BzzPdHzMlSAJSqlgiItIbmkQQebRWjo6xLw9OF65CHoR
+    KRNuOq4UXs8aOEd1dt+/OgGPKsJsIUMzy+9J6VqYf0vzlLxABadWr4XJok0JFvMS
+    pe2LJ1McQsNiFGlIiXIB7mgotdma79Ya6kivgQ+US6ePjBz2ir78ReB91r0dD+j8
+    2MSiq6PWElty34VqCcPdzbXPtRz5j4XptFsts0VgOvJ+OlwYE7P2M0+qO/R5ofll
+    TRZKZvfnENoykLz3Z2kptcubvvket9LnsBQODfroCd/ei/IxxGAUs2jzPqDzHs7e
+    Zdujz4Sbj2ybzcF+7ZmLfiNr4g9DTV2NeEXoY6I6m9dYtfoBsaRs96mAsup85qlj
+    vzJOELK9CFL7wOhZLYPlerYeEvd0CtpLJ0RVypUuESh99v6fPbVVWdEEWRWHNels
+    qCyaofDe1Vph1Nf3sqcqT1QmEylTAgMBAAGjdTBzMA4GA1UdDwEB/wQEAwIFoDAT
+    BgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQoo/dy
+    rTnapu5oBldSIusAKBWhVjAfBgNVHSMEGDAWgBQ8EaZiCmGb65SqkTrrNgHuoEip
+    AzANBgkqhkiG9w0BAQsFAAOCAYEACd5rWOV1DAIbZSQCqfhEEsTMPCyxc/p347eS
+    sH63gyo7NDKcqHgo2XEfm2Cp/wbQmRjq7I8OV6e41dZrtEQzq1iXto01M/s4ssQk
+    7agDED9+TFSYtRdnWdBre1m9WOECcjw3n2wniLlhMwU2FmBEYc0eDToDUOcWLO+b
+    V/wp1ovtJiRY3VhXkKqgkiQnqYQ80Q7DDjZ5deM0Ezk5KJPL6Gg+wwhWCGVnHCxM
+    wCji7NhZ8XN05b6169haKB4xOnwBWOUaIry8EujAOXiAnYNRpigO9l/isRfbe4H7
+    V7Wvgn9YPPpLLijZ+Ds0fRHCMuHJ4BGjGEe8PrgAYoHIH+iYZhbRbWnbo29vo+cg
+    2e3lpie4i+fv0xLqHsGJ5tu5jBwJHntJpljDr6fQf4uaujZaQsj0BFmbukbL8z9n
+    pqUFdQZZ4aap8mzy5q9u6PlMQPbIq1bWqKom4i7hrrFqWBByXlHDiv6kGOuZ33eM
+    NH20TiArDOCZoizBKVGHP666OWQJ
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIEXTCCAsWgAwIBAgIQDqAvoGhrmyB/EvhjT/efWzANBgkqhkiG9w0BAQsFADA4
+    MQwwCgYDVQQGEwNVU0ExFjAUBgNVBAoTDUNsb3VkIEZvdW5kcnkxEDAOBgNVBAMT
+    B2Jvc2gtY2EwHhcNMjAxMjIzMTY1OTAxWhcNMjExMjIzMTY1OTAxWjA4MQwwCgYD
+    VQQGEwNVU0ExFjAUBgNVBAoTDUNsb3VkIEZvdW5kcnkxEDAOBgNVBAMTB2Jvc2gt
+    Y2EwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCsMTj5yHLez8jzONu1
+    tv+u0dqzt8UdWCtUtHCDkIiNJIcB3PkGG7x/LvZ0bMydWeFcBq0g15tfG6N6vHnF
+    4p2E9nSe0XjEEnxEkmtdpoFVPZdHTBgc6H5LOMshPH1ARWpuvBnDb87oVinIZBaf
+    7BjhUQcRoGtsomk/R9Ke9FB4rMZUfuY/7CC8lDyP5Y02VeTAUimK6/WfDh3VPB3e
+    vQfXKJY0Ba5s43fIdudV+fcuKDut01oKmiBL6IHLRSrZKta5mg4fgimst6nJ4xvU
+    SWqYWS4yMxf6pOrTHPjbKUqXqbK4Reh+oQoE12WJZ3NvXr1GoDzt1xzTNzUpUVws
+    nQm5Fo9H07mkjKeu8gOrOBQ2FqaK+eZ5FFNV7kToVQj2KVTEbLLcTrF454jhsoSd
+    EOlqVUjtfxGz0dGEuy+IgMvSSjtky7eI08jdBWMiOThQvR3n0Q6TXF/wBwCEfgDa
+    4eVeziaUGPXUsefR2+2ZCQ6Z31SmtUGECciCKmKtZTekKCUCAwEAAaNjMGEwDgYD
+    VR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFDwRpmIKYZvr
+    lKqROus2Ae6gSKkDMB8GA1UdIwQYMBaAFDwRpmIKYZvrlKqROus2Ae6gSKkDMA0G
+    CSqGSIb3DQEBCwUAA4IBgQA/LX15Qb7v/og06XB27TPl9StGBiewrb0WdHEz9H16
+    eN926TwxWKUr6QcbGg6UbNfLUfMC3VicCDMTQCSNhBTUXm+4pKcJsTyM9/Sk/e4U
+    5+l3FTgxXs+3mEoYJy16QlkU1XDr1q6Myo9Kc38d1yUW9OPxBV4Ur3+12uk5ElSC
+    jZu7l+ox2FLds1TmYBhRR/2Jdbm5aoamh4FVpkmDgGedjERREymvnOIMkhWyUfWE
+    L8Sxa2d8427cBieiEP4foLgjWKr2+diCDrBymU/pz/ZMRRpvUc2uFV005/vmDedK
+    xQACQ8ZWBYWzNCV4C0Y5AS1PETxbocZ09Yw6K1XyVveEp8aQ/ROMkAUOObhMD45W
+    GZNwewGU/V7kclDgMwq6R1VXr5R7NtK9V96vi6ZaujoJKvF1PFpZ/IHWcfFkpVoy
+    Fu8L5PIkg4weBW+87kp+CCseEXPUplpqQCAnmVJdvilK6vgKc7T+vzbET8LNw7NX
+    mHOVA3CR2w+yUhN4uiCI1aY=
+    -----END CERTIFICATE-----
+  https-server.key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIG4gIBAAKCAYEAm+H+Qys3UqstleDpEKDtKf3PIaob8QlhZiK+z9HGZamo1RDe
+    Qx4t7zM2BzzPdHzMlSAJSqlgiItIbmkQQebRWjo6xLw9OF65CHoRKRNuOq4UXs8a
+    OEd1dt+/OgGPKsJsIUMzy+9J6VqYf0vzlLxABadWr4XJok0JFvMSpe2LJ1McQsNi
+    FGlIiXIB7mgotdma79Ya6kivgQ+US6ePjBz2ir78ReB91r0dD+j82MSiq6PWElty
+    34VqCcPdzbXPtRz5j4XptFsts0VgOvJ+OlwYE7P2M0+qO/R5ofllTRZKZvfnENoy
+    kLz3Z2kptcubvvket9LnsBQODfroCd/ei/IxxGAUs2jzPqDzHs7eZdujz4Sbj2yb
+    zcF+7ZmLfiNr4g9DTV2NeEXoY6I6m9dYtfoBsaRs96mAsup85qljvzJOELK9CFL7
+    wOhZLYPlerYeEvd0CtpLJ0RVypUuESh99v6fPbVVWdEEWRWHNelsqCyaofDe1Vph
+    1Nf3sqcqT1QmEylTAgMBAAECggGALak0Ln6xNOD5eGaqPnm1HtC+5LCMgL1rr1xM
+    IlnjUJIy5z6KrIRhliidEd+pMQkBcEkzD5Cvuy95ZwYVgghXmKNn5YryL9nnP2lq
+    L2sGpd+qDd+CYavk545A2H/ubOsIe3HQ8VLFhrpH4znfPtkps75BsSZyWr1QBU3s
+    T3hWg41fwNq0lyAD5Gbl0+zkx+fW75v6xFfIOPjUSpjpfnRZb2jkQp+wnL9GjQuF
+    TQXEVJyoLzZkXr8YwYWDKiewkO/MYT6/b2sNm+O/KDBneki4lUWHgzRI/h+xQ0a1
+    ANty8hFPEVFnctLRCIe0PnyZq+Mm6em5ZycNy4+Nep05EmLSLwCTkrzfCS9hriKo
+    c1m2tT3Zb/rnBcnfEbovCvLi6b0Ti68tMxOWGO9JXqltl5ewfcHptaWV+BUuSJLF
+    uQpgRBqJ3MR2lQgge5Ny6Wmcg9r0DVdNAEAgUk2dz1ToZV+DB/d2t4ua29YbHXiu
+    HaQlHM/l8jbKBYips5Gg4GdDl5DhAoHBAMIavZ2wBbsMiR+cJgA6RWpqnd30LY6z
+    3LYkkEsUYETAF+yx+bsaibW/kBlaEyCOZyeI94wOxomLjxC0nqMyNIYZZSzYvYuX
+    ALAz9buxvro5sz+OG0OrlwUX3Tn1oRlgk40dx09e2MXZyqNwPCHc1aphZfi11MRP
+    QYDBVZuCH3cEjj1eAZ7VfxVcbi4+bmqowcGLrM87OjbQkcvgoYO8IhixOW8wPl9O
+    BVRrSHTOXftEdCDcHp7QPHoYtJ3izTSbwwKBwQDNlx3e64acoTB0drbRwM878qrv
+    we1UM+LFxcJiUrrW4gHcXcROfWXf9AcsHxC6FxfibS3peNhD3DelWLNwaZ8Y+uti
+    VqFlPAX2J7Wu7BWcgZ0W1DvaUBcYIyYmY3SnzCCZNOurPuz9myxEYJm+mMpJgbzR
+    HTQGP4GSgz+1q3GhjQgJNzWdpLwKUBsZd0YTIZV9w5DJqjtgX8ejWj2wN5aish0h
+    QklZsChdpfCWm1fUR83n3WGEpY2H25lkQWgIszECgcByNImcXhUBGT8U+irht2dg
+    VZrNHP4xGGKkSJ8djb+Ws+9ftNfa3qJn7W47fGQEo8TN3ijIn2jxRMvIaH1uR/vf
+    atG8sUnU9+PPyMKszMgLiieNHW+tQSh6NrBTidJfvBMU1JCQgp3Iy3wO7dpzkhul
+    Q+lbjKDDYF6KAzb7aHRa8rM+KDGL4tIDH380dkdBOknGNwhWZeK6nb0q1+AwQmFN
+    ZfkFEr2gFafNI9Jd544kaQJq0xixGJR8wkyDGQ7kBUECgcAeLmIXOLJRSiSH5Gmg
+    T1Lc9Rn9CpYht2BCMm7/6i89nn4xcJ6B+0y6XOO0qXbWKs+50Nddn/z3sVuF7Yii
+    Jw9RJnzpudgFuZMSeO/mFwhxKmH6WPvUZ8+MHpTaK92TSJc8hpVWVW2LKX2NKDVJ
+    0rpXojEq7cOWazpFXPk8XUfYNJEKcU1wsB9e0DW6PlVON67vgIc/47rFwinXpEbM
+    GM0HY2h9WnLUNNUoMlUodvOk2Um0ET7gr0Egwa86FZQFOvECgcASJomR33IqVW7m
+    6HIYOCm4Jv/Yxl6JQMhV7ibHPkTCsetcynD08q/oMj6CLbZKNZTbLxjQXp7vGDSw
+    1Q/KOtMpLJyaMUD6VqH6tnTQbYstl6ZpbmGNwS/l8dFdi5Jc6q3KwQmzME+UP9mV
+    0ZTdSsq74+hc5DSLy9NUXkn7cPOqRV05JkS/jTIi3xAeTCSrWDpBGumEsFPRLYcx
+    PjCnczNj73SR4BLnGMSBp0D3Cqs364HT1f/l3KvFYxRcD5NxIwU=
+    -----END RSA PRIVATE KEY-----

--- a/test/e2e/http_test.go
+++ b/test/e2e/http_test.go
@@ -118,3 +118,117 @@ spec:
 		}
 	})
 }
+
+func TestHTTPSSelfSignedCerts(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, logger}
+	sas := ServiceAccounts{env.Namespace}
+
+	// When updating, certs and keys must be regenerated for server and added to server.go and config-test/config-map.yml
+	serverNamespace := "https-server"
+
+	yaml1 := fmt.Sprintf(`---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: test-https
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - http:
+      url: https://https-svc.%s.svc.cluster.local:80/deployment.yml
+  template:
+  - ytt: {}
+  deploy:
+  - kapp:
+      intoNs: %s
+`, serverNamespace, env.Namespace) + sas.ForNamespaceYAML()
+
+	name := "test-https"
+	httpsServerName := "test-https-server"
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+		kapp.Run([]string{"delete", "-a", httpsServerName, "-n", serverNamespace})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy https server with self signed certs", func() {
+		kapp.Run([]string{"deploy", "-f", "assets/self-signed-https-server.yml", "-a", httpsServerName})
+	})
+
+	logger.Section("deploy", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+
+		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
+
+		var cr v1alpha1.App
+
+		err := yaml.Unmarshal([]byte(out), &cr)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal: %s", err)
+		}
+
+		expectedStatus := v1alpha1.AppStatus{
+			Conditions: []v1alpha1.AppCondition{{
+				Type:   v1alpha1.ReconcileSucceeded,
+				Status: corev1.ConditionTrue,
+			}},
+			Deploy: &v1alpha1.AppStatusDeploy{
+				ExitCode: 0,
+				Finished: true,
+			},
+			Fetch: &v1alpha1.AppStatusFetch{
+				ExitCode: 0,
+			},
+			Inspect: &v1alpha1.AppStatusInspect{
+				ExitCode: 0,
+			},
+			Template: &v1alpha1.AppStatusTemplate{
+				ExitCode: 0,
+			},
+			ObservedGeneration:  1,
+			FriendlyDescription: "Reconcile succeeded",
+		}
+
+		{
+			// deploy
+			if !strings.Contains(cr.Status.Deploy.Stdout, "Wait to:") {
+				t.Fatalf("Expected non-empty deploy output: '%s'", cr.Status.Deploy.Stdout)
+			}
+			cr.Status.Deploy.StartedAt = metav1.Time{}
+			cr.Status.Deploy.UpdatedAt = metav1.Time{}
+			cr.Status.Deploy.Stdout = ""
+
+			// fetch
+			if !strings.Contains(cr.Status.Fetch.Stdout, "kind: LockConfig") {
+				t.Fatalf("Expected non-empty fetch output: '%s'", cr.Status.Fetch.Stdout)
+			}
+			cr.Status.Fetch.StartedAt = metav1.Time{}
+			cr.Status.Fetch.UpdatedAt = metav1.Time{}
+			cr.Status.Fetch.Stdout = ""
+
+			// inspect
+			if !strings.Contains(cr.Status.Inspect.Stdout, "Resources in app 'test-https-ctrl'") {
+				t.Fatalf("Expected non-empty inspect output: '%s'", cr.Status.Inspect.Stdout)
+			}
+			cr.Status.Inspect.UpdatedAt = metav1.Time{}
+			cr.Status.Inspect.Stdout = ""
+
+			// template
+			cr.Status.Template.UpdatedAt = metav1.Time{}
+			cr.Status.Template.Stderr = ""
+		}
+
+		if !reflect.DeepEqual(expectedStatus, cr.Status) {
+			t.Fatalf("Status is not same: %#v vs %#v", expectedStatus, cr.Status)
+		}
+	})
+
+}


### PR DESCRIPTION
* Users will specify custom ca certs in a config map. Kapp controller
  will read the certs from the config map on startup and add them to
  the system's list of trusted ca certs

Authored-by: Eli Wrenn <ewrenn@pivotal.io>