### PR TITLE
Support Testing Integration with secretgen-controller

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -51,6 +51,7 @@ jobs:
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)
 
+        export KAPPCTRL_E2E_SECRETGEN_CONTROLLER=true
         ./hack/deploy-test.sh
 
         export KAPPCTRL_E2E_NAMESPACE=kappctrl-test

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -5,8 +5,16 @@ Install ytt, kbld, kapp beforehand (https://k14s.io).
 ```
 ./hack/build.sh # to build locally
 
+# deploys secretgen-controller with kapp-controller
+# and also runs tests where kapp-controller integrates 
+# with secretgen-controller
+export KAPPCTRL_E2E_SECRETGEN_CONTROLLER=true
+
 # add `-v image_repo=docker.io/username/kapp-controller` with your registry to ytt invocation inside
 ./hack/deploy.sh # to deploy
+
+# deploys test assets in addition to kapp-controller for e2e tests
+./hack/deploy-test.sh
 
 export KAPPCTRL_E2E_NAMESPACE=kappctrl-test
 ./hack/test-all.sh

--- a/hack/deploy-test.sh
+++ b/hack/deploy-test.sh
@@ -3,3 +3,6 @@
 set -e
 
 ./hack/build.sh && ytt -f config/ -f config-test/ | kbld -f- | kapp deploy -a kc -f- -c -y
+
+source ./hack/secretgen-controller.sh
+deploy_secretgen-controller

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -3,3 +3,6 @@
 set -e
 
 ./hack/build.sh && ytt -f config/ | kbld -f- | kapp deploy -a kc -f- -c -y
+
+source ./hack/secretgen-controller.sh
+deploy_secretgen-controller

--- a/hack/secretgen-controller.sh
+++ b/hack/secretgen-controller.sh
@@ -1,0 +1,8 @@
+deploy_secretgen-controller() {
+  if [ "$KAPPCTRL_E2E_SECRETGEN_CONTROLLER" == "true" ]; then
+    echo "Deploying secretgen-controller..."
+    kapp deploy -a sgc -f https://github.com/vmware-tanzu/secretgen-controller/releases/download/v0.3.0/release.yml -c -y
+  else
+    echo "Skipping secretgen-controller deployment"
+  fi
+}

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -6,6 +6,10 @@ go clean -testcache
 
 # create ns if not exists because the `apply -f -` won't complain on a no-op if the ns already exists.
 kubectl create ns $KAPPCTRL_E2E_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-go test ./test/e2e/ -timeout 60m -test.v $@
+go test ./test/e2e/kappcontroller -timeout 60m -test.v $@
+
+if [ "$KAPPCTRL_E2E_SECRETGEN_CONTROLLER" == "true" ]; then
+  go test ./test/e2e/secretgencontroller -timeout 60m -test.v $@
+fi
 
 echo E2E SUCCESS

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -8,3 +8,6 @@ $ ./hack/test-e2e.sh -run TestVersion
 ```
 
 See `./test/e2e/env.go` for required environment variables for some tests.
+
+If running tests for kapp-controller's integration with secretgen-controller, 
+you will need to set the environment variable `KAPPCTRL_E2E_SECRETGEN_CONTROLLER=true`. 

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -14,9 +14,9 @@ import (
 )
 
 type Kapp struct {
-	t         *testing.T
-	namespace string
-	l         Logger
+	T         *testing.T
+	Namespace string
+	L         Logger
 }
 
 type RunOpts struct {
@@ -38,10 +38,10 @@ func (k Kapp) Run(args []string) string {
 
 func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	if !opts.NoNamespace {
-		args = append(args, []string{"-n", k.namespace}...)
+		args = append(args, []string{"-n", k.Namespace}...)
 	}
 	if opts.IntoNs {
-		args = append(args, []string{"--into-ns", k.namespace}...)
+		args = append(args, []string{"--into-ns", k.Namespace}...)
 	}
 	if !opts.Interactive {
 		args = append(args, "--yes")
@@ -51,7 +51,7 @@ func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 		ctx = context.TODO()
 	}
 
-	k.l.Debugf("Running '%s'...\n", k.cmdDesc(args, opts))
+	k.L.Debugf("Running '%s'...\n", k.cmdDesc(args, opts))
 
 	cmdName := "kapp"
 	cmd := exec.CommandContext(ctx, cmdName, args...)
@@ -78,7 +78,7 @@ func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 		err = fmt.Errorf("Execution error: stdout: '%s' stderr: '%s' error: '%s'", stdoutStr, stderr.String(), err)
 
 		if !opts.AllowError {
-			k.t.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args, opts), err)
+			k.T.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args, opts), err)
 		}
 	}
 

