### PR TITLE
Supplement hack/gen-crds.sh with overlay for internalpackagemetadata

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -43,6 +43,8 @@ jobs:
         mkdir /tmp/bin
         export PATH=/tmp/bin:$PATH
 
+        ./hack/verify-no-dirty-files.sh
+
         wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-linux-amd64 > /tmp/bin/minikube
         echo "9d34cb50bc39f80d39f92d1fb7cb23a271504b519f5e805574894d395ce3e7b3  /tmp/bin/minikube" | sha256sum -c -
         chmod +x /tmp/bin/minikube

--- a/config/crd-overlay.yml
+++ b/config/crd-overlay.yml
@@ -18,3 +18,11 @@ spec:
 #@overlay/remove
 #@overlay/match missing_ok=True
 status:
+
+#@overlay/match by=overlay.subset({"metadata":{"name":"internalpackagemetadata.internal.packaging.carvel.dev"}}), expects="0+"
+---
+metadata:
+  name: internalpackagemetadatas.internal.packaging.carvel.dev
+spec:
+  names:
+    plural: internalpackagemetadatas

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,6 +13,7 @@ go mod tidy
 go build $repro_flags -mod=vendor -o controller ./cmd/main.go
 ls -la ./controller
 
+./hack/gen-crds.sh
 ytt -f config/ >/dev/null
 
 echo SUCCESS

--- a/hack/crd-overlay.yml
+++ b/hack/crd-overlay.yml
@@ -19,7 +19,7 @@ spec:
 #@overlay/match missing_ok=True
 status:
 
-#@overlay/match by=overlay.subset({"metadata":{"name":"internalpackagemetadata.internal.packaging.carvel.dev"}}), expects="0+"
+#@overlay/match by=overlay.subset({"metadata":{"name":"internalpackagemetadata.internal.packaging.carvel.dev"}})
 ---
 metadata:
   name: internalpackagemetadatas.internal.packaging.carvel.dev

--- a/hack/deploy-test.sh
+++ b/hack/deploy-test.sh
@@ -3,4 +3,3 @@
 set -e
 
 ./hack/build.sh && ytt -f config/ -f config-test/ | kbld -f- | kapp deploy -a kc -f- -c -y
-

--- a/hack/gen-crds.sh
+++ b/hack/gen-crds.sh
@@ -11,6 +11,6 @@ go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go \
   output:dir=./tmp/crds \
   paths=./pkg/apis/...
 
-ytt -f tmp/crds -f config/crd-overlay.yml > config/crds.yml
+ytt -f tmp/crds -f ./hack/crd-overlay.yml > config/crds.yml
 
 rm -rf tmp/crds

--- a/hack/verify-no-dirty-files.sh
+++ b/hack/verify-no-dirty-files.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+./hack/build.sh
+
+if ! git diff --exit-code >/dev/null; then
+  echo "Error: Running ./hack/build.sh resulted in non zero exit code from git diff. Please run './hack/build.sh' and 'git add' the generated file(s)."
+  echo "Showing diff:"
+  git diff --exit-code
+  exit 1
+fi

--- a/pkg/apis/internalpackaging/v1alpha1/types.go
+++ b/pkg/apis/internalpackaging/v1alpha1/types.go
@@ -11,6 +11,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=internalpackagemetadata
 type InternalPackageMetadata struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.


### PR DESCRIPTION
Since the autogenerated clients use [internalpackagemetadatas](https://github.com/vmware-tanzu/carvel-kapp-controller/blob/c7eb79b7d62aad63339928d561081898c4918352/pkg/client/clientset/versioned/typed/internalpackaging/v1alpha1/internalpackagemetadata.go#L55) as plural, crds need s added to be consistent.

By default, `controller-gen` has `internalpackagemetadata` as the plural name of the CRD so this preserves the automation of the script.