### PR TITLE
Update CRD to use apiextensions.k8s.io/v1

### DIFF
--- a/config/crd.yml
+++ b/config/crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apps.kappctrl.k14s.io
@@ -10,27 +10,50 @@ spec:
     plural: apps
     singular: app
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Description
+      type: string
+      description: Friendly description
+      jsonPath: .status.friendlyDescription
+    - name: Since-Deploy
+      type: date
+      description: Last time app started being deployed. Does not mean anything was changed.
+      jsonPath: .status.deploy.startedAt
+    - name: Age
+      type: date
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created.
+        It is not guaranteed to be set in happens-before order across separate operations.
+        Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists.
+        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
   - name: v1alpha1
     served: true
     storage: true
-  additionalPrinterColumns:
-  - name: Description
-    type: string
-    description: Friendly description
-    JSONPath: .status.friendlyDescription
-  - name: Since-Deploy
-    type: date
-    description: Last time app started being deployed. Does not mean anything was changed.
-    JSONPath: .status.deploy.startedAt
-  - name: Age
-    type: date
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created.
-      It is not guaranteed to be set in happens-before order across separate operations.
-      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists.
-      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-    JSONPath: .metadata.creationTimestamp
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Description
+      type: string
+      description: Friendly description
+      jsonPath: .status.friendlyDescription
+    - name: Since-Deploy
+      type: date
+      description: Last time app started being deployed. Does not mean anything was changed.
+      jsonPath: .status.deploy.startedAt
+    - name: Age
+      type: date
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created.
+        It is not guaranteed to be set in happens-before order across separate operations.
+        Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists.
+        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
The existing apiextensions.k8s.io/v1beta1 is deprecated as of k8s 1.16.
This updates the CRD yaml to use the current v1 API version to avoid
deprecation warnings being emitted when applying this CRD.

Closes: #38