--- a/test/e2e/kappcontroller/app_secret_configmap_reconcile_test.go
+++ b/test/e2e/kappcontroller/app_secret_configmap_reconcile_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
@@ -10,15 +10,16 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_AppReconcileOccurs_WhenSecretUpdated(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	kubectl := Kubectl{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	name := "configmap-with-secret"
 	// syncPeriod set to 1 hour so that test
@@ -73,7 +74,7 @@ stringData:
 	defer cleanUp()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{StdinReader: strings.NewReader(appYaml)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
 	})
 
 	logger.Section("update secret", func() {
@@ -90,7 +91,7 @@ stringData:
     hello_msg: updated`
 
 		// Update secret
-		kubectl.RunWithOpts([]string{"apply", "-f", "-"}, RunOpts{StdinReader: strings.NewReader(updatedSecret)})
+		kubectl.RunWithOpts([]string{"apply", "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(updatedSecret)})
 	})
 
 	logger.Section("check App uses new secret", func() {
@@ -112,11 +113,11 @@ stringData:
 }
 
 func Test_AppReconcileOccurs_WhenConfigMapUpdated(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	kubectl := Kubectl{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	name := "configmap-with-configmap"
 	// syncPeriod set to 1 hour so that test
@@ -171,7 +172,7 @@ data:
 	defer cleanUp()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{StdinReader: strings.NewReader(appYaml)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
 	})
 
 	logger.Section("update configmap", func() {
@@ -188,7 +189,7 @@ data:
     hello_msg: updated`
 
 		// Update configmap
-		kubectl.RunWithOpts([]string{"apply", "-f", "-"}, RunOpts{StdinReader: strings.NewReader(updatedConfigMap)})
+		kubectl.RunWithOpts([]string{"apply", "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(updatedConfigMap)})
 	})
 
 	logger.Section("check App uses new configmap", func() {

--- a/test/e2e/kappcontroller/app_status_test.go
+++ b/test/e2e/kappcontroller/app_status_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
@@ -11,15 +11,16 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_AppStatus_DisplaysUsefulErrorMessage_ForDeploymentFailure(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	name := "useful-err-app-deploy"
 	appYaml := fmt.Sprintf(`
@@ -56,7 +57,7 @@ spec:
 	defer cleanUpApp()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{StdinReader: strings.NewReader(appYaml), AllowError: true})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml), AllowError: true})
 	})
 
 	out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})

--- a/test/e2e/kappcontroller/helm_test.go
+++ b/test/e2e/kappcontroller/helm_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
@@ -11,15 +11,16 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestHelm(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	expectedStatus := &v1alpha1.AppStatus{
 		GenericStatus: v1alpha1.GenericStatus{
@@ -146,7 +147,7 @@ stringData:
 
 			logger.Section("deploy", func() {
 				kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", tc.appCRName},
-					RunOpts{IntoNs: true, StdinReader: strings.NewReader(tc.deploymentYAML)})
+					e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(tc.deploymentYAML)})
 
 				out := kapp.Run([]string{"inspect", "-a", tc.appCRName, "--raw", "--tty=false", "--filter-kind=App"})
 

--- a/test/e2e/kappcontroller/http_test.go
+++ b/test/e2e/kappcontroller/http_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
@@ -11,31 +11,30 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGitHttpsPublic(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+func TestHTTP(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	yaml1 := fmt.Sprintf(`
----
 apiVersion: kappctrl.k14s.io/v1alpha1
 kind: App
 metadata:
-  name: test-git-https-public
+  name: test-http
   annotations:
     kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
 spec:
   serviceAccountName: kappctrl-e2e-ns-sa
   fetch:
-  - git:
-      url: https://github.com/k14s/kapp
-      ref: origin/develop
-      subPath: examples/gitops/guestbook
+  - http:
+      url: https://raw.githubusercontent.com/k14s/kapp/db2cc63e12e988235eb8815af8edc0ca0cfaa79c/examples/simple-app-example/config-1.yml
+      sha256: 71b0a2dceb6bb6e7a519d0587abd9400a265cabbe2c084f783df94a92db6d980
   template:
   - ytt: {}
   deploy:
@@ -43,7 +42,7 @@ spec:
       intoNs: %s
 `, env.Namespace) + sas.ForNamespaceYAML()
 
-	name := "test-git-https-public"
+	name := "test-http"
 	cleanUp := func() {
 		kapp.Run([]string{"delete", "-a", name})
 	}
@@ -53,7 +52,7 @@ spec:
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 
 		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
 
@@ -92,7 +91,7 @@ spec:
 		{
 			// deploy
 			if !strings.Contains(cr.Status.Deploy.Stdout, "Wait to:") {
-				t.Fatalf("Expected non-empty deploy output")
+				t.Fatalf("Expected non-empty deploy output: '%s'", cr.Status.Deploy.Stdout)
 			}
 			cr.Status.Deploy.StartedAt = metav1.Time{}
 			cr.Status.Deploy.UpdatedAt = metav1.Time{}
@@ -107,8 +106,8 @@ spec:
 			cr.Status.Fetch.Stdout = ""
 
 			// inspect
-			if !strings.Contains(cr.Status.Inspect.Stdout, "Resources in app 'test-git-https-public-ctrl'") {
-				t.Fatalf("Expected non-empty inspect output")
+			if !strings.Contains(cr.Status.Inspect.Stdout, "Resources in app 'test-http-ctrl'") {
+				t.Fatalf("Expected non-empty inspect output: '%s'", cr.Status.Inspect.Stdout)
 			}
 			cr.Status.Inspect.UpdatedAt = metav1.Time{}
 			cr.Status.Inspect.Stdout = ""
@@ -124,52 +123,52 @@ spec:
 	})
 }
 
-func TestGitSshPrivate(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+func TestHTTPSSelfSignedCerts(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
-	yaml1 := fmt.Sprintf(`
----
+	// When updating, certs and keys must be regenerated for server and added to server.go and config-test/config-map.yml
+	serverNamespace := "https-server"
+
+	yaml1 := fmt.Sprintf(`---
 apiVersion: kappctrl.k14s.io/v1alpha1
 kind: App
 metadata:
-  name: test-git-ssh-private
+  name: test-https
   annotations:
     kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
 spec:
   serviceAccountName: kappctrl-e2e-ns-sa
   fetch:
-  - git:
-      url: git@git-server.%s.svc.cluster.local:/git-server/repos/myrepo.git
-      ref: origin/master
-      secretRef:
-        name: git-private-key
+  - http:
+      url: https://https-svc.%s.svc.cluster.local:443/deployment.yml
   template:
   - ytt: {}
   deploy:
   - kapp:
       intoNs: %s
-`, env.Namespace, env.Namespace) + sas.ForNamespaceYAML()
+`, serverNamespace, env.Namespace) + sas.ForNamespaceYAML()
 
-	name := "test-git-ssh-private"
-	gitServerName := "test-git-server"
+	name := "test-https"
+	httpsServerName := "test-https-server"
+
 	cleanUp := func() {
 		kapp.Run([]string{"delete", "-a", name})
-		kapp.Run([]string{"delete", "-a", gitServerName})
+		kapp.Run([]string{"delete", "-a", httpsServerName, "-n", serverNamespace})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
-	logger.Section("deploy git server", func() {
-		kapp.Run([]string{"deploy", "-f", "assets/git-server.yml", "-a", gitServerName})
+	logger.Section("deploy https server with self signed certs", func() {
+		kapp.Run([]string{"deploy", "-f", "../assets/https-server/server.yml", "-f", "../assets/https-server/certs-for-custom-ca.yml", "-a", httpsServerName})
 	})
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 
 		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
 
@@ -208,7 +207,7 @@ spec:
 		{
 			// deploy
 			if !strings.Contains(cr.Status.Deploy.Stdout, "Wait to:") {
-				t.Fatalf("Expected non-empty deploy output")
+				t.Fatalf("Expected non-empty deploy output: '%s'", cr.Status.Deploy.Stdout)
 			}
 			cr.Status.Deploy.StartedAt = metav1.Time{}
 			cr.Status.Deploy.UpdatedAt = metav1.Time{}
@@ -223,8 +222,8 @@ spec:
 			cr.Status.Fetch.Stdout = ""
 
 			// inspect
-			if !strings.Contains(cr.Status.Inspect.Stdout, "Resources in app 'test-git-ssh-private-ctrl'") {
-				t.Fatalf("Expected non-empty inspect output")
+			if !strings.Contains(cr.Status.Inspect.Stdout, "Resources in app 'test-https-ctrl'") {
+				t.Fatalf("Expected non-empty inspect output: '%s'", cr.Status.Inspect.Stdout)
 			}
 			cr.Status.Inspect.UpdatedAt = metav1.Time{}
 			cr.Status.Inspect.Stdout = ""
@@ -238,4 +237,5 @@ spec:
 			t.Fatalf("Status is not same: %#v vs %#v", expectedStatus, cr.Status)
 		}
 	})
+
 }

--- a/test/e2e/kappcontroller/imgpkg_bundle_test.go
+++ b/test/e2e/kappcontroller/imgpkg_bundle_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
@@ -11,15 +11,16 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_FetchAndDeployImgpkgBundle_Successfully(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	// contents for kappctrl-e2e-bundle
 	// available in test/e2e/assets/kappctrl-e2e-bundle
@@ -56,7 +57,7 @@ spec:
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(appYaml)})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(appYaml)})
 
 		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
 
@@ -127,10 +128,10 @@ spec:
 }
 
 func TestImgpkgBundleSkipTLSVerify(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	// If this changes, the skip-tls-verify domain must be updated to match
 	registryNamespace := "registry"
@@ -165,12 +166,12 @@ spec:
 	defer cleanUp()
 
 	logger.Section("deploy registry with self signed certs", func() {
-		kapp.Run([]string{"deploy", "-f", "assets/registry/registry.yml", "-f", "assets/registry/certs-for-skip-tls.yml", "-a", registryName})
+		kapp.Run([]string{"deploy", "-f", "../assets/registry/registry.yml", "-f", "../assets/registry/certs-for-skip-tls.yml", "-a", registryName})
 	})
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+			e2e.RunOpts{AllowError: true, IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 
 		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
 

--- a/test/e2e/kappcontroller/multi_fetch_test.go
+++ b/test/e2e/kappcontroller/multi_fetch_test.go
@@ -1,21 +1,22 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestMultiFetch(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	yaml1 := `
 apiVersion: kappctrl.k14s.io/v1alpha1
@@ -61,7 +62,7 @@ spec:
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 	})
 
 	logger.Section("verify", func() {

--- a/test/e2e/kappcontroller/noopdelete_test.go
+++ b/test/e2e/kappcontroller/noopdelete_test.go
@@ -1,20 +1,22 @@
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 )
 
 func Test_NoopDelete_DeletesAfterServiceAccountDeleted(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	kubectl := Kubectl{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 	name := "instl-pkg-noop-delete"
 	cfgMapName := "configmap"
 
@@ -53,7 +55,7 @@ spec:
 	defer cleanUpConfigMap()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{StdinReader: strings.NewReader(appYaml)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
 	})
 
 	kubectl.Run([]string{"wait", "--for=condition=ReconcileSucceeded", "apps/" + name, "--timeout", "1m"})

--- a/test/e2e/kappcontroller/proxy_test.go
+++ b/test/e2e/kappcontroller/proxy_test.go
@@ -1,17 +1,19 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 )
 
 func TestHTTPProxy(t *testing.T) {
-	logger := Logger{}
-	kubectl := Kubectl{t, "kapp-controller", logger}
+	logger := e2e.Logger{}
+	kubectl := e2e.Kubectl{t, "kapp-controller", logger}
 
 	// These two variables must match their respective values in config-test/confi-map.yml
 	proxyURL := "proxy-svc.proxy-server.svc.cluster.local:80"

--- a/test/e2e/kappcontroller/service_account_test.go
+++ b/test/e2e/kappcontroller/service_account_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"strings"
@@ -9,13 +9,14 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 )
 
 func TestServiceAccountNotAllowed(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	yaml1 := `
 ---
@@ -80,7 +81,7 @@ spec:
 
 	logger.Section("deploy forbidden resource", func() {
 		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1), AllowError: true})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1), AllowError: true})
 		if err == nil {
 			t.Fatalf("Expected err, but was nil")
 		}
@@ -107,6 +108,6 @@ spec:
 
 	logger.Section("deploy allowed resources", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml2)})
 	})
 }

--- a/test/e2e/kappcontroller/sops_test.go
+++ b/test/e2e/kappcontroller/sops_test.go
@@ -1,21 +1,22 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestSops(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	yaml1 := `
 apiVersion: kappctrl.k14s.io/v1alpha1
@@ -199,7 +200,7 @@ stringData:
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
-			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
 	})
 
 	logger.Section("verify fully encrypted configmap", func() {

--- a/test/e2e/kappcontroller/template_test.go
+++ b/test/e2e/kappcontroller/template_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kappcontroller
 
 import (
 	"fmt"
@@ -9,15 +9,16 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_YttTemplate_UsesFileMarks(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	kubectl := Kubectl{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	name := "configmap-with-non-yml-ext-file"
 	// This App's ConfigMap is in a non yaml file
@@ -62,7 +63,7 @@ spec:
 	defer cleanUp()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{StdinReader: strings.NewReader(appYaml)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
 	})
 
 	logger.Section("check ConfigMap exists", func() {
@@ -71,11 +72,11 @@ spec:
 }
 
 func Test_YttTemplate_ValuesFrom(t *testing.T) {
-	env := BuildEnv(t)
-	logger := Logger{}
-	kapp := Kapp{t, env.Namespace, logger}
-	kubectl := Kubectl{t, env.Namespace, logger}
-	sas := ServiceAccounts{env.Namespace}
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
 
 	name := "ytt-values-from"
 	appYaml := fmt.Sprintf(`
@@ -140,7 +141,7 @@ data:
 	defer cleanUp()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, RunOpts{StdinReader: strings.NewReader(appYaml)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
 	})
 
 	logger.Section("check ConfigMap exists", func() {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -13,9 +13,9 @@ import (
 )
 
 type Kubectl struct {
-	t         *testing.T
-	namespace string
-	l         Logger
+	T         *testing.T
+	Namespace string
+	L         Logger
 }
 
 func (k Kubectl) Run(args []string) string {
@@ -25,14 +25,14 @@ func (k Kubectl) Run(args []string) string {
 
 func (k Kubectl) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	if !opts.NoNamespace {
-		args = append(args, []string{"-n", k.namespace}...)
+		args = append(args, []string{"-n", k.Namespace}...)
 	}
 	ctx := opts.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	k.l.Debugf("Running '%s'...\n", k.cmdDesc(args))
+	k.L.Debugf("Running '%s'...\n", k.cmdDesc(args))
 
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
@@ -53,7 +53,7 @@ func (k Kubectl) RunWithOpts(args []string, opts RunOpts) (string, error) {
 		err = fmt.Errorf("Execution error: stderr: '%s' error: '%s'", stderr.String(), err)
 
 		if !opts.AllowError {
-			k.t.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args), err)
+			k.T.Fatalf("Failed to successfully execute '%s': %v", k.cmdDesc(args), err)
 		}
 	}
 

--- a/test/e2e/secretgencontroller/secretgen-controller.go
+++ b/test/e2e/secretgencontroller/secretgen-controller.go
@@ -1,0 +1,9 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package secretgencontroller
+
+// This go file is being temporarily placed under this folder
+// to avoid the test-e2e.sh failing while no secretgen-controller
+// tests are available to run. There needs to be a go file under this folder
+// to prevent this. This should be removed when tests have been created.

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ServiceAccounts struct {
-	namespace string
+	Namespace string
 }
 
 func (sa ServiceAccounts) ForNamespaceYAML() string {
@@ -49,5 +49,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: kappctrl-e2e-ns-role
-`, sa.namespace)
+`, sa.Namespace)
 }


### PR DESCRIPTION
Closes #282 

This pull request adds the ability to deploy secretgen-controller and run associated tests for kapp-controller's integration with secretgen-controller based on an environment variable being set named `KAPPCTRL_E2E_SECRETGEN-CONTROLLER`. 

If `KAPPCTRL_E2E_SECRETGEN-CONTROLLER=true`, both deploy.sh and deploy-test.sh will deploy a specific version of secretgen-controller. Additionally, if `KAPPCTRL_E2E_SECRETGEN-CONTROLLER=true`, test-all.sh will run tests under the secretgencontroller folder.