### PR TITLE
Make metrics server port configurable

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -35,11 +35,12 @@ const (
 )
 
 type Options struct {
-	Concurrency       int
-	Namespace         string
-	EnablePprof       bool
-	APIRequestTimeout time.Duration
-	PackagingGloablNS string
+	Concurrency        int
+	Namespace          string
+	EnablePprof        bool
+	APIRequestTimeout  time.Duration
+	PackagingGloablNS  string
+	MetricsBindAddress string
 }
 
 // Based on https://github.com/kubernetes-sigs/controller-runtime/blob/8f633b179e1c704a6e40440b528252f147a3362a/examples/builtins/main.go
@@ -53,7 +54,8 @@ func Run(opts Options, runLog logr.Logger) error {
 		restConfig.Timeout = opts.APIRequestTimeout
 	}
 
-	mgr, err := manager.New(restConfig, manager.Options{Namespace: opts.Namespace, Scheme: kcconfig.Scheme})
+	mgr, err := manager.New(restConfig, manager.Options{Namespace: opts.Namespace,
+		Scheme: kcconfig.Scheme, MetricsBindAddress: opts.MetricsBindAddress})
 	if err != nil {
 		return fmt.Errorf("Setting up overall controller manager: %s", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ func main() {
 	flag.IntVar(&ctrlOpts.Concurrency, "concurrency", 10, "Max concurrent reconciles")
 	flag.StringVar(&ctrlOpts.Namespace, "namespace", "", "Namespace to watch")
 	flag.StringVar(&ctrlOpts.PackagingGloablNS, "packaging-global-namespace", "", "The namespace used for global packaging resources")
+	flag.StringVar(&ctrlOpts.MetricsBindAddress, "metrics-bind-address", ":8080", "Address for metrics server. If 0, then metrics server doesnt listen on any port.")
 	flag.BoolVar(&ctrlOpts.EnablePprof, "dangerous-enable-pprof", false, "If set to true, enable pprof on "+controller.PprofListenAddr)
 	flag.DurationVar(&ctrlOpts.APIRequestTimeout, "api-request-timeout", time.Duration(0), "HTTP timeout for Kubernetes API requests")
 	flag.BoolVar(&runController, controllerinit.InternalControllerFlag, false, "[Internal] run the controller code")


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows end users to specify metrics server port via a flag (`metrics-bind-address`). The flag can be set on the deployment like so:

```yaml
#@ load("@ytt:data", "data")

apiVersion: apps/v1
kind: Deployment
metadata:
  name: kapp-controller
  namespace: #@ data.values.namespace
  annotations:
    kapp-controller.carvel.dev/version: #@ data.values.kapp_controller_version
spec:
  selector:
    matchLabels:
      app: kapp-controller
  replicas: 1
  revisionHistoryLimit: 0
  template:
    metadata:
      labels:
        app: kapp-controller
    spec:
      serviceAccount: kapp-controller-sa
      containers:
      - name: kapp-controller
        image: kapp-controller
        args:
        - #@ "-packaging-global-namespace={}".format(data.values.packaging_global_namespace)
        #@ if/end data.values.dangerous_enable_pprof:
        - -dangerous-enable-pprof=true
        - -metrics-bind-address=8082
        env:
        - name: KAPPCTRL_MEM_TMP_DIR
          value: /etc/kappctrl-mem-tmp
        - name: KAPPCTRL_SYSTEM_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: KAPPCTRL_API_PORT
          value: #@ str(data.values.api_port)
        resources:
          requests:
            cpu: 120m
            memory: 100Mi
        volumeMounts:
        - name: template-fs
          mountPath: /etc/kappctrl-mem-tmp
        securityContext:
          runAsUser: 1000
          runAsGroup: 2000
        ports:
        - containerPort: #@ data.values.api_port
          name: api
          protocol: TCP
      securityContext:
        fsGroup: 3000
      volumes:
      - name: template-fs
        emptyDir:
          #! https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
          medium: Memory
```

#### Which issue(s) this PR fixes:

Fixes #394

#### Does this PR introduce a user-facing change?

```release-note
Allows users to configure the metrics server port via kapp-controller flag
```

#### Additional Notes for your reviewer:

Verified via logs:

```
kapp-controller-7957488c96-qgswn > kapp-controller | {"level":"info","ts":1634749394.024642,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8082"}
```

and `lsof`:

```
$ kubectl exec -it kapp-controller-56774bbf86-ng9kv -n kapp-controller -- lsof -i TCP:8082 
COMMAND   PID            USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
kapp-cont  16 kapp-controller    8u  IPv6 424496      0t0  TCP *:8082 (LISTEN)
```

#### Additional documentation e.g., Proposal, usage docs, etc.:

Not sure if we document these flags but can look into adding if we do.
