### PR TITLE
Allow Users to Provide Schema for Package Values

### DIFF
--- a/config/install.package.carvel.dev_internalpackages.yaml
+++ b/config/install.package.carvel.dev_internalpackages.yaml
@@ -403,12 +403,11 @@ spec:
               - spec
               type: object
             valuesSchema:
-              additionalProperties:
-                type: string
               description: valuesSchema can be used to show template values that can
                 be configured by users when a Package is installed in an OpenAPI schema
                 format.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             version:
               type: string
           type: object

--- a/config/install.package.carvel.dev_internalpackages.yaml
+++ b/config/install.package.carvel.dev_internalpackages.yaml
@@ -402,6 +402,13 @@ spec:
               required:
               - spec
               type: object
+            valuesSchema:
+              additionalProperties:
+                type: string
+              description: valuesSchema can be used to show template values that can
+                be configured by users when a Package is installed in an OpenAPI schema
+                format.
+              type: object
             version:
               type: string
           type: object

--- a/config/install.package.carvel.dev_internalpackages.yaml
+++ b/config/install.package.carvel.dev_internalpackages.yaml
@@ -407,7 +407,8 @@ spec:
                 be configured by users when a Package is installed in an OpenAPI schema
                 format.
               properties:
-                openAPISchemaV3:
+                openAPIv3:
+                  nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
               type: object

--- a/config/install.package.carvel.dev_internalpackages.yaml
+++ b/config/install.package.carvel.dev_internalpackages.yaml
@@ -406,8 +406,11 @@ spec:
               description: valuesSchema can be used to show template values that can
                 be configured by users when a Package is installed in an OpenAPI schema
                 format.
+              properties:
+                openAPISchemaV3:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
               type: object
-              x-kubernetes-preserve-unknown-fields: true
             version:
               type: string
           type: object

