### PR TITLE
WIP DO NOT MERGE: Automate release process for kapp-controller via GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: kapp-controller release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  kapp-controller-release:
+    name: kapp-controller release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+        with:
+          path: src/github.com/${{ github.repository }}
+      - name: Install Carvel Tools
+        uses: vmware-tanzu/carvel-setup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          only: ytt, kbld
+          ytt: v0.35.1
+          kbld: v0.30.0
+      - name: Run release script
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          set -e -x
+
+          # TODO: Update login process once new registry
+          # is chosen. See https://github.com/vmware-tanzu/carvel-kapp-controller/issues/319.
+          docker login -u k14s -p "$REGISTRY_PASSWORD"
+
+          ./hack/build-release.sh
+
+      - name: Upload release yaml to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: release.yml
+          path: ./tmp/release.yml


### PR DESCRIPTION
This pull request automates the process of carrying out certain aspects of the kapp-controller release process, including:
* Pushing a built kapp-controller image based off a tag being pushed
* Generating the release YAML
* Uploading the release YAML to GitHub (Currently, it's using a GitHub action for uploading, but I think it would make more sense to have `goreleaser` create prerelease and update file there)

With this change, the maintainer carrying out the release would need to manually do the following steps:
* Download the release YAML and upload to Draft a new release page through GitHub UI
* Grab the checksum for the release yaml from logs of the job
* Draft release notes

Remaining TODOs:
* ~Adding registry credentials to GitHub repository to authenticate for push~ If ghcr.io is kapp-controller's future registry, probably will use GitHub token instead as documented [here](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions).
* Updating docs on release process to mention new release process flow 

Additional note:
This process has been tested  on my personal fork of kapp-controller: https://github.com/danielhelfand/carvel-kapp-controller