### PR TITLE
Remove carvel-triage from closed issues

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -7,9 +7,8 @@ jobs:
   add-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://k8slt/closed-issue-label-action@sha256:84360552559e0de4dfaaeefcf1ea0a1070a6250621f98539caf3eaad9395feb7
+      - uses: docker://k8slt/github-labeler-action@sha256:69b376b059806729c25c7d1f6cb0c88e1547eae6f57451414d108915bf4ddffd
         if: github.event.issue.state == 'closed' && github.event.issue.closed_at != github.event.comment.created_at
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          ignore-comments: true
-          default-labels: '["carvel-triage"]'
+          add-labels: "carvel-triage"

--- a/.github/workflows/closed-issue.yml
+++ b/.github/workflows/closed-issue.yml
@@ -1,13 +1,13 @@
-name: Reopened issue labeling
+name: Remove label on close
 on:
   issues:
-    types: ['reopened']
+    types: ['closed']
 
 jobs:
-  add-labels:
+  remove-labels:
     runs-on: ubuntu-latest
     steps:
       - uses: docker://k8slt/github-labeler-action@sha256:69b376b059806729c25c7d1f6cb0c88e1547eae6f57451414d108915bf4ddffd
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          add-labels: "carvel-triage"
+          remove-labels: "carvel-triage"


### PR DESCRIPTION
Update the action used to label our issues because the previous one did not allow us to remove issues