### PR TITLE
feat(template.helm): Support for Helm Chart spec v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,13 @@ RUN wget -O- https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.
   echo "d36b6ef34cb43966ebf7404edb83b30d9f819b62ea5bc08b1dadb805fd72ce1a  /usr/local/bin/vendir" | sha256sum -c - && \
   chmod +x /usr/local/bin/vendir && vendir version
 
+
+# [DEPRECATED] Helm V2
+# Maintaining two versions of helm until we drop support in a future release
+RUN wget -O- https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz > /helm && \
+  echo "f3bec3c7c55f6a9eb9e6586b8c503f370af92fe987fcbf741f37707606d70296  /helm" | sha256sum -c - && \
+  mkdir /helm-v2-unpacked && tar -C /helm-v2-unpacked -xzvf /helm
+
 RUN wget -O- https://get.helm.sh/helm-v3.5.3-linux-amd64.tar.gz > /helm && \
   echo "2170a1a644a9e0b863f00c17b761ce33d4323da64fc74562a3a6df2abbf6cd70  /helm" | sha256sum -c - && \
   mkdir /helm-unpacked && tar -C /helm-unpacked -xzvf /helm
@@ -68,6 +75,7 @@ USER kapp-controller
 COPY --from=0 /go/src/github.com/vmware-tanzu/carvel-kapp-controller/controller kapp-controller
 
 # fetchers
+COPY --from=0 /helm-v2-unpacked/linux-amd64/helm helmv2
 COPY --from=0 /helm-unpacked/linux-amd64/helm .
 COPY --from=0 /usr/local/bin/imgpkg .
 COPY --from=0 /usr/local/bin/vendir .

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,8 @@ RUN wget -O- https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.
   echo "d36b6ef34cb43966ebf7404edb83b30d9f819b62ea5bc08b1dadb805fd72ce1a  /usr/local/bin/vendir" | sha256sum -c - && \
   chmod +x /usr/local/bin/vendir && vendir version
 
-# helm
-RUN wget -O- https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz > /helm && \
-  echo "f3bec3c7c55f6a9eb9e6586b8c503f370af92fe987fcbf741f37707606d70296  /helm" | sha256sum -c - && \
+RUN wget -O- https://get.helm.sh/helm-v3.5.3-linux-amd64.tar.gz > /helm && \
+  echo "2170a1a644a9e0b863f00c17b761ce33d4323da64fc74562a3a6df2abbf6cd70  /helm" | sha256sum -c - && \
   mkdir /helm-unpacked && tar -C /helm-unpacked -xzvf /helm
 
 # sops

--- a/examples/redis-helm.yml
+++ b/examples/redis-helm.yml
@@ -8,7 +8,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "11.3.4"
+      version: "12.10.1"
       repository:
         url: https://charts.bitnami.com/bitnami
   template:

--- a/pkg/template/helm_template.go
+++ b/pkg/template/helm_template.go
@@ -51,7 +51,7 @@ func (t *HelmTemplate) TemplateDir(dirPath string) (exec.CmdRunResult, bool) {
 		namespace = t.opts.Namespace
 	}
 
