### PR TITLE
One installer script usable for both Docker and MacOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,26 +22,8 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR /go/src/github.com/vmware-tanzu/carvel-kapp-controller/
 
 # carvel
-RUN wget -O- https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.35.1/ytt-linux-amd64 > /usr/local/bin/ytt && \
-  echo "0aa78f7b5f5a0a4c39bddfed915172880344270809c26b9844e9d0cbf6437030  /usr/local/bin/ytt" | sha256sum -c - && \
-  chmod +x /usr/local/bin/ytt && ytt version
-
-RUN wget -O- https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.37.0/kapp-linux-amd64 > /usr/local/bin/kapp && \
-  echo "f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538  /usr/local/bin/kapp" | sha256sum -c - && \
-  chmod +x /usr/local/bin/kapp && kapp version
-
-RUN wget -O- https://github.com/vmware-tanzu/carvel-kbld/releases/download/v0.30.0/kbld-linux-amd64 > /usr/local/bin/kbld && \
-  echo "76c5c572e7a9095256b4c3ae2e076c370ef70ce9ff4eb138662f56828889a00c  /usr/local/bin/kbld" | sha256sum -c - && \
-  chmod +x /usr/local/bin/kbld && kbld version
-
-RUN wget -O- https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.14.0/imgpkg-linux-amd64 > /usr/local/bin/imgpkg && \
-  echo "bd53355fc3a05666681ddf2ba1dfae2da894bc1c74d86cdc545d772749abc887  /usr/local/bin/imgpkg" | sha256sum -c - && \
-  chmod +x /usr/local/bin/imgpkg && imgpkg version
-
-RUN wget -O- https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.1/vendir-linux-amd64 > /usr/local/bin/vendir && \
-  echo "7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184  /usr/local/bin/vendir" | sha256sum -c - && \
-  chmod +x /usr/local/bin/vendir && vendir version
-
+COPY ./hack/install-deps.sh .
+RUN ./install-deps.sh
 
 # [DEPRECATED] Helm V2
 # Maintaining two versions of helm until we drop support in a future release

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -18,7 +18,12 @@ install() {
     dl_bin="curl -s -L"
   fi
 
-  shasum -v 1>/dev/null 2>&1 || (echo "Missing shasum binary" && exit 1)
+  if which sha256sum; then
+	echo "found sha256sum"
+  else
+	echo "Missing sha256sum binary"
+	exit 1
+  fi
 
   ytt_version=v0.35.1
   kbld_version=v0.30.0
@@ -48,35 +53,35 @@ install() {
 
   echo "Installing ytt..."
   $dl_bin https://github.com/vmware-tanzu/carvel-ytt/releases/download/${ytt_version}/ytt-${binary_type} > /tmp/ytt
-  echo "${ytt_checksum}  /tmp/ytt" | shasum -c -
+  echo "${ytt_checksum}  /tmp/ytt" | sha256sum -c -
   mv /tmp/ytt ${dst_dir}/ytt
   chmod +x ${dst_dir}/ytt
   echo "Installed ${dst_dir}/ytt ${ytt_version}"
 
   echo "Installing kbld..."
   $dl_bin https://github.com/vmware-tanzu/carvel-kbld/releases/download/${kbld_version}/kbld-${binary_type} > /tmp/kbld
-  echo "${kbld_checksum}  /tmp/kbld" | shasum -c -
+  echo "${kbld_checksum}  /tmp/kbld" | sha256sum -c -
   mv /tmp/kbld ${dst_dir}/kbld
   chmod +x ${dst_dir}/kbld
   echo "Installed ${dst_dir}/kbld ${kbld_version}"
 
   echo "Installing kapp..."
   $dl_bin https://github.com/vmware-tanzu/carvel-kapp/releases/download/${kapp_version}/kapp-${binary_type} > /tmp/kapp
-  echo "${kapp_checksum}  /tmp/kapp" | shasum -c -
+  echo "${kapp_checksum}  /tmp/kapp" | sha256sum -c -
   mv /tmp/kapp ${dst_dir}/kapp
   chmod +x ${dst_dir}/kapp
   echo "Installed ${dst_dir}/kapp ${kapp_version}"
 
   echo "Installing imgpkg..."
   $dl_bin https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/${imgpkg_version}/imgpkg-${binary_type} > /tmp/imgpkg
-  echo "${imgpkg_checksum}  /tmp/imgpkg" | shasum -c -
+  echo "${imgpkg_checksum}  /tmp/imgpkg" | sha256sum -c -
   mv /tmp/imgpkg ${dst_dir}/imgpkg
   chmod +x ${dst_dir}/imgpkg
   echo "Installed ${dst_dir}/imgpkg ${imgpkg_version}"
 
   echo "Installing vendir..."
   $dl_bin https://github.com/vmware-tanzu/carvel-vendir/releases/download/${vendir_version}/vendir-${binary_type} > /tmp/vendir
-  echo "${vendir_checksum}  /tmp/vendir" | shasum -c -
+  echo "${vendir_checksum}  /tmp/vendir" | sha256sum -c -
   mv /tmp/vendir ${dst_dir}/vendir
   chmod +x ${dst_dir}/vendir
   echo "Installed ${dst_dir}/vendir ${vendir_version}"

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -10,7 +10,7 @@ fi
 install() {
   set -euo pipefail
 
-  dst_dir="${K14SIO_INSTALL_BIN_DIR:-/usr/local/bin}"
+  dst_dir="${CARVEL_INSTALL_BIN_DIR:-${K14SIO_INSTALL_BIN_DIR:-/usr/local/bin}}"
 
   if [ -x "$(command -v wget)" ]; then
     dl_bin="wget -nv -O-"

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -1,54 +1,85 @@
-#!/bin/zsh
+#!/bin/bash
 
 # shamelessly adapted from https://github.com/vmware-tanzu/carvel/blob/develop/site/static/install.sh
+
+if test -z "$BASH_VERSION"; then
+  echo "Please run this script using bash, not sh or any other shell." >&2
+  exit 1
+fi
 
 install() {
   set -euo pipefail
 
   dst_dir="${K14SIO_INSTALL_BIN_DIR:-/usr/local/bin}"
 
-  wget --version 1>/dev/null 2>&1 || (echo "Missing wget binary" && exit 1)
+  if [ -x "$(command -v wget)" ]; then
+    dl_bin="wget -nv -O-"
+  else
+    dl_bin="curl -s -L"
+  fi
+
   shasum -v 1>/dev/null 2>&1 || (echo "Missing shasum binary" && exit 1)
 
-  carvel_tools=(ytt kbld kapp imgpkg vendir)
-
-  declare -A versions
-  declare -A checksums
-
-  versions[ytt]=v0.35.1
-  versions[kbld]=v0.30.0
-  versions[kapp]=v0.37.0
-  versions[imgpkg]=v0.14.0
-  versions[vendir]=v0.21.1
+  ytt_version=v0.35.1
+  kbld_version=v0.30.0
+  kapp_version=v0.37.0
+  imgpkg_version=v0.14.0
+  vendir_version=v0.21.1
 
   if [[ `uname` == Darwin ]]; then
     binary_type=darwin-amd64
-    checksums[ytt]=1f2b61d02f6d8184889719d5e0277a1ea82219f96873345157e81075ca59808e
-    checksums[kbld]=73274d02b0c2837d897c463f820f2c8192e8c3f63fd90c526de5f23d4c6bdec4
-    checksums[kapp]=da6411b79c66138cd7437beb268675edf2df3c0a4a8be07fb140dd4ebde758c1
-    checksums[kwt]=555d50d5bed601c2e91f7444b3f44fdc424d721d7da72955725a97f3860e2517
-    checksums[imgpkg]=3c63f224833590526c3b48ab5db1be4ec07ece6a6eb4879888fefba14b6176be
-    checksums[vendir]=579d661291f669a4f618c602e48d456693762e2ba23d4d8b64d12ceea05dd2cd
+    ytt_checksum=1f2b61d02f6d8184889719d5e0277a1ea82219f96873345157e81075ca59808e
+    kbld_checksum=73274d02b0c2837d897c463f820f2c8192e8c3f63fd90c526de5f23d4c6bdec4
+    kapp_checksum=da6411b79c66138cd7437beb268675edf2df3c0a4a8be07fb140dd4ebde758c1
+    kwt_checksum=555d50d5bed601c2e91f7444b3f44fdc424d721d7da72955725a97f3860e2517
+    imgpkg_checksum=3c63f224833590526c3b48ab5db1be4ec07ece6a6eb4879888fefba14b6176be
+    vendir_checksum=579d661291f669a4f618c602e48d456693762e2ba23d4d8b64d12ceea05dd2cd
   else
     binary_type=linux-amd64
-    checksums[ytt]=0aa78f7b5f5a0a4c39bddfed915172880344270809c26b9844e9d0cbf6437030
-    checksums[kbld]=76c5c572e7a9095256b4c3ae2e076c370ef70ce9ff4eb138662f56828889a00c
-    checksums[kapp]=f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538
-    checksums[kwt]=92a1f18be6a8dca15b7537f4cc666713b556630c20c9246b335931a9379196a0
-    checksums[imgpkg]=bd53355fc3a05666681ddf2ba1dfae2da894bc1c74d86cdc545d772749abc887
-    checksums[vendir]=7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184
+    ytt_checksum=0aa78f7b5f5a0a4c39bddfed915172880344270809c26b9844e9d0cbf6437030
+    kbld_checksum=76c5c572e7a9095256b4c3ae2e076c370ef70ce9ff4eb138662f56828889a00c
+    kapp_checksum=f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538
+    kwt_checksum=92a1f18be6a8dca15b7537f4cc666713b556630c20c9246b335931a9379196a0
+    imgpkg_checksum=bd53355fc3a05666681ddf2ba1dfae2da894bc1c74d86cdc545d772749abc887
+    vendir_checksum=7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184
   fi
 
   echo "Installing ${binary_type} binaries..."
 
-  for i in ${carvel_tools[@]}; do
-    echo "Installing ${i}..."
-    wget -nv -O- https://github.com/vmware-tanzu/carvel-${i}/releases/download/${versions[${i}]}/${i}-${binary_type} > /tmp/${i}
-    echo "${checksums[${i}]}  /tmp/${i}" | shasum -c -
-    mv /tmp/${i} ${dst_dir}/${i}
-    chmod +x ${dst_dir}/${i}
-    echo "Installed ${dst_dir}/${i} ${versions[${i}]}"
-  done
+  echo "Installing ytt..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-ytt/releases/download/${ytt_version}/ytt-${binary_type} > /tmp/ytt
+  echo "${ytt_checksum}  /tmp/ytt" | shasum -c -
+  mv /tmp/ytt ${dst_dir}/ytt
+  chmod +x ${dst_dir}/ytt
+  echo "Installed ${dst_dir}/ytt ${ytt_version}"
+
+  echo "Installing kbld..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-kbld/releases/download/${kbld_version}/kbld-${binary_type} > /tmp/kbld
+  echo "${kbld_checksum}  /tmp/kbld" | shasum -c -
+  mv /tmp/kbld ${dst_dir}/kbld
+  chmod +x ${dst_dir}/kbld
+  echo "Installed ${dst_dir}/kbld ${kbld_version}"
+
+  echo "Installing kapp..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-kapp/releases/download/${kapp_version}/kapp-${binary_type} > /tmp/kapp
+  echo "${kapp_checksum}  /tmp/kapp" | shasum -c -
+  mv /tmp/kapp ${dst_dir}/kapp
+  chmod +x ${dst_dir}/kapp
+  echo "Installed ${dst_dir}/kapp ${kapp_version}"
+
+  echo "Installing imgpkg..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/${imgpkg_version}/imgpkg-${binary_type} > /tmp/imgpkg
+  echo "${imgpkg_checksum}  /tmp/imgpkg" | shasum -c -
+  mv /tmp/imgpkg ${dst_dir}/imgpkg
+  chmod +x ${dst_dir}/imgpkg
+  echo "Installed ${dst_dir}/imgpkg ${imgpkg_version}"
+
+  echo "Installing vendir..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-vendir/releases/download/${vendir_version}/vendir-${binary_type} > /tmp/vendir
+  echo "${vendir_checksum}  /tmp/vendir" | shasum -c -
+  mv /tmp/vendir ${dst_dir}/vendir
+  chmod +x ${dst_dir}/vendir
+  echo "Installed ${dst_dir}/vendir ${vendir_version}"
 }
 
 install

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# shamelessly adapted from https://github.com/vmware-tanzu/carvel/blob/develop/site/static/install.sh
+
+if test -z "$BASH_VERSION"; then
+  echo "Please run this script using bash, not sh or any other shell." >&2
+  exit 1
+fi
+
+install() {
+  set -euo pipefail
+
+  dst_dir="${K14SIO_INSTALL_BIN_DIR:-/usr/local/bin}"
+
+  if [ -x "$(command -v wget)" ]; then
+    dl_bin="wget -nv -O-"
+  else
+    dl_bin="curl -s -L"
+  fi
+
+  shasum -v 1>/dev/null 2>&1 || (echo "Missing shasum binary" && exit 1)
+
+  ytt_version=v0.35.1
+  kbld_version=v0.30.0
+  kapp_version=v0.37.0
+  imgpkg_version=v0.14.0
+  vendir_version=v0.21.1
+
+  if [[ `uname` == Darwin ]]; then
+    binary_type=darwin-amd64
+    ytt_checksum=1f2b61d02f6d8184889719d5e0277a1ea82219f96873345157e81075ca59808e
+    kbld_checksum=73274d02b0c2837d897c463f820f2c8192e8c3f63fd90c526de5f23d4c6bdec4
+    kapp_checksum=da6411b79c66138cd7437beb268675edf2df3c0a4a8be07fb140dd4ebde758c1
+    kwt_checksum=555d50d5bed601c2e91f7444b3f44fdc424d721d7da72955725a97f3860e2517
+    imgpkg_checksum=3c63f224833590526c3b48ab5db1be4ec07ece6a6eb4879888fefba14b6176be
+    vendir_checksum=579d661291f669a4f618c602e48d456693762e2ba23d4d8b64d12ceea05dd2cd
+  else
+    binary_type=linux-amd64
+    ytt_checksum=0aa78f7b5f5a0a4c39bddfed915172880344270809c26b9844e9d0cbf6437030
+    kbld_checksum=76c5c572e7a9095256b4c3ae2e076c370ef70ce9ff4eb138662f56828889a00c
+    kapp_checksum=f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538
+    kwt_checksum=92a1f18be6a8dca15b7537f4cc666713b556630c20c9246b335931a9379196a0
+    imgpkg_checksum=bd53355fc3a05666681ddf2ba1dfae2da894bc1c74d86cdc545d772749abc887
+    vendir_checksum=7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184
+  fi
+
+  echo "Installing ${binary_type} binaries..."
+
+  echo "Installing ytt..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-ytt/releases/download/${ytt_version}/ytt-${binary_type} > /tmp/ytt
+  echo "${ytt_checksum}  /tmp/ytt" | shasum -c -
+  mv /tmp/ytt ${dst_dir}/ytt
+  chmod +x ${dst_dir}/ytt
+  echo "Installed ${dst_dir}/ytt ${ytt_version}"
+
+  echo "Installing kbld..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-kbld/releases/download/${kbld_version}/kbld-${binary_type} > /tmp/kbld
+  echo "${kbld_checksum}  /tmp/kbld" | shasum -c -
+  mv /tmp/kbld ${dst_dir}/kbld
+  chmod +x ${dst_dir}/kbld
+  echo "Installed ${dst_dir}/kbld ${kbld_version}"
+
+  echo "Installing kapp..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-kapp/releases/download/${kapp_version}/kapp-${binary_type} > /tmp/kapp
+  echo "${kapp_checksum}  /tmp/kapp" | shasum -c -
+  mv /tmp/kapp ${dst_dir}/kapp
+  chmod +x ${dst_dir}/kapp
+  echo "Installed ${dst_dir}/kapp ${kapp_version}"
+
+  echo "Installing imgpkg..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/${imgpkg_version}/imgpkg-${binary_type} > /tmp/imgpkg
+  echo "${imgpkg_checksum}  /tmp/imgpkg" | shasum -c -
+  mv /tmp/imgpkg ${dst_dir}/imgpkg
+  chmod +x ${dst_dir}/imgpkg
+  echo "Installed ${dst_dir}/imgpkg ${imgpkg_version}"
+
+  echo "Installing vendir..."
+  $dl_bin https://github.com/vmware-tanzu/carvel-vendir/releases/download/${vendir_version}/vendir-${binary_type} > /tmp/vendir
+  echo "${vendir_checksum}  /tmp/vendir" | shasum -c -
+  mv /tmp/vendir ${dst_dir}/vendir
+  chmod +x ${dst_dir}/vendir
+  echo "Installed ${dst_dir}/vendir ${vendir_version}"
+}
+
+install

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -1,85 +1,54 @@
-#!/bin/bash
+#!/bin/zsh
 
 # shamelessly adapted from https://github.com/vmware-tanzu/carvel/blob/develop/site/static/install.sh
-
-if test -z "$BASH_VERSION"; then
-  echo "Please run this script using bash, not sh or any other shell." >&2
-  exit 1
-fi
 
 install() {
   set -euo pipefail
 
   dst_dir="${K14SIO_INSTALL_BIN_DIR:-/usr/local/bin}"
 
-  if [ -x "$(command -v wget)" ]; then
-    dl_bin="wget -nv -O-"
-  else
-    dl_bin="curl -s -L"
-  fi
-
+  wget --version 1>/dev/null 2>&1 || (echo "Missing wget binary" && exit 1)
   shasum -v 1>/dev/null 2>&1 || (echo "Missing shasum binary" && exit 1)
 
-  ytt_version=v0.35.1
-  kbld_version=v0.30.0
-  kapp_version=v0.37.0
-  imgpkg_version=v0.14.0
-  vendir_version=v0.21.1
+  carvel_tools=(ytt kbld kapp imgpkg vendir)
+
+  declare -A versions
+  declare -A checksums
+
+  versions[ytt]=v0.35.1
+  versions[kbld]=v0.30.0
+  versions[kapp]=v0.37.0
+  versions[imgpkg]=v0.14.0
+  versions[vendir]=v0.21.1
 
   if [[ `uname` == Darwin ]]; then
     binary_type=darwin-amd64
-    ytt_checksum=1f2b61d02f6d8184889719d5e0277a1ea82219f96873345157e81075ca59808e
-    kbld_checksum=73274d02b0c2837d897c463f820f2c8192e8c3f63fd90c526de5f23d4c6bdec4
-    kapp_checksum=da6411b79c66138cd7437beb268675edf2df3c0a4a8be07fb140dd4ebde758c1
-    kwt_checksum=555d50d5bed601c2e91f7444b3f44fdc424d721d7da72955725a97f3860e2517
-    imgpkg_checksum=3c63f224833590526c3b48ab5db1be4ec07ece6a6eb4879888fefba14b6176be
-    vendir_checksum=579d661291f669a4f618c602e48d456693762e2ba23d4d8b64d12ceea05dd2cd
+    checksums[ytt]=1f2b61d02f6d8184889719d5e0277a1ea82219f96873345157e81075ca59808e
+    checksums[kbld]=73274d02b0c2837d897c463f820f2c8192e8c3f63fd90c526de5f23d4c6bdec4
+    checksums[kapp]=da6411b79c66138cd7437beb268675edf2df3c0a4a8be07fb140dd4ebde758c1
+    checksums[kwt]=555d50d5bed601c2e91f7444b3f44fdc424d721d7da72955725a97f3860e2517
+    checksums[imgpkg]=3c63f224833590526c3b48ab5db1be4ec07ece6a6eb4879888fefba14b6176be
+    checksums[vendir]=579d661291f669a4f618c602e48d456693762e2ba23d4d8b64d12ceea05dd2cd
   else
     binary_type=linux-amd64
-    ytt_checksum=0aa78f7b5f5a0a4c39bddfed915172880344270809c26b9844e9d0cbf6437030
-    kbld_checksum=76c5c572e7a9095256b4c3ae2e076c370ef70ce9ff4eb138662f56828889a00c
-    kapp_checksum=f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538
-    kwt_checksum=92a1f18be6a8dca15b7537f4cc666713b556630c20c9246b335931a9379196a0
-    imgpkg_checksum=bd53355fc3a05666681ddf2ba1dfae2da894bc1c74d86cdc545d772749abc887
-    vendir_checksum=7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184
+    checksums[ytt]=0aa78f7b5f5a0a4c39bddfed915172880344270809c26b9844e9d0cbf6437030
+    checksums[kbld]=76c5c572e7a9095256b4c3ae2e076c370ef70ce9ff4eb138662f56828889a00c
+    checksums[kapp]=f845233deb6c87feac7c82d9b3f5e03ced9a4672abb1a14d4e5b74fe53bc4538
+    checksums[kwt]=92a1f18be6a8dca15b7537f4cc666713b556630c20c9246b335931a9379196a0
+    checksums[imgpkg]=bd53355fc3a05666681ddf2ba1dfae2da894bc1c74d86cdc545d772749abc887
+    checksums[vendir]=7d9ffd06a888bf13e16ad964d7a0d0f6b7c23e8cad9774084c563cda81b91184
   fi
 
   echo "Installing ${binary_type} binaries..."
 
-  echo "Installing ytt..."
-  $dl_bin https://github.com/vmware-tanzu/carvel-ytt/releases/download/${ytt_version}/ytt-${binary_type} > /tmp/ytt
-  echo "${ytt_checksum}  /tmp/ytt" | shasum -c -
-  mv /tmp/ytt ${dst_dir}/ytt
-  chmod +x ${dst_dir}/ytt
-  echo "Installed ${dst_dir}/ytt ${ytt_version}"
-
-  echo "Installing kbld..."
-  $dl_bin https://github.com/vmware-tanzu/carvel-kbld/releases/download/${kbld_version}/kbld-${binary_type} > /tmp/kbld
-  echo "${kbld_checksum}  /tmp/kbld" | shasum -c -
-  mv /tmp/kbld ${dst_dir}/kbld
-  chmod +x ${dst_dir}/kbld
-  echo "Installed ${dst_dir}/kbld ${kbld_version}"
-
-  echo "Installing kapp..."
-  $dl_bin https://github.com/vmware-tanzu/carvel-kapp/releases/download/${kapp_version}/kapp-${binary_type} > /tmp/kapp
-  echo "${kapp_checksum}  /tmp/kapp" | shasum -c -
-  mv /tmp/kapp ${dst_dir}/kapp
-  chmod +x ${dst_dir}/kapp
-  echo "Installed ${dst_dir}/kapp ${kapp_version}"
-
-  echo "Installing imgpkg..."
-  $dl_bin https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/${imgpkg_version}/imgpkg-${binary_type} > /tmp/imgpkg
-  echo "${imgpkg_checksum}  /tmp/imgpkg" | shasum -c -
-  mv /tmp/imgpkg ${dst_dir}/imgpkg
-  chmod +x ${dst_dir}/imgpkg
-  echo "Installed ${dst_dir}/imgpkg ${imgpkg_version}"
-
-  echo "Installing vendir..."
-  $dl_bin https://github.com/vmware-tanzu/carvel-vendir/releases/download/${vendir_version}/vendir-${binary_type} > /tmp/vendir
-  echo "${vendir_checksum}  /tmp/vendir" | shasum -c -
-  mv /tmp/vendir ${dst_dir}/vendir
-  chmod +x ${dst_dir}/vendir
-  echo "Installed ${dst_dir}/vendir ${vendir_version}"
+  for i in ${carvel_tools[@]}; do
+    echo "Installing ${i}..."
+    wget -nv -O- https://github.com/vmware-tanzu/carvel-${i}/releases/download/${versions[${i}]}/${i}-${binary_type} > /tmp/${i}
+    echo "${checksums[${i}]}  /tmp/${i}" | shasum -c -
+    mv /tmp/${i} ${dst_dir}/${i}
+    chmod +x ${dst_dir}/${i}
+    echo "Installed ${dst_dir}/${i} ${versions[${i}]}"
+  done
 }
 
 install


### PR DESCRIPTION
updated to resolve merge conflicts from https://github.com/vmware-tanzu/carvel-kapp-controller/pull/291   -- versions were already correct. 

manually verified both docker image and running on my mac seem to result in the right versions of things.