--- a/pkg/apiserver/apis/packages/types.go
+++ b/pkg/apiserver/apis/packages/types.go
@@ -6,6 +6,7 @@ package packages
 import (
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +genclient
@@ -57,7 +58,8 @@ type PackageSpec struct {
 	// can be configured by users when a Package is installed
 	// in an OpenAPI schema format.
 	// +optional
-	ValuesSchema map[string]string `json:"valuesSchema,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	ValuesSchema runtime.RawExtension `json:"valuesSchema,omitempty"`
 }
 
 type Maintainer struct {

--- a/pkg/apiserver/apis/packages/types.go
+++ b/pkg/apiserver/apis/packages/types.go
@@ -58,8 +58,7 @@ type PackageSpec struct {
 	// can be configured by users when a Package is installed
 	// in an OpenAPI schema format.
 	// +optional
-	// +kubebuilder:pruning:PreserveUnknownFields
-	ValuesSchema runtime.RawExtension `json:"valuesSchema,omitempty"`
+	ValuesSchema ValuesSchema `json:"valuesSchema,omitempty"`
 }
 
 type Maintainer struct {
@@ -73,4 +72,10 @@ type AppTemplateSpec struct {
 type PackageStatus struct {
 	ObservedGeneration int64                     `json:"observedGeneration"`
 	Conditions         []kcv1alpha1.AppCondition `json:"conditions"`
+}
+
+type ValuesSchema struct {
+	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
+	OpenAPISchemaV3 runtime.RawExtension `json:"openAPISchemaV3,omitempty"`
 }

--- a/pkg/apiserver/apis/packages/types.go
+++ b/pkg/apiserver/apis/packages/types.go
@@ -76,6 +76,7 @@ type PackageStatus struct {
 
 type ValuesSchema struct {
 	// +optional
+	// +nullable
 	// +kubebuilder:pruning:PreserveUnknownFields
-	OpenAPISchemaV3 runtime.RawExtension `json:"openAPISchemaV3,omitempty"`
+	OpenAPIv3 runtime.RawExtension `json:"openAPIv3,omitempty"`
 }

--- a/pkg/apiserver/apis/packages/types.go
+++ b/pkg/apiserver/apis/packages/types.go
@@ -54,6 +54,7 @@ type PackageSpec struct {
 
 	Template AppTemplateSpec `json:"template,omitempty"`
 	// TODO ValuesSchema
+	ValuesSchema map[string]string `json:"valuesSchema,omitempty"`
 }
 
 type Maintainer struct {

--- a/pkg/apiserver/apis/packages/types.go
+++ b/pkg/apiserver/apis/packages/types.go
@@ -53,7 +53,10 @@ type PackageSpec struct {
 	ReleasedAt string `json:"releasedAt,omitempty"`
 
 	Template AppTemplateSpec `json:"template,omitempty"`
-	// TODO ValuesSchema
+	// valuesSchema can be used to show template values that
+	// can be configured by users when a Package is installed
+	// in an OpenAPI schema format.
+	// +optional
 	ValuesSchema map[string]string `json:"valuesSchema,omitempty"`
 }
 

--- a/pkg/apiserver/apis/packages/v1alpha1/package.go
+++ b/pkg/apiserver/apis/packages/v1alpha1/package.go
@@ -54,6 +54,7 @@ type PackageSpec struct {
 
 	Template AppTemplateSpec `json:"template,omitempty"`
 	// TODO ValuesSchema
+	ValuesSchema map[string]string `json:"valuesSchema,omitempty"`
 }
 
 type Maintainer struct {

--- a/pkg/apiserver/apis/packages/v1alpha1/package.go
+++ b/pkg/apiserver/apis/packages/v1alpha1/package.go
@@ -53,7 +53,10 @@ type PackageSpec struct {
 	ReleasedAt string `json:"releasedAt,omitempty"`
 
 	Template AppTemplateSpec `json:"template,omitempty"`
-	// TODO ValuesSchema
+	// valuesSchema can be used to show template values that
+	// can be configured by users when a Package is installed
+	// in an OpenAPI schema format.
+	// +optional
 	ValuesSchema map[string]string `json:"valuesSchema,omitempty"`
 }
 

--- a/pkg/apiserver/apis/packages/v1alpha1/package.go
+++ b/pkg/apiserver/apis/packages/v1alpha1/package.go
@@ -5,8 +5,8 @@ package v1alpha1
 
 import (
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/packages"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +genclient
@@ -59,7 +59,7 @@ type PackageSpec struct {
 	// in an OpenAPI schema format.
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
-	ValuesSchema runtime.RawExtension `json:"valuesSchema,omitempty"`
+	ValuesSchema packages.ValuesSchema `json:"valuesSchema,omitempty"`
 }
 
 type Maintainer struct {

--- a/pkg/apiserver/apis/packages/v1alpha1/package.go
+++ b/pkg/apiserver/apis/packages/v1alpha1/package.go
@@ -6,6 +6,7 @@ package v1alpha1
 import (
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +genclient
@@ -57,7 +58,8 @@ type PackageSpec struct {
 	// can be configured by users when a Package is installed
 	// in an OpenAPI schema format.
 	// +optional
-	ValuesSchema map[string]string `json:"valuesSchema,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	ValuesSchema runtime.RawExtension `json:"valuesSchema,omitempty"`
 }
 
 type Maintainer struct {

--- a/pkg/apiserver/apis/packages/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apiserver/apis/packages/v1alpha1/zz_generated.conversion.go
@@ -160,6 +160,7 @@ func autoConvert_v1alpha1_PackageSpec_To_packages_PackageSpec(in *PackageSpec, o
 	out.CapactiyRequirementsDescription = in.CapactiyRequirementsDescription
 	out.Licenses = *(*[]string)(unsafe.Pointer(&in.Licenses))
 	out.ReleasedAt = in.ReleasedAt
+	out.ValuesSchema = in.ValuesSchema
 	if err := Convert_v1alpha1_AppTemplateSpec_To_packages_AppTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -186,6 +187,7 @@ func autoConvert_packages_PackageSpec_To_v1alpha1_PackageSpec(in *packages.Packa
 	out.CapactiyRequirementsDescription = in.CapactiyRequirementsDescription
 	out.Licenses = *(*[]string)(unsafe.Pointer(&in.Licenses))
 	out.ReleasedAt = in.ReleasedAt
+	out.ValuesSchema = in.ValuesSchema
 	if err := Convert_packages_AppTemplateSpec_To_v1alpha1_AppTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}

--- a/test/e2e/package_test.go
+++ b/test/e2e/package_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/installpackage/v1alpha1"
+)
+
+func Test_PackageWithValuesSchema_PreservesSchemaData(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, logger}
+	kubectl := Kubectl{t: t, namespace: env.Namespace, l: logger}
+	name := "pkg-with-schema"
+
+	pkgYaml := fmt.Sprintf(`---
+apiVersion: package.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: %s
+spec:
+  publicName: pkg.fail.carvel.dev
+  version: 1.0.0
+  displayName: "Test Package in repo"
+  description: "Package used for testing"
+  valuesSchema:
+    {
+   "properties": {
+      "svc_port": {
+        "description": "Port number for service. Defaults to 80.",
+         "type": "int"
+      },
+      "hello_msg": {
+         "description": "The message simple-app will display",
+         "type": "string"
+      }
+   }
+}
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: k8slt/kctrl-example-pkg:v1.0.0
+      template:
+      - ytt:
+          paths:
+          - "config.yml"
+          - "values.yml"
+      - kbld:
+          paths:
+          - "-"
+          - ".imgpkg/images.yml"
+      deploy:
+      - kapp: {}`, name)
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(pkgYaml)})
+
+	out := kubectl.Run([]string{"get", "packages/pkg-with-schema", "-o=jsonpath={.spec.valuesSchema}"})
+	if !strings.Contains(out, "properties") && !strings.Contains(out, "hello_msg") && !strings.Contains(out, "svc_port") {
+		t.Fatalf("Could not find properties on values schema. Got:\n%s", out)
+	}
+
+	out = kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=Package"})
+	var cr v1alpha1.InternalPackage
+	err := yaml.Unmarshal([]byte(out), &cr)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %s", err)
+	}
+
+	var into interface{}
+	err = json.Unmarshal(cr.Spec.ValuesSchema.Raw, &into)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %s", err)
+	}
+}

