### PR TITLE
Remove proxy logging with details

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -195,14 +195,14 @@ func Run(opts Options, runLog logr.Logger) error {
 
 func logProxies(runLog logr.Logger) {
 	if proxyVal := os.Getenv("http_proxy"); proxyVal != "" {
-		runLog.Info(fmt.Sprintf("Using http proxy '%s'", proxyVal))
+		runLog.Info("http_proxy is enabled.")
 	}
 
 	if proxyVal := os.Getenv("https_proxy"); proxyVal != "" {
-		runLog.Info(fmt.Sprintf("Using https proxy '%s'", proxyVal))
+		runLog.Info("https_proxy is enabled.")
 	}
 
 	if noProxyVal := os.Getenv("no_proxy"); noProxyVal != "" {
-		runLog.Info(fmt.Sprintf("No proxy set for: %s", noProxyVal))
+		runLog.Info("no_proxy is enabled.")
 	}
 }

--- a/test/e2e/kappcontroller/proxy_test.go
+++ b/test/e2e/kappcontroller/proxy_test.go
@@ -4,32 +4,27 @@
 package kappcontroller
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 )
 
 func TestHTTPProxy(t *testing.T) {
+	assert := assert.New(t)
 	logger := e2e.Logger{}
 	kubectl := e2e.Kubectl{t, "kapp-controller", logger}
 
-	// These two variables must match their respective values in config-test/confi-map.yml
-	proxyURL := "proxy-svc.proxy-server.svc.cluster.local:80"
-	noProxyDomains := "github.com,docker.io"
-
+	// Proxy configured in config-test/secret-config.yml
 	logger.Section("inspect controller logs for propogation of proxy env vars", func() {
 		// app name must match the app name being deployed in hack/deploy-test.sh
 		out := kubectl.Run([]string{"logs", "deployment/kapp-controller"})
 
-		if !strings.Contains(out, fmt.Sprintf("Using http proxy '%s'", proxyURL)) {
-			t.Fatalf("expected log line detailing http_proxy settings")
-		}
+		assert.Containsf(out, "http_proxy is enabled.",
+			"expected log line detailing http_proxy is enabled")
 
-		if !strings.Contains(out, fmt.Sprintf("No proxy set for: %s", noProxyDomains)) {
-			t.Fatalf("expected log line detailing no_proxy settings")
-		}
+		assert.Containsf(out, "no_proxy is enabled.",
+			"expected log line detailing no_proxy is enabled")
 	})
 
 }

--- a/test/e2e/kappcontroller/proxy_test.go
+++ b/test/e2e/kappcontroller/proxy_test.go
@@ -20,11 +20,8 @@ func TestHTTPProxy(t *testing.T) {
 		// app name must match the app name being deployed in hack/deploy-test.sh
 		out := kubectl.Run([]string{"logs", "deployment/kapp-controller"})
 
-		assert.Containsf(out, "http_proxy is enabled.",
-			"expected log line detailing http_proxy is enabled")
-
-		assert.Containsf(out, "no_proxy is enabled.",
-			"expected log line detailing no_proxy is enabled")
+		assert.Contains(out, "http_proxy is enabled.", "expected log line detailing http_proxy is enabled")
+		assert.Contains(out, "no_proxy is enabled.", "expected log line detailing no_proxy is enabled")
 	})
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

Currently, we are logging proxy information including usernames and passwords when any of `http_proxy`, `https_proxy` or `no_proxy` has been set in the config / secret. This is a security issue and we want to remove the logging.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #392

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

The conversation in the issue will give guidance on why I opted for not fully removing the logging (TL;DR is that the tests need some way to validate the proxy has been enabled, and logging is the simplest way to get that outcome), and why I opted for a simple "on" style log instead of redacting.

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