-	args := []string{"template", chartPath, "--name", name, "--namespace", namespace}
+	args := []string{"template", name, chartPath, "--namespace", namespace, "--include-crds"}
 
 	for _, source := range t.opts.ValuesFrom {
 		var paths []string

--- a/pkg/template/helm_template.go
+++ b/pkg/template/helm_template.go
@@ -179,7 +179,7 @@ func (t *HelmTemplate) writeFile(dstPath, subPath string, content []byte) (strin
 	return newPath, nil
 }
 
-type helmTemplateCMDArgs struct {
+type helmTemplateCmdArgs struct {
 	binaryName string
 	args       []string
 }
@@ -187,10 +187,10 @@ type helmTemplateCMDArgs struct {
 const helmBinaryName = "helm"
 
 // DEPRECATED
-const helm2ChartSpecVersion = "v1"
 const helm2BinaryName = "helmv2"
+const helm2ChartSpecVersion = "v1"
 
-// auxiliary struct used during Chart.yaml unmarshall
+// auxiliary struct used for Chart.yaml unmarshalling
 type chartSpec struct {
 	APIVersion string
 }
@@ -199,7 +199,8 @@ type chartSpec struct {
 // Returns the Helm Binary Name and the arguments required to be passed to the "helm template" subcommand
 // The returned values depend on the ApiVersion property inside the Chart.yaml file.
 // apiVersion==v1 will fallback to old Helm 2 binary and command format.
-func helmTemplateCmdLookup(releaseName, chartPath, namespace string) (*helmTemplateCMDArgs, error) {
+func helmTemplateCmdLookup(releaseName, chartPath, namespace string) (*helmTemplateCmdArgs, error) {
+	// Load [chartPath]/Chart.yaml and inspect apiVersion value.
 	bs, err := ioutil.ReadFile(path.Join(chartPath, "Chart.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("helmTemplateCmdLookup: %w", err)
@@ -210,8 +211,8 @@ func helmTemplateCmdLookup(releaseName, chartPath, namespace string) (*helmTempl
 		return nil, fmt.Errorf("helmTemplateCmdLookup: %w", err)
 	}
 
-	// By default use Helm 3+ format except for chart.apiSpec=v1
-	res := &helmTemplateCMDArgs{
+	// By default, use Helm 3+ format except for chart.apiSpec=v1
+	res := &helmTemplateCmdArgs{
 		binaryName: helmBinaryName,
 		args:       []string{"template", releaseName, chartPath, "--namespace", namespace, "--include-crds"},
 	}

--- a/pkg/template/helm_template_test.go
+++ b/pkg/template/helm_template_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/memdir"
+)
+
+func TestHelmTemplateCmdLookup(t *testing.T) {
+	tests := []struct {
+		chartSpecVersion string                // i.e v1 or v2
+		binaryName       string                // returned helm binary name
+		args             func(string) []string // returned helm template arguments
+	}{
+		{
+			"v1",
+			helm2BinaryName,
+			func(path string) []string {
+				return []string{"template", path, "--name", "testRelease", "--namespace", "testNs"}
+			},
+		},
+		{
+			"v2",
+			helmBinaryName,
+			func(path string) []string {
+				return []string{"template", "testRelease", path, "--namespace", "testNs", "--include-crds"}
+			},
+		},
+		{
+			"v3", // Non existent today but will fallback to newer version of the binary and format
+			helmBinaryName,
+			func(path string) []string {
+				return []string{"template", "testRelease", path, "--namespace", "testNs", "--include-crds"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tmpDir, err := newTestChartPath(tc.chartSpecVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tmpDir.Remove()
+
+		cmd, err := helmTemplateCmdLookup("testRelease", tmpDir.Path(), "testNs")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := cmd.binaryName, tc.binaryName; got != want {
+			t.Errorf("got=%q, want=%q", got, want)
+		}
+
+		if got, want := cmd.args, tc.args(tmpDir.Path()); !reflect.DeepEqual(got, want) {
+			t.Errorf("got=%q, want=%q", got, want)
+		}
+	}
+
+}
+
+// Create a temporary testing directory containing a Chart.yaml file
+func newTestChartPath(specVersion string) (*memdir.TmpDir, error) {
+	chartSpecContent := fmt.Sprintf(`
+apiVersion: %s
+appVersion: 5.6.2
+name: myApp
+`, specVersion)
+
+	tmpDir := memdir.NewTmpDir("chartPath")
+	err := tmpDir.Create()
+	if err != nil {
+		return nil, err
+	}
+
+	chartPath := tmpDir.Path()
+
+	err = ioutil.WriteFile(path.Join(chartPath, "Chart.yaml"), []byte(chartSpecContent), 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpDir, nil
+}

--- a/pkg/template/helm_template_test.go
+++ b/pkg/template/helm_template_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package template
+package template_test
 
 import (
 	"fmt"
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/memdir"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 )
 
 func TestHelmTemplateCmdLookup(t *testing.T) {
@@ -21,21 +22,21 @@ func TestHelmTemplateCmdLookup(t *testing.T) {
 	}{
 		{
 			"v1",
-			helm2BinaryName,
+			"helmv2",
 			func(path string) []string {
 				return []string{"template", path, "--name", "testRelease", "--namespace", "testNs"}
 			},
 		},
 		{
 			"v2",
-			helmBinaryName,
+			"helm",
 			func(path string) []string {
 				return []string{"template", "testRelease", path, "--namespace", "testNs", "--include-crds"}
 			},
 		},
 		{
 			"v3", // Non existent today but will fallback to newer version of the binary and format
-			helmBinaryName,
+			"helm",
 			func(path string) []string {
 				return []string{"template", "testRelease", path, "--namespace", "testNs", "--include-crds"}
 			},
@@ -49,16 +50,16 @@ func TestHelmTemplateCmdLookup(t *testing.T) {
 		}
 		defer tmpDir.Remove()
 
-		cmd, err := helmTemplateCmdLookup("testRelease", tmpDir.Path(), "testNs")
+		cmd, err := template.NewHelmTemplateCmdArgs("testRelease", tmpDir.Path(), "testNs")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if got, want := cmd.binaryName, tc.binaryName; got != want {
+		if got, want := cmd.BinaryName, tc.binaryName; got != want {
 			t.Errorf("got=%q, want=%q", got, want)
 		}
 
-		if got, want := cmd.args, tc.args(tmpDir.Path()); !reflect.DeepEqual(got, want) {
+		if got, want := cmd.Args, tc.args(tmpDir.Path()); !reflect.DeepEqual(got, want) {
 			t.Errorf("got=%q, want=%q", got, want)
 		}
 	}

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -21,11 +21,34 @@ func TestHelm(t *testing.T) {
 	kapp := Kapp{t, env.Namespace, logger}
 	sas := ServiceAccounts{env.Namespace}
 
-	yaml1 := fmt.Sprintf(`
+	expectedStatus := &v1alpha1.AppStatus{
+		Conditions: []v1alpha1.AppCondition{{
+			Type:   v1alpha1.ReconcileSucceeded,
+			Status: corev1.ConditionTrue,
+		}},
+		Deploy: &v1alpha1.AppStatusDeploy{
+			ExitCode: 0,
+			Finished: true,
+		},
+		Fetch: &v1alpha1.AppStatusFetch{
+			ExitCode: 0,
+		},
+		Inspect: &v1alpha1.AppStatusInspect{
+			ExitCode: 0,
+		},
+		Template: &v1alpha1.AppStatusTemplate{
+			ExitCode: 0,
+		},
+		ConsecutiveReconcileSuccesses: 1,
+		ObservedGeneration:            1,
+		FriendlyDescription:           "Reconcile succeeded",
+	}
+
+	helmV2YAML := fmt.Sprintf(`
 apiVersion: kappctrl.k14s.io/v1alpha1
 kind: App
 metadata:
-  name: test-helm
+  name: test-helm-v2
   annotations:
     kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
 spec:
@@ -33,6 +56,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
+      # Chart version v1, DEPRECATED 
       version: "11.3.4"
       repository:
         url: https://charts.bitnami.com/bitnami
@@ -56,81 +80,114 @@ stringData:
     password: "1234567891234"
 `, env.Namespace) + sas.ForNamespaceYAML()
 
-	name := "test-helm"
-	cleanUp := func() {
-		kapp.Run([]string{"delete", "-a", name})
-	}
+	helmV3YAML := fmt.Sprintf(`
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: test-helm
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - helmChart:
+      name: redis
+      version: "12.10.1"
+      repository:
+        url: https://charts.bitnami.com/bitnami
+  template:
+  - helmTemplate:
+      valuesFrom:
+      - secretRef:
+          name: test-helm-values
+  deploy:
+  - kapp:
+      intoNs: %s
+      delete:
+        rawOptions: ["--apply-ignored=true"]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-helm-values
+stringData:
+  data.yml: |
+    password: "1234567891234"
+`, env.Namespace) + sas.ForNamespaceYAML()
 
-	cleanUp()
-	defer cleanUp()
-
-	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
-
-		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
-
-		var cr v1alpha1.App
-
-		err := yaml.Unmarshal([]byte(out), &cr)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal: %s", err)
-		}
-
-		expectedStatus := v1alpha1.AppStatus{
-			Conditions: []v1alpha1.AppCondition{{
-				Type:   v1alpha1.ReconcileSucceeded,
-				Status: corev1.ConditionTrue,
-			}},
-			Deploy: &v1alpha1.AppStatusDeploy{
-				ExitCode: 0,
-				Finished: true,
-			},
-			Fetch: &v1alpha1.AppStatusFetch{
-				ExitCode: 0,
-			},
-			Inspect: &v1alpha1.AppStatusInspect{
-				ExitCode: 0,
-			},
-			Template: &v1alpha1.AppStatusTemplate{
-				ExitCode: 0,
-			},
-			ConsecutiveReconcileSuccesses: 1,
-			ObservedGeneration:            1,
-			FriendlyDescription:           "Reconcile succeeded",
-		}
-
+	tests := []struct {
+		desc           string
+		appCRName      string
+		deploymentYAML string
+		expectedStatus *v1alpha1.AppStatus
+	}{
 		{
-			// deploy
-			if !strings.Contains(cr.Status.Deploy.Stdout, "Wait to:") {
-				t.Fatalf("Expected non-empty deploy output: '%s'", cr.Status.Deploy.Stdout)
+			"Helm v2 (chart spec v1) deployment",
+			"test-helm-v2",
+			helmV2YAML,
+			expectedStatus,
+		},
+		{
+			"Helm v3 (chart spec v2) deployment",
+			"test-helm",
+			helmV3YAML,
+			expectedStatus,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			cleanUp := func() {
+				kapp.Run([]string{"delete", "-a", tc.appCRName})
 			}
-			cr.Status.Deploy.StartedAt = metav1.Time{}
-			cr.Status.Deploy.UpdatedAt = metav1.Time{}
-			cr.Status.Deploy.Stdout = ""
+			cleanUp()
+			defer cleanUp()
 
-			// fetch
-			if !strings.Contains(cr.Status.Fetch.Stdout, "kind: LockConfig") {
-				t.Fatalf("Expected non-empty fetch output: '%s'", cr.Status.Fetch.Stdout)
-			}
-			cr.Status.Fetch.StartedAt = metav1.Time{}
-			cr.Status.Fetch.UpdatedAt = metav1.Time{}
-			cr.Status.Fetch.Stdout = ""
+			logger.Section("deploy", func() {
+				kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", tc.appCRName},
+					RunOpts{IntoNs: true, StdinReader: strings.NewReader(tc.deploymentYAML)})
 
-			// inspect
-			if !strings.Contains(cr.Status.Inspect.Stdout, "Resources in app 'test-helm-ctrl'") {
-				t.Fatalf("Expected non-empty inspect output: '%s'", cr.Status.Inspect.Stdout)
-			}
-			cr.Status.Inspect.UpdatedAt = metav1.Time{}
-			cr.Status.Inspect.Stdout = ""
+				out := kapp.Run([]string{"inspect", "-a", tc.appCRName, "--raw", "--tty=false", "--filter-kind=App"})
 
-			// template
-			cr.Status.Template.UpdatedAt = metav1.Time{}
-			cr.Status.Template.Stderr = ""
-		}
+				var cr v1alpha1.App
 
-		if !reflect.DeepEqual(expectedStatus, cr.Status) {
-			t.Fatalf("Status is not same: %#v vs %#v", expectedStatus, cr.Status)
-		}
-	})
+				err := yaml.Unmarshal([]byte(out), &cr)
+				if err != nil {
+					t.Fatalf("Failed to unmarshal: %s", err)
+				}
+
+				{
+					// deploy
+					if !strings.Contains(cr.Status.Deploy.Stdout, "Wait to:") {
+						t.Fatalf("Expected non-empty deploy output: '%s'", cr.Status.Deploy.Stdout)
+					}
+					cr.Status.Deploy.StartedAt = metav1.Time{}
+					cr.Status.Deploy.UpdatedAt = metav1.Time{}
+					cr.Status.Deploy.Stdout = ""
+
+					// fetch
+					if !strings.Contains(cr.Status.Fetch.Stdout, "kind: LockConfig") {
+						t.Fatalf("Expected non-empty fetch output: '%s'", cr.Status.Fetch.Stdout)
+					}
+					cr.Status.Fetch.StartedAt = metav1.Time{}
+					cr.Status.Fetch.UpdatedAt = metav1.Time{}
+					cr.Status.Fetch.Stdout = ""
+
+					// inspect
+					if !strings.Contains(cr.Status.Inspect.Stdout, fmt.Sprintf("Resources in app '%s-ctrl'", tc.appCRName)) {
+						t.Fatalf("Expected non-empty inspect output: '%s'", cr.Status.Inspect.Stdout)
+					}
+					cr.Status.Inspect.UpdatedAt = metav1.Time{}
+					cr.Status.Inspect.Stdout = ""
+
+					// template
+					cr.Status.Template.UpdatedAt = metav1.Time{}
+					cr.Status.Template.Stderr = ""
+				}
+
+				if !reflect.DeepEqual(*tc.expectedStatus, cr.Status) {
+					t.Fatalf("Status is not same: %#v vs %#v", expectedStatus, cr.Status)
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
Hi,

UPDATE: Changed the approach to follow the "option b" described [here](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/53#issuecomment-814368436). The code now chooses both the binary and the right arguments for the `helm template` command based on the apiVersion in the `Chart.yaml` file. If you are interested in seeing the more simplistic solution of maintaining only one binary (option a), visit back this previous commit 9e9bd0abe2e86e10abb1f6e9aa9ef4b83f901972.

> NOTE: The approach chosen here has not been agreed by the core maintainers ([waiting for feedback](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/53#issuecomment-814394241)). I am creating this PR just to kick of the contribution tires :). That way I can get familiar with the source code, CI e2e testing, CLA and so on. Happy to change/scrap it if necessary.

~This PR adds support to templating Helm Chart v2 templates by upgrading the bundled Helm binary to V3. The approach followed is the "option a" described [here](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/53#issuecomment-814368436), some additional comments about the change:~

* The e2e test now runs both an old chart (v1 spec) and a v2 one to showcase backward compatibility.
* ~The `template` command format has changed so it needed to be updated accordingly.~
* The template args and binary names are chosen programatically. I tried to encapsulate this logic so it can be stripped easily in the future.
* I took a look at `vendir` [fetch code](https://github.com/vmware-tanzu/carvel-vendir/blob/develop/pkg/vendir/fetch/helmchart/sync.go#L143) which seems to leverages the `fetch` command which to my knowledge has not changed from v2 to v3. I can see that in vendir there is code to explicitly load a Helm 3 binary `helmBinary = "helm3"` but I can't figure out its purpose since the code does not seem to leverage new Helm functionality such as OCI registry pulls. What am I missing? 
* I bumped the chart version in `examples/redis-helm.yml` to use a non deprecated Chart. I also tried to bump `examples/nginx-helm-git.yml` but for this one it can not be done since newer versions of the chart have subchart dependencies, and kapp-controller does not run `helm dep update` (this is not a problem in the redis case because we fetch from a release tarball not from git). We could choose a different app though, let me know your preference.
* ~I was thinking about adding unit tests to the `templateDir` method at `pkg/template/helm_template.go` but that (I think) would require some work to decouple the code from the `helm` binary, using interfaces for example. I decided not to do so because that change might be too intrusive taking into account that this is my first contribution and risky since I do not know the codebase well enough. if you find it necessary I am happy to revisit that.~
* Added some unit tests for the new branching logic
* I tried to be consistent with the used imported libraries for yaml unmarshalling, filesystem handling and so on. Let me know if I missed anything. 
 
Let me know your thoughts!

Cheers!
Miguel

Closes #53