### PR TITLE
Fix tests and associated test assets for new bundle format

### DIFF
--- a/examples/packaging-with-repo/package-repository.yml
+++ b/examples/packaging-with-repo/package-repository.yml
@@ -10,4 +10,4 @@ spec:
   fetch:
     imgpkgBundle:
       # Created via `imgpkg push -b ... -f ./test/e2e/assets/kc-e2e-test-repo`
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:0a1188ca009df9b449ddc19f38e9707521f2415335fcd17b253608869dd870fd
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:c827fa462ae7fdb9670fb6719c189cb2e8e11f62822e2a13e8eaeaf42ec72c93

--- a/test/e2e/assets/kc-e2e-test-repo/.imgpkg/images.yml
+++ b/test/e2e/assets/kc-e2e-test-repo/.imgpkg/images.yml
@@ -3,7 +3,7 @@ apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
     kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v1.0.0
-  image: index.docker.io/k8slt/kctrl-example-pkg@sha256:95241524c255f8d811152e09a3ec3de71cb00385c6c463228fb448ccffdf1628
+  image: index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75
 - annotations:
     kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v2.0.0
   image: index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a

--- a/test/e2e/package_repo_test.go
+++ b/test/e2e/package_repo_test.go
@@ -100,7 +100,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:0a1188ca009df9b449ddc19f38e9707521f2415335fcd17b253608869dd870fd`
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:c827fa462ae7fdb9670fb6719c189cb2e8e11f62822e2a13e8eaeaf42ec72c93`
 
 	cleanUp := func() {
 		kapp.Run([]string{"delete", "-a", name})
@@ -173,7 +173,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:0a1188ca009df9b449ddc19f38e9707521f2415335fcd17b253608869dd870fd`
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:c827fa462ae7fdb9670fb6719c189cb2e8e11f62822e2a13e8eaeaf42ec72c93`
 
 	cleanUp := func() {
 		kubectl.Run([]string{"delete", "pkgr/basic.test.carvel.dev"})
@@ -214,7 +214,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:0a1188ca009df9b449ddc19f38e9707521f2415335fcd17b253608869dd870fd`
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:c827fa462ae7fdb9670fb6719c189cb2e8e11f62822e2a13e8eaeaf42ec72c93`
 
 	cleanUp := func() {
 		kctl.RunWithOpts([]string{"delete", "package/pkg.test.carvel.dev.1.0.0"}, RunOpts{AllowError: true})

--- a/test/e2e/package_test.go
+++ b/test/e2e/package_test.go
@@ -38,8 +38,7 @@ spec:
       template:
       - ytt:
           paths:
-          - "config.yml"
-          - "values.yml"
+          - config/
       - kbld:
           paths:
           - "-"
@@ -86,8 +85,7 @@ spec:
       template:
       - ytt:
           paths:
-          - "config.yml"
-          - "values.yml"
+          - config/
       - kbld:
           paths:
           - "-"
@@ -152,8 +150,7 @@ spec:
       template:
       - ytt:
           paths:
-          - "config.yml"
-          - "values.yml"
+          - config/
       - kbld:
           paths:
           - "-"

--- a/test/e2e/packageinstall_test.go
+++ b/test/e2e/packageinstall_test.go
@@ -203,8 +203,7 @@ spec:
       template:
       - ytt:
           paths:
-          - "config.yml"
-          - "values.yml"
+          - config/
       - kbld:
           paths:
           - "-"
@@ -291,7 +290,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:0a1188ca009df9b449ddc19f38e9707521f2415335fcd17b253608869dd870fd
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:c827fa462ae7fdb9670fb6719c189cb2e8e11f62822e2a13e8eaeaf42ec72c93
 ---
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall


### PR DESCRIPTION
Our documentation examples recommend storing configs in a folder called config/ for bundles. These test updates reflect this new file structure but change no test outcomes.

Co-Authored-By: Joe Kimmel <86852107+joe-kimmel-vmw@users.noreply.github.com>