### PR TITLE
Adding Linters for Checking for Deadcode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ linters:
   enable:
     - goheader
     - golint
+    - deadcode
+    - unused
   disable-all: true
 # all available settings of specific linters
 linters-settings:

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -267,12 +267,3 @@ func (a *App) setDeleteCompleted(result exec.CmdRunResult) {
 func (a *App) removeAllConditions() {
 	a.app.Status.Conditions = nil
 }
-
-func (a *App) removeCondition(appCondType v1alpha1.AppConditionType) {
-	for i, cond := range a.app.Status.Conditions {
-		if cond.Type == appCondType {
-			a.app.Status.Conditions = append(a.app.Status.Conditions[:i], a.app.Status.Conditions[i+1:]...)
-			return
-		}
-	}
-}

--- a/pkg/app/crd_app.go
+++ b/pkg/app/crd_app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/reftracker"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -27,8 +26,6 @@ func init() {
 type CRDApp struct {
 	app      *App
 	appModel *kcv1alpha1.App
-	nsName   types.NamespacedName // TODO fill in?
-
 	log       logr.Logger
 	appClient kcclient.Interface
 }

--- a/pkg/reftracker/ref_key.go
+++ b/pkg/reftracker/ref_key.go
@@ -14,15 +14,15 @@ func NewRefKey(kind, refName, namespace string) RefKey {
 }
 
 func NewSecretKey(refName, namespace string) RefKey {
-	return RefKey{"secret", refName, namespace}
+	return NewRefKey("secret", refName, namespace)
 }
 
 func NewConfigMapKey(refName, namespace string) RefKey {
-	return RefKey{"configmap", refName, namespace}
+	return NewRefKey("configmap", refName, namespace)
 }
 
 func NewAppKey(refName, namespace string) RefKey {
-	return RefKey{"app", refName, namespace}
+	return NewRefKey("app", refName, namespace)
 }
 
 func (r RefKey) Kind() string {


### PR DESCRIPTION
This pull request adds linters to detect if any deadcode is in any changes being added to kapp-controller. 

Currently, there are only two instances of unused code. For now, I have marked them to not be linted since I can see the field and func being useful in the future, but can also remove them.

