### PR TITLE
Delete app if serviceaccount does not exist and no resources deployed

### DIFF
--- a/pkg/apis/kappctrl/v1alpha1/types.go
+++ b/pkg/apis/kappctrl/v1alpha1/types.go
@@ -77,8 +77,9 @@ type AppStatus struct {
 	ObservedGeneration int64          `json:"observedGeneration"`
 	Conditions         []AppCondition `json:"conditions"`
 
-	FriendlyDescription string `json:"friendlyDescription"`
-	UsefulErrorMessage  string `json:"usefulErrorMessage"`
+	FriendlyDescription  string `json:"friendlyDescription"`
+	UsefulErrorMessage   string `json:"usefulErrorMessage"`
+	HasDeployedResources bool
 }
 
 type AppStatusFetch struct {

--- a/pkg/app/app_deploy.go
+++ b/pkg/app/app_deploy.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	ctldep "github.com/vmware-tanzu/carvel-kapp-controller/pkg/deploy"
@@ -63,6 +64,10 @@ func (a *App) delete(changedFunc func(exec.CmdRunResult)) exec.CmdRunResult {
 
 				kapp, err := a.newKapp(*dep.Kapp, cancelCh)
 				if err != nil {
+					if strings.Contains(err.Error(), "Getting service account") && !a.app.Status.HasDeployedResources {
+						err = a.unblockDeletion()
+					}
+
 					return exec.NewCmdRunResultWithErr(fmt.Errorf("Preparing kapp: %s", err))
 				}
 

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
@@ -160,6 +161,10 @@ func (a *App) updateLastDeploy(result exec.CmdRunResult) exec.CmdRunResult {
 		Error:     result.ErrorStr(),
 		StartedAt: a.app.Status.Deploy.StartedAt,
 		UpdatedAt: metav1.NewTime(time.Now().UTC()),
+	}
+
+	if strings.Contains(a.app.Status.Deploy.Stdout, "ok: reconcile") {
+		a.app.Status.HasDeployedResources = true
 	}
 
 	a.updateStatus("marking last deploy")

--- a/pkg/customerrors/serviceaccount_error.go
+++ b/pkg/customerrors/serviceaccount_error.go
@@ -1,0 +1,25 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package customerrors
+
+const (
+	ServiceAccountNotFound = 1
+)
+
+type ServiceAccountError struct {
+	errorMsg string
+	kind     int
+}
+
+func NewServiceAccountError(errorMsg string, kind int) *ServiceAccountError {
+	return &ServiceAccountError{errorMsg, kind}
+}
+
+func (s ServiceAccountError) Error() string {
+	return s.errorMsg
+}
+
+func (s ServiceAccountError) Kind() int {
+	return s.kind
+}

--- a/pkg/deploy/factory.go
+++ b/pkg/deploy/factory.go
@@ -6,6 +6,7 @@ package deploy
 import (
 	"fmt"
 
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/customerrors"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -30,7 +31,8 @@ func (f Factory) NewKapp(opts v1alpha1.AppDeployKapp, saName string,
 	case len(saName) > 0:
 		genericOpts, err = f.serviceAccounts.Find(genericOpts, saName)
 		if err != nil {
-			return nil, err
+			saErr := customerrors.NewServiceAccountError(err.Error(), customerrors.ServiceAccountNotFound)
+			return nil, saErr
 		}
 
 	case clusterOpts != nil:

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -85,6 +85,7 @@ spec:
 			ConsecutiveReconcileSuccesses: 1,
 			ObservedGeneration:            1,
 			FriendlyDescription:           "Reconcile succeeded",
+			HasDeployedResources:          true,
 		}
 
 		{
@@ -199,6 +200,7 @@ spec:
 			ConsecutiveReconcileSuccesses: 1,
 			ObservedGeneration:            1,
 			FriendlyDescription:           "Reconcile succeeded",
+			HasDeployedResources:          true,
 		}
 
 		{

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -42,6 +42,7 @@ func TestHelm(t *testing.T) {
 		ConsecutiveReconcileSuccesses: 1,
 		ObservedGeneration:            1,
 		FriendlyDescription:           "Reconcile succeeded",
+		HasDeployedResources:          true,
 	}
 
 	helmV2YAML := fmt.Sprintf(`

--- a/test/e2e/http_test.go
+++ b/test/e2e/http_test.go
@@ -83,6 +83,7 @@ spec:
 			ConsecutiveReconcileSuccesses: 1,
 			ObservedGeneration:            1,
 			FriendlyDescription:           "Reconcile succeeded",
+			HasDeployedResources:          true,
 		}
 
 		{
@@ -197,6 +198,7 @@ spec:
 			ConsecutiveReconcileSuccesses: 1,
 			ObservedGeneration:            1,
 			FriendlyDescription:           "Reconcile succeeded",
+			HasDeployedResources:          true,
 		}
 
 		{

--- a/test/e2e/imgpkg_bundle_test.go
+++ b/test/e2e/imgpkg_bundle_test.go
@@ -87,6 +87,7 @@ spec:
 			ConsecutiveReconcileSuccesses: 1,
 			ObservedGeneration:            1,
 			FriendlyDescription:           "Reconcile succeeded",
+			HasDeployedResources:          true,
 		}
 
 		{


### PR DESCRIPTION
Closes #114 

This pull request adds the ability to delete an App CR in the event that the user forgot to initially deploy appropriate RBAC for the App. It also preserves existing behavior (i.e. not proceeding with delete) for Apps that have been deployed successfully but where the serviceaccount has been deleted.

For Apps that have never deployed any resources successfully, this approach simply removes the finalizer for the App. It is known whether the App has deployed resources at some point via a new App status field called `HasDeployedResources`.