### PR TITLE
Backfill PackageInstall Upgrade Test and Fix Test_PackageRepoDelete

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -45,8 +45,8 @@ jobs:
 
         ./hack/verify-no-dirty-files.sh
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-linux-amd64 > /tmp/bin/minikube
-        echo "9d34cb50bc39f80d39f92d1fb7cb23a271504b519f5e805574894d395ce3e7b3  /tmp/bin/minikube" | sha256sum -c -
+        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64 > /tmp/bin/minikube
+        echo "5d423a00a24fdfbb95627a3fadbf58540fc4463be2338619257c529f93cf061b  /tmp/bin/minikube" | sha256sum -c -
         chmod +x /tmp/bin/minikube
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)

--- a/test/e2e/package_repo_test.go
+++ b/test/e2e/package_repo_test.go
@@ -221,6 +221,8 @@ spec:
 		kctl.RunWithOpts([]string{"delete", "package/pkg.test.carvel.dev.2.0.0"}, RunOpts{AllowError: true})
 		kctl.RunWithOpts([]string{"delete", "packagemetadata/pkg.test.carvel.dev"}, RunOpts{AllowError: true})
 		kctl.RunWithOpts([]string{"delete", "pkgr/basic.test.carvel.dev"}, RunOpts{AllowError: true})
+		// kapp delete still needed in event checking if packages existing fails
+		kapp.Run([]string{"delete", "-a","repo"})
 	}
 	defer cleanUp()
 
@@ -230,7 +232,7 @@ spec:
 	})
 
 	logger.Section("check packages exist", func() {
-		retry(t, 20*time.Second, func() error {
+		retry(t, 30*time.Second, func() error {
 			_, err := kctl.RunWithOpts([]string{"get", "pkgm/pkg.test.carvel.dev"}, RunOpts{AllowError: true})
 			if err != nil {
 				return fmt.Errorf("Expected to find pkgm pkg.test.carvel.dev, but couldn't: %v", err)


### PR DESCRIPTION
This pull request backfills a test for PackageInstalls upgrading from one Package version to another. 

It also makes changes to `Test_PackageRepoDelete` as documented below:
* PackageRepo creation may have slightly slower performance with addition of b380458 so bumping timeout for test
* In event checking if Packages exist fails, kapp delete may not be run for test. Added to cleanUp() func.

This pull request changes minikube version to 1.21 to address earlier issues with deploying kapp-controller in CI: https://github.com/vmware-tanzu/carvel-kapp-controller/runs/2956127108?check_suite_focus=true