### PR TITLE
allow Package CR annotations

### DIFF
--- a/examples/packaging-with-repo/package-repository.yml
+++ b/examples/packaging-with-repo/package-repository.yml
@@ -10,4 +10,4 @@ spec:
   fetch:
     imgpkgBundle:
       # Created via `imgpkg push -b ... -f ./test/e2e/assets/kc-e2e-test-repo`
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:1ff03133ff04bb13058cf12b411386b05810a0c583a322be37496a6626d45fd4
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c

--- a/pkg/pkgrepository/package_repo_app.go
+++ b/pkg/pkgrepository/package_repo_app.go
@@ -49,24 +49,21 @@ func NewPackageRepoApp(pkgRepository *pkgingv1alpha1.PackageRepository) (*kcv1al
 #@overlay/remove
 ---
 
-#@overlay/match by=overlay.or_op(pkg, pkgm),expects="0+"
+#@overlay/match by=overlay.all,expects="0+"
 ---
 metadata:
+  #! Ensure that all resources do not set some random namespace
+  #! so that all resource end in the PackageRepository's namespace
+  #@overlay/match missing_ok=True
+  #@overlay/remove
+  namespace:
+
   #@overlay/match missing_ok=True
   annotations:
     #@overlay/match missing_ok=True
     kapp.k14s.io/disable-original: ""
     #@overlay/match missing_ok=True
     kapp.k14s.io/disable-wait: ""
-
-#! Ensure that all resources do not set some random namespace
-#! so that all resource end in the PackageRepository's namespace
-#@overlay/match by=overlay.all,expects="0+"
----
-metadata:
-  #@overlay/match missing_ok=True
-  #@overlay/remove
-  namespace:
 `,
 					},
 				},

--- a/pkg/pkgrepository/package_repo_app.go
+++ b/pkg/pkgrepository/package_repo_app.go
@@ -57,7 +57,9 @@ func NewPackageRepoApp(pkgRepository *pkgingv1alpha1.PackageRepository) (*kcv1al
 metadata:
   #@overlay/match missing_ok=True
   annotations:
+    #@overlay/match missing_ok=True
     kapp.k14s.io/disable-original: ""
+    #@overlay/match missing_ok=True
     kapp.k14s.io/disable-wait: ""
 
 #! Ensure that all resources do not set some random namespace

--- a/pkg/pkgrepository/package_repo_app.go
+++ b/pkg/pkgrepository/package_repo_app.go
@@ -45,14 +45,11 @@ func NewPackageRepoApp(pkgRepository *pkgingv1alpha1.PackageRepository) (*kcv1al
 #@ pkg = overlay.subset({"apiVersion":"data.packaging.carvel.dev/v1alpha1", "kind": "Package"})
 #@ pkgm = overlay.subset({"apiVersion":"data.packaging.carvel.dev/v1alpha1", "kind": "PackageMetadata"})
 
-#! TODO remove me
-#@ pkgv = overlay.subset({"apiVersion":"data.packaging.carvel.dev/v1alpha1", "kind": "PackageVersion"})
-
-#@overlay/match by=overlay.not_op(overlay.or_op(pkg, pkgm, pkgv)),expects="0+"
+#@overlay/match by=overlay.not_op(overlay.or_op(pkg, pkgm)),expects="0+"
 #@overlay/remove
 ---
 
-#@overlay/match by=overlay.or_op(pkg, pkgm, pkgv),expects="0+"
+#@overlay/match by=overlay.or_op(pkg, pkgm),expects="0+"
 ---
 metadata:
   #@overlay/match missing_ok=True

--- a/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/extra-resource.yml
+++ b/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/extra-resource.yml
@@ -1,0 +1,9 @@
+# Test that unknown/extra resource does not fail installation of the bundle
+# (This resource will be ignored at the package repository installation.)
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageExtra
+metadata:
+  name: pkg.test.carvel.dev.1.0.0
+spec:
+  refName: pkg.test.carvel.dev

--- a/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.1.0.0.yml
+++ b/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.1.0.0.yml
@@ -5,7 +5,7 @@ metadata:
   # This is just the resource name and shouldn't be used to reference this package
   # in other resources
   name: pkg.test.carvel.dev.1.0.0
-  # cluster scoped
+  # Test that no annotations/labels are needed
 spec:
   # This is the name we want to reference in resources such as PackageInstall.
   refName: pkg.test.carvel.dev

--- a/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.2.0.0.yml
+++ b/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.2.0.0.yml
@@ -4,8 +4,10 @@ kind: Package
 metadata:
   name: pkg.test.carvel.dev.2.0.0
   annotations:
+    # Test that arbitrary annotation can be added
     pkg.test.carvel.dev/test-ann: ""
   labels:
+    # Test that arbitrary label can be added
     pkg.test.carvel.dev/test-label: ""
 spec:
   refName: pkg.test.carvel.dev

--- a/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.2.0.0.yml
+++ b/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.2.0.0.yml
@@ -3,6 +3,10 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: pkg.test.carvel.dev.2.0.0
+  annotations:
+    pkg.test.carvel.dev/test-ann: ""
+  labels:
+    pkg.test.carvel.dev/test-label: ""
 spec:
   refName: pkg.test.carvel.dev
   # In this new version of the package, we are including some overlays

--- a/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.3.0.0-rc.1.yml
+++ b/test/e2e/assets/kc-e2e-test-repo/packages/pkg.test.carvel.dev/pkg.test.carvel.dev.3.0.0-rc.1.yml
@@ -45,3 +45,5 @@ spec:
           type: string
           description: Hello msg for the app
           default: "stranger"
+  # Test that unknown key is ignored
+  unknownKey_DO_NOT_COPY: true

--- a/test/e2e/package_repo_test.go
+++ b/test/e2e/package_repo_test.go
@@ -100,7 +100,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:1ff03133ff04bb13058cf12b411386b05810a0c583a322be37496a6626d45fd4`
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c`
 
 	cleanUp := func() {
 		kapp.Run([]string{"delete", "-a", name})
@@ -173,7 +173,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:1ff03133ff04bb13058cf12b411386b05810a0c583a322be37496a6626d45fd4`
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c`
 
 	cleanUp := func() {
 		kubectl.Run([]string{"delete", "pkgr/basic.test.carvel.dev"})
@@ -214,7 +214,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:1ff03133ff04bb13058cf12b411386b05810a0c583a322be37496a6626d45fd4`
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c`
 
 	cleanUp := func() {
 		kctl.RunWithOpts([]string{"delete", "package/pkg.test.carvel.dev.1.0.0"}, RunOpts{AllowError: true})

--- a/test/e2e/packageinstall_test.go
+++ b/test/e2e/packageinstall_test.go
@@ -290,7 +290,7 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:1ff03133ff04bb13058cf12b411386b05810a0c583a322be37496a6626d45fd4
+      image: index.docker.io/k8slt/kc-e2e-test-repo@sha256:ddd93b67b97c1460580ca1afd04326d16900dc716c4357cade85b83deab76f1c
 ---
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall


### PR DESCRIPTION
following error is raised for any Package CR with annotations.

```
 error: 'Templating dir: Error (see .status.usefulErrorMessage for details)'
      exitCode: 1
      stderr: |
        ytt: Error: Overlaying (in following order: kapp-controller-clean-up.yml):
          Document on line kapp-controller-clean-up.yml:15:
            Map item (key 'metadata') on line kapp-controller-clean-up.yml:16:
              Map item (key 'annotations') on line kapp-controller-clean-up.yml:18:
                Map item (key 'kapp.k14s.io/disable-original') on line kapp-controller-clean-up.yml:19:
                  Expected number of matched nodes to be 1, but was 0
      updatedAt: "2021-07-27T18:49:19Z"
    usefulErrorMessage: |
      ytt: Error: Overlaying (in following order: kapp-controller-clean-up.yml):
        Document on line kapp-controller-clean-up.yml:15:
          Map item (key 'metadata') on line kapp-controller-clean-up.yml:16:
            Map item (key 'annotations') on line kapp-controller-clean-up.yml:18:
              Map item (key 'kapp.k14s.io/disable-original') on line kapp-controller-clean-up.yml:19:
                Expected number of matched nodes to be 1, but was 0
```

this change modifies "clean up" ytt template to allow us to inject our annotations into Package CRs that already have other annotations.