### PR TITLE
Only run test-gh workflow for prs when opened or reopened

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -5,6 +5,7 @@ name: test-gh
     - 'docs/**'
     - '*.md'
   pull_request:
+    types: [opened, reopened]
     paths-ignore:
     - 'docs/**'
     - '*.md'


### PR DESCRIPTION
This helps to avoid running the workflow twice when a pull request is opened. Previously, all push/pull request events would result in a new run, which lead to duplicate runs occurring during pull requests.