### PR TITLE
Change exit status 1 error message to suggest UsefulErrorMessage

### DIFF
--- a/pkg/app/app_reconcile_test.go
+++ b/pkg/app/app_reconcile_test.go
@@ -52,15 +52,15 @@ func Test_NoInspectReconcile_IfNoDeployAttempted(t *testing.T) {
 		Conditions: []v1alpha1.AppCondition{{
 			Type:    v1alpha1.ReconcileFailed,
 			Status:  corev1.ConditionTrue,
-			Message: "Fetching resources: exit status 1",
+			Message: "Fetching resources: Error (see .status.usefulErrorMessage for details)",
 		}},
 		Fetch: &v1alpha1.AppStatusFetch{
-			Error:    "Fetching resources: exit status 1",
+			Error:    "Fetching resources: Error (see .status.usefulErrorMessage for details)",
 			ExitCode: 1,
 		},
 		ConsecutiveReconcileFailures: 1,
 		ObservedGeneration:           0,
-		FriendlyDescription:          "Reconcile failed: Fetching resources: exit status 1",
+		FriendlyDescription:          "Reconcile failed: Fetching resources: Error (see .status.usefulErrorMessage for details)",
 		UsefulErrorMessage:           "Error: Syncing directory '0': Syncing directory '.' with HTTP contents: Downloading URL: Initiating URL download: Get i-dont-exist: unsupported protocol scheme \"\"\n",
 	}
 
@@ -114,18 +114,18 @@ foo: bar`,
 		Conditions: []v1alpha1.AppCondition{{
 			Type:    v1alpha1.ReconcileFailed,
 			Status:  corev1.ConditionTrue,
-			Message: "Templating dir: exit status 1",
+			Message: "Templating dir: Error (see .status.usefulErrorMessage for details)",
 		}},
 		Fetch: &v1alpha1.AppStatusFetch{
 			ExitCode: 0,
 		},
 		Template: &v1alpha1.AppStatusTemplate{
-			Error:    "Templating dir: exit status 1",
+			Error:    "Templating dir: Error (see .status.usefulErrorMessage for details)",
 			ExitCode: 1,
 		},
 		ConsecutiveReconcileFailures: 1,
 		ObservedGeneration:           0,
-		FriendlyDescription:          "Reconcile failed: Templating dir: exit status 1",
+		FriendlyDescription:          "Reconcile failed: Templating dir: Error (see .status.usefulErrorMessage for details)",
 		UsefulErrorMessage:           "ytt: Error: Non-ytt comment at line file.yml:1: '# comment':\n  Unrecognized comment type (expected '#@' or '#!'). (hint: if this is plain YAML — not a template — consider `--file-mark '<filename>:type=yaml-plain'`)\n",
 	}
 

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -35,7 +35,12 @@ func (r *CmdRunResult) AttachErrorf(msg string, err error) {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			r.ExitCode = exitError.ExitCode()
 		}
-		r.Error = fmt.Errorf(msg, err)
+
+		if err.Error() == "exit status 1" {
+			r.Error = fmt.Errorf(msg, "Error (see .status.usefulErrorMessage for details)")
+		} else {
+			r.Error = fmt.Errorf(msg, err)
+		}
 	}
 }
 

--- a/test/e2e/app_status_test.go
+++ b/test/e2e/app_status_test.go
@@ -71,12 +71,12 @@ spec:
 		Conditions: []v1alpha1.AppCondition{{
 			Type:   v1alpha1.ReconcileFailed,
 			Status: corev1.ConditionTrue,
-			Message: "Deploying: exit status 1",
+			Message: "Deploying: Error (see .status.usefulErrorMessage for details)",
 		}},
 		Deploy: &v1alpha1.AppStatusDeploy{
 			ExitCode: 1,
 			Finished: true,
-			Error: "Deploying: exit status 1",
+			Error: "Deploying: Error (see .status.usefulErrorMessage for details)",
 		},
 		Fetch: &v1alpha1.AppStatusFetch{
 			ExitCode: 0,
@@ -90,7 +90,7 @@ spec:
 		ConsecutiveReconcileSuccesses: 0,
 		ConsecutiveReconcileFailures:  1,
 		ObservedGeneration:            1,
-		FriendlyDescription:           "Reconcile failed: Deploying: exit status 1",
+		FriendlyDescription:           "Reconcile failed: Deploying: Error (see .status.usefulErrorMessage for details)",
 		UsefulErrorMessage:            "kapp: Error: Checking existance of resource configmap/configmap (v1) namespace: does-not-exist: configmaps \"configmap\" is forbidden:\n  User \"system:serviceaccount:" + env.Namespace + ":kappctrl-e2e-ns-sa\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"does-not-exist\" (reason: Forbidden)",
 	}
 

--- a/test/e2e/service_account_test.go
+++ b/test/e2e/service_account_test.go
@@ -85,7 +85,7 @@ spec:
 			t.Fatalf("Expected err, but was nil")
 		}
 
-		if !strings.Contains(err.Error(), "Reconcile failed:  (message: Deploying: exit status 1)") {
+		if !strings.Contains(err.Error(), "Reconcile failed:  (message: Deploying: Error (see .status.usefulErrorMessage for details))") {
 			t.Fatalf("Expected err to contain service account failure, but was: %s", err)
 		}
 


### PR DESCRIPTION
This helps to address the following proposed solution for issue #110 outlined in this [comment](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/110#issuecomment-814492293). The proposed solution was as follows:

> Having friendlyDescription display more relevant information than exit status 1. Perhaps something that explicitly calls out to view the section of the status stderr section or proposed most recent error field.

This pull request changes error messages with `exit status 1` to `check UsefulErrorMessage in status for more details` to help users more quickly locate error information. The current message proposed highlights using `UsefulErrorMessage` introduced in #157.

Open to any suggestions on better suggested message rather than `check UsefulErrorMessage in status for more details`. 