### PR TITLE
Prevent crash when templating method is invalid

### DIFF
--- a/pkg/app/app_template.go
+++ b/pkg/app/app_template.go
@@ -35,7 +35,7 @@ func (a *App) template(dirPath string) exec.CmdRunResult {
 			template = a.templateFactory.NewSops(*tpl.Sops, genericOpts)
 		default:
 			result.AttachErrorf("%s", fmt.Errorf("Unsupported way to template"))
-			break
+			return result
 		}
 
 		if isStream {


### PR DESCRIPTION
Fixes #66 

When templating a deployment according to the App CRD, kapp-controller
supports different methods, including ytt, helm, etc.

When the user specifies an unsupported method, the code used a "break"
inside a switch statement, which did not have the intended effect and
resulted in a nil pointer deref.

Instead of breaking, return immediately in the case that the user
provided an unsupported templating method in the App CRD.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>