--- a/test/e2e/package_test.go
+++ b/test/e2e/package_test.go
@@ -17,7 +17,7 @@ func Test_PackageWithValuesSchema_PreservesSchemaData(t *testing.T) {
 	logger := Logger{}
 	kapp := Kapp{t, env.Namespace, logger}
 	kubectl := Kubectl{t: t, namespace: env.Namespace, l: logger}
-	name := "pkg-with-schema"
+	name := "pkg-with-schema.1.0.0"
 
 	pkgYaml := fmt.Sprintf(`---
 apiVersion: package.carvel.dev/v1alpha1
@@ -25,7 +25,7 @@ kind: Package
 metadata:
   name: %s
 spec:
-  publicName: pkg.fail.carvel.dev
+  publicName: pkg-with-schema
   version: 1.0.0
   displayName: "Test Package in repo"
   description: "Package used for testing"
@@ -63,7 +63,7 @@ spec:
 
 	kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(pkgYaml)})
 
-	out := kubectl.Run([]string{"get", "packages/pkg-with-schema", "-o=jsonpath={.spec.valuesSchema.openAPIv3}"})
+	out := kubectl.Run([]string{"get", "packages/"+name, "-o=jsonpath={.spec.valuesSchema.openAPIv3}"})
 	if !strings.Contains(out, "properties") && !strings.Contains(out, "hello_msg") && !strings.Contains(out, "svc_port") {
 		t.Fatalf("Could not find properties on values schema. Got:\n%s", out)
 	}

--- a/test/e2e/package_test.go
+++ b/test/e2e/package_test.go
@@ -31,7 +31,8 @@ spec:
   displayName: "Test Package in repo"
   description: "Package used for testing"
   valuesSchema:
-    {
+    openAPISchemaV3:
+      {
    "properties": {
       "svc_port": {
         "description": "Port number for service. Defaults to 80.",
@@ -68,7 +69,7 @@ spec:
 
 	kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(pkgYaml)})
 
-	out := kubectl.Run([]string{"get", "packages/pkg-with-schema", "-o=jsonpath={.spec.valuesSchema}"})
+	out := kubectl.Run([]string{"get", "packages/pkg-with-schema", "-o=jsonpath={.spec.valuesSchema.openAPISchemaV3}"})
 	if !strings.Contains(out, "properties") && !strings.Contains(out, "hello_msg") && !strings.Contains(out, "svc_port") {
 		t.Fatalf("Could not find properties on values schema. Got:\n%s", out)
 	}
@@ -81,7 +82,7 @@ spec:
 	}
 
 	var into interface{}
-	err = json.Unmarshal(cr.Spec.ValuesSchema.Raw, &into)
+	err = json.Unmarshal(cr.Spec.ValuesSchema.OpenAPISchemaV3.Raw, &into)
 	if err != nil {
 		t.Fatalf("failed to unmarshal: %s", err)
 	}

--- a/test/e2e/package_test.go
+++ b/test/e2e/package_test.go
@@ -31,7 +31,7 @@ spec:
   displayName: "Test Package in repo"
   description: "Package used for testing"
   valuesSchema:
-    openAPISchemaV3:
+    openAPIv3:
       {
    "properties": {
       "svc_port": {
@@ -69,7 +69,7 @@ spec:
 
 	kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, RunOpts{StdinReader: strings.NewReader(pkgYaml)})
 
-	out := kubectl.Run([]string{"get", "packages/pkg-with-schema", "-o=jsonpath={.spec.valuesSchema.openAPISchemaV3}"})
+	out := kubectl.Run([]string{"get", "packages/pkg-with-schema", "-o=jsonpath={.spec.valuesSchema.openAPIv3}"})
 	if !strings.Contains(out, "properties") && !strings.Contains(out, "hello_msg") && !strings.Contains(out, "svc_port") {
 		t.Fatalf("Could not find properties on values schema. Got:\n%s", out)
 	}
@@ -82,7 +82,7 @@ spec:
 	}
 
 	var into interface{}
-	err = json.Unmarshal(cr.Spec.ValuesSchema.OpenAPISchemaV3.Raw, &into)
+	err = json.Unmarshal(cr.Spec.ValuesSchema.OpenAPIv3.Raw, &into)
 	if err != nil {
 		t.Fatalf("failed to unmarshal: %s", err)
 	}

--- a/test/e2e/package_test.go
+++ b/test/e2e/package_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -32,18 +31,13 @@ spec:
   description: "Package used for testing"
   valuesSchema:
     openAPIv3:
-      {
-   "properties": {
-      "svc_port": {
-        "description": "Port number for service. Defaults to 80.",
-         "type": "int"
-      },
-      "hello_msg": {
-         "description": "The message simple-app will display",
-         "type": "string"
-      }
-   }
-}
+      properties:
+        svc_port:
+          description: Port number for service. Defaults to 80.
+          type: int
+        hello_msg:
+          description: The message simple-app will display
+          type: string
   template:
     spec:
       fetch:
@@ -82,7 +76,7 @@ spec:
 	}
 
 	var into interface{}
-	err = json.Unmarshal(cr.Spec.ValuesSchema.OpenAPIv3.Raw, &into)
+	err = yaml.Unmarshal(cr.Spec.ValuesSchema.OpenAPIv3.Raw, &into)
 	if err != nil {
 		t.Fatalf("failed to unmarshal: %s", err)
 	}


### PR DESCRIPTION
Closes #104 

This pull request adds the property `valuesSchema` to Packages to allow users to provide an open API schema for data values that can be configured by users during installation. Since the implementation currently is represented as `map[string]string`, users can provide any key to access a schema like below:

```yaml
---
apiVersion: package.carvel.dev/v1alpha1
kind: Package
metadata:
  name: simple-app.corp.com.1.0.0
spec:
  publicName: simple-app.corp.com
  version: 1.0.0
  valuesSchema:
    openAPIV3JSON: |
      {...}
```

We can add further validation or change the `map[string]string` to a struct to restrict what keys are allowed if we would like and will supplement this feature with docs to recommend ways to specify key:value pairs for adding a schema. 

As mentioned in #104, validation of values with this schema is out of scope. Additionally, users will have to manually declare these value schemas until automation is available from tools like `ytt` to generate/add these schemas to Packages.