### PR TITLE
Guard against events that have nil objects

### DIFF
--- a/pkg/apiserver/registry/packages/crd_rest.go
+++ b/pkg/apiserver/registry/packages/crd_rest.go
@@ -260,7 +260,9 @@ func (r *CRDREST) packageToInternalPackage(pkg *packages.Package) *installv1alph
 }
 
 func (r *CRDREST) translate(evt watch.Event) watch.Event {
-	intpkg := evt.Object.(*installv1alpha1.InternalPackage)
-	evt.Object = r.internalPackageToPackage(intpkg)
+	if evt.Object != nil {
+		intpkg := evt.Object.(*installv1alpha1.InternalPackage)
+		evt.Object = r.internalPackageToPackage(intpkg)
+	}
 	return evt
 }


### PR DESCRIPTION
* After some period of time, this watcher gets an event with a nil
  objet and causes a crash.