### PR TITLE
Update minikube version to 1.21

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -45,8 +45,8 @@ jobs:
 
         ./hack/verify-no-dirty-files.sh
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.10.0/minikube-linux-amd64 > /tmp/bin/minikube
-        echo "9d34cb50bc39f80d39f92d1fb7cb23a271504b519f5e805574894d395ce3e7b3  /tmp/bin/minikube" | sha256sum -c -
+        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64 > /tmp/bin/minikube
+        echo "5d423a00a24fdfbb95627a3fadbf58540fc4463be2338619257c529f93cf061b  /tmp/bin/minikube" | sha256sum -c -
         chmod +x /tmp/bin/minikube
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)


### PR DESCRIPTION
This pull request changes minikube version to 1.21 to address earlier issues with deploying kapp-controller in CI: https://github.com/vmware-tanzu/carvel-kapp-controller/runs/2956127108?check_suite_focus=true