### PR TITLE
Add environment variable to parametrize service name

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -46,7 +46,7 @@ const (
 	kappctrlSVCEnvKey = "KAPPCTRL_SYSTEM_SERVICE"
 	kappctrlAPIEnvKey = "KAPPCTRL_SYSTEM_API"
 
-	defaultApiServiceName = "v1alpha1.data.packaging.carvel.dev"
+	apiServiceName = "v1alpha1.data.packaging.carvel.dev"
 )
 
 var (
@@ -134,7 +134,6 @@ func (as *APIServer) Stop() {
 }
 
 func (as *APIServer) isReady() (bool, error) {
-	apiServiceName := getEnvVal(kappctrlAPIEnvKey, defaultApiServiceName)
 	apiService, err := as.aggClient.ApiregistrationV1().APIServices().Get(context.TODO(), apiServiceName, metav1.GetOptions{})
 	if err != nil {
 		return false, fmt.Errorf("error getting APIService %s: %v", apiServiceName, err)
@@ -190,7 +189,6 @@ func newServerConfig(aggClient aggregatorclient.Interface, bindPort int) (*gener
 
 func updateAPIService(client aggregatorclient.Interface, caProvider dynamiccertificates.CAContentProvider) error {
 	klog.Info("Syncing CA certificate with APIServices")
-	apiServiceName := getEnvVal(kappctrlAPIEnvKey, defaultApiServiceName)
 	apiService, err := client.ApiregistrationV1().APIServices().Get(context.TODO(), apiServiceName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting APIService %s: %v", apiServiceName, err)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -203,7 +203,7 @@ func updateAPIService(client aggregatorclient.Interface, caProvider dynamiccerti
 }
 
 func apiServiceEndoint() string {
-	const apiServiceName = getEnvVal(kappctrlSVCEnvKey, "packaging-api")
+	var apiServiceName = getEnvVal(kappctrlSVCEnvKey, "packaging-api")
 	ns := os.Getenv(kappctrlNSEnvKey)
 	if ns == "" {
 		panic("Cannot get api service endpoint, Kapp-controller namespace is empty")

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -44,7 +44,6 @@ const (
 
 	kappctrlNSEnvKey  = "KAPPCTRL_SYSTEM_NAMESPACE"
 	kappctrlSVCEnvKey = "KAPPCTRL_SYSTEM_SERVICE"
-	kappctrlAPIEnvKey = "KAPPCTRL_SYSTEM_API"
 
 	apiServiceName = "v1alpha1.data.packaging.carvel.dev"
 )


### PR DESCRIPTION
The `Service` resource name was statically defined as `packaging-api`.

This change introduces the environment variable `KAPPCTRL_SYSTEM_SERVICE` allowing the user to override those values.

If the environment variable isn't defined, they will default to the previously statically defined value.

See [this comment](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/283#issuecomment-889989228) in the issue #283 for more informations.