### PR TITLE
Adding golint and goheader linters via golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.34
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+linters:
+  enable:
+    - goheader
+    - golint
+  disable-all: true
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    template-path: code-header-template.txt
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,9 @@ linters:
 # all available settings of specific linters
 linters-settings:
   goheader:
+    values:
+      regexp:
+        copyright-year: 202[0-1]
     template-path: code-header-template.txt
 issues:
   max-issues-per-linter: 0

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -14,7 +14,7 @@ import (
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Initialize gcp client auth plugin
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/cmd/controllerinit/run.go
+++ b/cmd/controllerinit/run.go
@@ -81,7 +81,7 @@ func runControllerCmd(cmdName string, args []string) error {
 }
 
 func configureSystem() error {
-	globalConfigurer, err := global.NewGlobalConfigurer()
+	globalConfigurer, err := global.NewConfigurer()
 	if err != nil {
 		return fmt.Errorf("Creating configurer: %s", err)
 	}

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,2 +1,2 @@
-Copyright 2020 VMware, Inc.
+Copyright {{copyright-year}} VMware, Inc.
 SPDX-License-Identifier: Apache-2.0

--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x -u
+
+./hack/build.sh
+./hack/linter.sh

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+golangci-lint cache clean
+golangci-lint run

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,5 +1,6 @@
- // Copyright 2020 VMware, Inc.
- // SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+// +build tools
 
 package tools
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 )
 
-type AppHooks struct {
+type Hooks struct {
 	BlockDeletion   func() error
 	UnblockDeletion func() error
 	UpdateStatus    func(string) error
@@ -24,7 +24,7 @@ type AppHooks struct {
 type App struct {
 	app     v1alpha1.App
 	appPrev v1alpha1.App
-	hooks   AppHooks
+	hooks   Hooks
 
 	fetchFactory    fetch.Factory
 	templateFactory template.Factory
@@ -36,7 +36,7 @@ type App struct {
 	flushAllStatusUpdates bool
 }
 
-func NewApp(app v1alpha1.App, hooks AppHooks,
+func NewApp(app v1alpha1.App, hooks Hooks,
 	fetchFactory fetch.Factory, templateFactory template.Factory,
 	deployFactory deploy.Factory, log logr.Logger) *App {
 

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -325,9 +325,9 @@ func (a *App) removeAllConditions() {
 	a.app.Status.Conditions = nil
 }
 
-func (a *App) removeCondition(type_ v1alpha1.AppConditionType) {
+func (a *App) removeCondition(appCondType v1alpha1.AppConditionType) {
 	for i, cond := range a.app.Status.Conditions {
-		if cond.Type == type_ {
+		if cond.Type == appCondType {
 			a.app.Status.Conditions = append(a.app.Status.Conditions[:i], a.app.Status.Conditions[i+1:]...)
 			return
 		}

--- a/pkg/app/crd_app.go
+++ b/pkg/app/crd_app.go
@@ -38,7 +38,7 @@ func NewCRDApp(appModel *kcv1alpha1.App, log logr.Logger,
 
 	crdApp := &CRDApp{appModel: appModel, log: log, appClient: appClient}
 
-	crdApp.app = NewApp(*appModel, AppHooks{
+	crdApp.app = NewApp(*appModel, Hooks{
 		BlockDeletion:   crdApp.blockDeletion,
 		UnblockDeletion: crdApp.unblockDeletion,
 		UpdateStatus:    crdApp.updateStatus,

--- a/pkg/deploy/kubeconfig_secrets.go
+++ b/pkg/deploy/kubeconfig_secrets.go
@@ -62,7 +62,7 @@ func (s *KubeconfigSecrets) fetchKubeconfigYAML(nsName string,
 	val, found := secret.Data[key]
 	if !found {
 		var otherKeys []string
-		for otherKey, _ := range secret.Data {
+		for otherKey := range secret.Data {
 			otherKeys = append(otherKeys, otherKey)
 		}
 

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package fetch
 
 import (

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (


### PR DESCRIPTION
Adding go-lint/goheader linters to CI. Also fixing violations flagged by go-lint/goheader. To review those changes, see commit [`ae955d4`](https://github.com/vmware-tanzu/carvel-kapp-controller/commit/ae955d46bc526c165098f8e20dbf965f0908ffc7).