### PR TITLE
sops: improve error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN wget -O- https://get.helm.sh/helm-v3.5.3-linux-amd64.tar.gz > /helm && \
   mkdir /helm-unpacked && tar -C /helm-unpacked -xzvf /helm
 
 # sops
-RUN wget -O- https://github.com/mozilla/sops/releases/download/v3.6.1/sops-v3.6.1.linux > /usr/local/bin/sops && \
-  echo "b2252aa00836c72534471e1099fa22fab2133329b62d7826b5ac49511fcc8997  /usr/local/bin/sops" | sha256sum -c - && \
+RUN wget -O- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && \
+  echo "185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74  /usr/local/bin/sops" | sha256sum -c - && \
   chmod +x /usr/local/bin/sops && sops -v
 
 # kapp-controller

--- a/pkg/template/sops.go
+++ b/pkg/template/sops.go
@@ -143,7 +143,7 @@ func (t *Sops) decryptSopsFile(path, newPath string, args, env []string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Running sops: %s", err)
+		return fmt.Errorf("Running sops: %s, %v", stderrBs.String(), err)
 	}
 
 	err = os.Remove(path)


### PR DESCRIPTION
- include sops stderr in the error when execution fails
- update sops to 3.7.1 which itself includes better error reporting