### PR TITLE
Solution issue #409

### DIFF
--- a/pkg/packageinstall/app.go
+++ b/pkg/packageinstall/app.go
@@ -21,9 +21,14 @@ import (
 const (
 	ManuallyControlledAnnKey = "ext.packaging.carvel.dev/manually-controlled"
 
+	HelmTemplateOverlayNameKey      = "ext.packaging.carvel.dev/helm-template-name"
+	HelmTemplateOverlayNameSpaceKey = "ext.packaging.carvel.dev/helm-template-namespace"
+
 	// Resulting secret names are sorted deterministically by suffix
-	ExtYttPathsFromSecretNameAnnKey       = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
-	ExtYttPathsFromSecretNameAnnKeyPrefix = ExtYttPathsFromSecretNameAnnKey + "."
+	ExtYttPathsFromSecretNameAnnKey        = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
+	ExtYttPathsFromSecretNameAnnKeyPrefix  = ExtYttPathsFromSecretNameAnnKey + "."
+	ExtHelmPathsFromSecretNameAnnKey       = "ext.packaging.carvel.dev/helm-template-values-from-secret-name"
+	ExtHelmPathsFromSecretNameAnnKeyPrefix = ExtHelmPathsFromSecretNameAnnKey + "."
 
 	ExtYttDataValuesOverlaysAnnKey = "ext.packaging.carvel.dev/ytt-data-values-overlays"
 
@@ -88,9 +93,27 @@ func NewApp(existingApp *v1alpha1.App, pkgInstall *pkgingv1alpha1.PackageInstall
 
 	valuesApplied := false
 	yttPathsApplied := false
+	helmPathsApplied := false
 
 	for i, templateStep := range desiredApp.Spec.Template {
 		if templateStep.HelmTemplate != nil {
+			if !helmPathsApplied {
+				helmPathsApplied = true
+
+				if _, found := pkgInstall.Annotations[HelmTemplateOverlayNameKey]; found {
+					templateStep.HelmTemplate.Name = pkgInstall.Annotations[HelmTemplateOverlayNameKey]
+				}
+				if _, found := pkgInstall.Annotations[HelmTemplateOverlayNameSpaceKey]; found {
+					templateStep.HelmTemplate.Namespace = pkgInstall.Annotations[HelmTemplateOverlayNameSpaceKey]
+				}
+				for _, secretName := range secretNamesFromAnn(pkgInstall, "helm") {
+					templateStep.HelmTemplate.ValuesFrom = append(templateStep.HelmTemplate.ValuesFrom, kcv1alpha1.AppTemplateValuesSource{
+						SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+							Name: secretName,
+						},
+					})
+				}
+			}
 			if !valuesApplied {
 				valuesApplied = true
 
@@ -108,7 +131,7 @@ func NewApp(existingApp *v1alpha1.App, pkgInstall *pkgingv1alpha1.PackageInstall
 			if !yttPathsApplied {
 				yttPathsApplied = true
 
-				for _, secretName := range secretNamesFromAnn(pkgInstall) {
+				for _, secretName := range secretNamesFromAnn(pkgInstall, "ytt") {
 					if templateStep.Ytt.Inline == nil {
 						templateStep.Ytt.Inline = &kcv1alpha1.AppFetchInline{}
 					}
@@ -152,27 +175,53 @@ func NewApp(existingApp *v1alpha1.App, pkgInstall *pkgingv1alpha1.PackageInstall
 	return desiredApp, nil
 }
 
-func secretNamesFromAnn(installedPkg *pkgingv1alpha1.PackageInstall) []string {
-	var suffixes []string
-	suffixToSecretName := map[string]string{}
+func secretNamesFromAnn(installedPkg *pkgingv1alpha1.PackageInstall, annType string) []string {
+	if annType == "ytt" {
+		var suffixes []string
+		suffixToSecretName := map[string]string{}
 
-	for annKey, secretName := range installedPkg.Annotations {
-		if annKey == ExtYttPathsFromSecretNameAnnKey {
-			suffix := ""
-			suffixToSecretName[suffix] = secretName
-			suffixes = append(suffixes, suffix)
-		} else if strings.HasPrefix(annKey, ExtYttPathsFromSecretNameAnnKeyPrefix) {
-			suffix := strings.TrimPrefix(annKey, ExtYttPathsFromSecretNameAnnKeyPrefix)
-			suffixToSecretName[suffix] = secretName
-			suffixes = append(suffixes, suffix)
+		for annKey, secretName := range installedPkg.Annotations {
+			if annKey == ExtYttPathsFromSecretNameAnnKey {
+				suffix := ""
+				suffixToSecretName[suffix] = secretName
+				suffixes = append(suffixes, suffix)
+			} else if strings.HasPrefix(annKey, ExtYttPathsFromSecretNameAnnKeyPrefix) {
+				suffix := strings.TrimPrefix(annKey, ExtYttPathsFromSecretNameAnnKeyPrefix)
+				suffixToSecretName[suffix] = secretName
+				suffixes = append(suffixes, suffix)
+			}
 		}
-	}
 
-	sort.Strings(suffixes)
+		sort.Strings(suffixes)
 
-	var result []string
-	for _, suffix := range suffixes {
-		result = append(result, suffixToSecretName[suffix])
+		var result []string
+		for _, suffix := range suffixes {
+			result = append(result, suffixToSecretName[suffix])
+		}
+		return result
+	} else if annType == "helm" {
+		var suffixes []string
+		suffixToSecretName := map[string]string{}
+
+		for annKey, secretName := range installedPkg.Annotations {
+			if annKey == ExtHelmPathsFromSecretNameAnnKey {
+				suffix := ""
+				suffixToSecretName[suffix] = secretName
+				suffixes = append(suffixes, suffix)
+			} else if strings.HasPrefix(annKey, ExtHelmPathsFromSecretNameAnnKeyPrefix) {
+				suffix := strings.TrimPrefix(annKey, ExtHelmPathsFromSecretNameAnnKeyPrefix)
+				suffixToSecretName[suffix] = secretName
+				suffixes = append(suffixes, suffix)
+			}
+		}
+
+		sort.Strings(suffixes)
+
+		var result []string
+		for _, suffix := range suffixes {
+			result = append(result, suffixToSecretName[suffix])
+		}
+		return result
 	}
-	return result
+	return nil
 }

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -46,6 +46,7 @@ func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
 				Spec: &kcv1alpha1.AppSpec{
 					Template: []kcv1alpha1.AppTemplate{
 						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
 						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
 						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
 					},
@@ -87,6 +88,9 @@ func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
 						},
 					},
 				}},
+				// Second Helm template step is untouched
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+
 				{Ytt: &kcv1alpha1.AppTemplateYtt{
 					Inline: &kcv1alpha1.AppFetchInline{
 						PathsFrom: []kcv1alpha1.AppFetchInlineSource{

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -20,16 +20,20 @@ import (
 // several tests below have no SyncPeriod set so they'll all use the same default.
 var defaultSyncPeriod metav1.Duration = metav1.Duration{10 * time.Minute}
 
-func TestAppExtYttPathsFromSecretNameAnn(t *testing.T) {
+func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
 	ipkg := &pkgingv1alpha1.PackageInstall{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name":      "no-suffix",
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.4":    "suffix-4",
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.2":    "suffix-2",
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.text": "suffix-text",
+				"ext.packaging.carvel.dev/ytt-paths-from-secret-name":                 "ytt-no-suffix",
+				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.4":               "ytt-suffix-4",
+				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.2":               "ytt-suffix-2",
+				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.text":            "ytt-suffix-text",
+				"ext.packaging.carvel.dev/helm-template-values-from-secret-name":      "helm-no-suffix",
+				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.4":    "helm-suffix-4",
+				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.2":    "helm-suffix-2",
+				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.text": "helm-suffix-text",
 			},
 		},
 	}
@@ -59,35 +63,132 @@ func TestAppExtYttPathsFromSecretNameAnn(t *testing.T) {
 		Spec: kcv1alpha1.AppSpec{
 			SyncPeriod: &defaultSyncPeriod,
 			Template: []kcv1alpha1.AppTemplate{
-				// Helm template step is untouched
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						kcv1alpha1.AppTemplateValuesSource{
+							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+								Name: "helm-no-suffix",
+							},
+						},
+						kcv1alpha1.AppTemplateValuesSource{
+							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+								Name: "helm-suffix-2",
+							},
+						},
+						kcv1alpha1.AppTemplateValuesSource{
+							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+								Name: "helm-suffix-4",
+							},
+						},
+						kcv1alpha1.AppTemplateValuesSource{
+							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+								Name: "helm-suffix-text",
+							},
+						},
+					},
+				}},
 				{Ytt: &kcv1alpha1.AppTemplateYtt{
 					Inline: &kcv1alpha1.AppFetchInline{
 						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
 							kcv1alpha1.AppFetchInlineSource{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "no-suffix",
+									Name: "ytt-no-suffix",
 								},
 							},
 							kcv1alpha1.AppFetchInlineSource{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "suffix-2",
+									Name: "ytt-suffix-2",
 								},
 							},
 							kcv1alpha1.AppFetchInlineSource{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "suffix-4",
+									Name: "ytt-suffix-4",
 								},
 							},
 							kcv1alpha1.AppFetchInlineSource{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "suffix-text",
+									Name: "ytt-suffix-text",
 								},
 							},
 						},
 					},
 				}},
 				// Second ytt templating step is untouched
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+			},
+		},
+	}
+
+	// Not interesting in metadata in this test
+	app.ObjectMeta = metav1.ObjectMeta{}
+
+	if !reflect.DeepEqual(expectedApp, app) {
+		bs, _ := yaml.Marshal(app)
+		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
+	}
+}
+func TestAppHelmOverlaysFromAnn(t *testing.T) {
+	ipkg := &pkgingv1alpha1.PackageInstall{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"ext.packaging.carvel.dev/helm-template-name":      "helm-new-name",
+				"ext.packaging.carvel.dev/helm-template-namespace": "helm-new-namespace",
+			},
+		},
+		Spec: pkgingv1alpha1.PackageInstallSpec{
+			Values: []pkgingv1alpha1.PackageInstallValues{
+				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values1"}},
+				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values2"}},
+			},
+		},
+	}
+
+	pkgVersion := datapkgingv1alpha1.Package{
+		Spec: datapkgingv1alpha1.PackageSpec{
+			RefName: "expec-pkg",
+			Version: "1.5.0",
+			Template: datapkgingv1alpha1.AppTemplateSpec{
+				Spec: &kcv1alpha1.AppSpec{
+					Template: []kcv1alpha1.AppTemplate{
+						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+							Name:      "helm-default-name",
+							Namespace: "helm-default-namespace",
+						}},
+						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+					},
+				},
+			},
+		},
+	}
+
+	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion)
+	if err != nil {
+		t.Fatalf("Expected no err, but was: %s", err)
+	}
+
+	expectedApp := &kcv1alpha1.App{
+		Spec: kcv1alpha1.AppSpec{
+			SyncPeriod: &defaultSyncPeriod,
+			Template: []kcv1alpha1.AppTemplate{
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+					Name:      "helm-new-name",
+					Namespace: "helm-new-namespace",
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						kcv1alpha1.AppTemplateValuesSource{
+							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+								Name: "values1",
+							},
+						},
+						kcv1alpha1.AppTemplateValuesSource{
+							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
+								Name: "values2",
+							},
+						},
+					},
+				}},
+				// Ytt template step is untouched
 				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
 			},
 		},


### PR DESCRIPTION
Added additional functionality to allow overwriting values from helm based packages and to exclusively only add helm secrets

New annotations:
ext.packaging.carvel.dev/helm-template-name
ext.packaging.carvel.dev/helm-template-namespace
ext.packaging.carvel.dev/helm-template-values-from-secret-name



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #409 

#### Does this PR introduce a user-facing change?

```release-note
Created new annotations to support the request from #409 
ext.packaging.carvel.dev/helm-template-name
ext.packaging.carvel.dev/helm-template-namespace
ext.packaging.carvel.dev/helm-template-values-from-secret-name

helm-template-name:
- overwrites upstream package helm name via packageinstall

helm-template-namespace:
- overwrites upstream package helm namespace via packageinstall

helm-template-paths-from-secret-name:
- allows users to explicitly define what secrets are used and not used between helm and ytt if used together

By default not adding the annotations will not modify upstream packages
```

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:

Additionally created new functions to test cover the changes that I made.

```test-log
+ '[' -z '' ']'
+ go clean -testcache
+ set -u
+ go test ./pkg/... ./cmd/... -test.v
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/internalpackaging/install	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/internalpackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/install	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/install	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/install	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1	[no test files]
=== RUN   TestValidatePackageMetadataNameInvalid
--- PASS: TestValidatePackageMetadataNameInvalid (0.00s)
=== RUN   TestValidatePackageMetadataNameValid
--- PASS: TestValidatePackageMetadataNameValid (0.00s)
=== RUN   TestValidatePackageNameInvalid
--- PASS: TestValidatePackageNameInvalid (0.00s)
=== RUN   TestValidatePackageNameValid
--- PASS: TestValidatePackageNameValid (0.00s)
=== RUN   TestValidatePackageSpecPackageVersionInvalidEmpty
--- PASS: TestValidatePackageSpecPackageVersionInvalidEmpty (0.00s)
=== RUN   TestValidatePackageSpecPackageVersionInvalidNonSemver
--- PASS: TestValidatePackageSpecPackageVersionInvalidNonSemver (0.00s)
=== RUN   TestValidatePackageSpecPackageVersionValid
--- PASS: TestValidatePackageSpecPackageVersionValid (0.00s)
=== RUN   TestValidatePackageSpecPackageNameInvalid
--- PASS: TestValidatePackageSpecPackageNameInvalid (0.00s)
=== RUN   TestValidatePackageSpecPackageNameValid
--- PASS: TestValidatePackageSpecPackageNameValid (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/validation	0.222s
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/clientset/versioned	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/clientset/versioned/fake	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/clientset/versioned/scheme	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/clientset/versioned/typed/datapackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/clientset/versioned/typed/datapackaging/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/informers/externalversions	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/informers/externalversions/datapackaging	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/informers/externalversions/datapackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/client/listers/datapackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/openapi	[no test files]
=== RUN   TestPackageVersionListIncludesGlobalAndNamespaced
--- PASS: TestPackageVersionListIncludesGlobalAndNamespaced (0.00s)
=== RUN   TestPackageVersionListPrefersNamespacedOverGlobal
--- PASS: TestPackageVersionListPrefersNamespacedOverGlobal (0.00s)
=== RUN   TestPackageVersionGetNotPresentInNS
--- PASS: TestPackageVersionGetNotPresentInNS (0.00s)
=== RUN   TestPackageVersionGetPresentInOnlyNS
--- PASS: TestPackageVersionGetPresentInOnlyNS (0.00s)
=== RUN   TestPackageVersionGetNotFound
--- PASS: TestPackageVersionGetNotFound (0.00s)
=== RUN   TestPackageVersionGetPreferNS
--- PASS: TestPackageVersionGetPreferNS (0.00s)
=== RUN   TestPackageVersionUpdateDoesntUpdateGlobal
--- PASS: TestPackageVersionUpdateDoesntUpdateGlobal (0.00s)
=== RUN   TestPackageVersionUpdateCreatesInNS
--- PASS: TestPackageVersionUpdateCreatesInNS (0.00s)
=== RUN   TestPackageVersionDeleteExistsInNS
--- PASS: TestPackageVersionDeleteExistsInNS (0.00s)
=== RUN   TestPackageVersionDeleteExistsGlobalNotInNS
--- PASS: TestPackageVersionDeleteExistsGlobalNotInNS (0.00s)
=== RUN   TestPackageListIncludesGlobalAndNamespaced
--- PASS: TestPackageListIncludesGlobalAndNamespaced (0.00s)
=== RUN   TestPackageListPrefersNamespacedOverGlobal
--- PASS: TestPackageListPrefersNamespacedOverGlobal (0.00s)
=== RUN   TestPackageGetNotPresentInNS
--- PASS: TestPackageGetNotPresentInNS (0.00s)
=== RUN   TestPackageGetPresentInOnlyNS
--- PASS: TestPackageGetPresentInOnlyNS (0.00s)
=== RUN   TestPackageGetNotFound
--- PASS: TestPackageGetNotFound (0.00s)
=== RUN   TestPackageGetPreferNS
--- PASS: TestPackageGetPreferNS (0.00s)
=== RUN   TestPackageUpdateDoesntUpdateGlobal
--- PASS: TestPackageUpdateDoesntUpdateGlobal (0.00s)
=== RUN   TestPackageUpdateCreatesInNS
--- PASS: TestPackageUpdateCreatesInNS (0.00s)
=== RUN   TestPackageDeleteExistsInNS
--- PASS: TestPackageDeleteExistsInNS (0.00s)
=== RUN   TestPackageDeleteExistsGlobalNotInNS
--- PASS: TestPackageDeleteExistsGlobalNotInNS (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/registry/datapackaging	1.494s
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/watchers	[no test files]
=== RUN   Test_NoInspectReconcile_IfNoDeployAttempted
--- PASS: Test_NoInspectReconcile_IfNoDeployAttempted (0.05s)
=== RUN   Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty
--- PASS: Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty (0.07s)
=== RUN   TestSucceededDurationUntilReady
--- PASS: TestSucceededDurationUntilReady (0.00s)
=== RUN   TestFailureSyncMathOverflowGuard
--- PASS: TestFailureSyncMathOverflowGuard (0.00s)
=== RUN   TestConsecutiveFailuresOverflowGuard
--- PASS: TestConsecutiveFailuresOverflowGuard (0.00s)
=== RUN   TestFailedDurationUntilReady
--- PASS: TestFailedDurationUntilReady (0.00s)
=== RUN   TestSucceededIsReadyAt
--- PASS: TestSucceededIsReadyAt (0.00s)
=== RUN   TestFailedIsReadyAt
--- PASS: TestFailedIsReadyAt (0.00s)
=== RUN   TestIsReadyAtWithStaleDeployTime
--- PASS: TestIsReadyAtWithStaleDeployTime (0.00s)
=== RUN   Test_SecretRefs_RetrievesAllSecretRefs
--- PASS: Test_SecretRefs_RetrievesAllSecretRefs (0.00s)
=== RUN   Test_SecretRefs_RetrievesNoSecretRefs_WhenNonePresent
--- PASS: Test_SecretRefs_RetrievesNoSecretRefs_WhenNonePresent (0.00s)
=== RUN   Test_ConfigMapRefs_RetrievesAllConfigMapRefs
--- PASS: Test_ConfigMapRefs_RetrievesAllConfigMapRefs (0.00s)
=== RUN   Test_ConfigMapRefs_RetrievesNoConfigMapRefs_WhenNonePresent
--- PASS: Test_ConfigMapRefs_RetrievesNoConfigMapRefs_WhenNonePresent (0.00s)
=== RUN   Test_AppRefTracker_HasAppRemovedForSecrets_ThatAreNoLongerUsedByApp
--- PASS: Test_AppRefTracker_HasAppRemovedForSecrets_ThatAreNoLongerUsedByApp (0.00s)
=== RUN   Test_AppRefTracker_HasNoAppsRemoved_WhenRefsRemainSame
--- PASS: Test_AppRefTracker_HasNoAppsRemoved_WhenRefsRemainSame (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/app	0.802s
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/fake	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/scheme	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/typed/internalpackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/typed/internalpackaging/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/typed/kappctrl/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/typed/kappctrl/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/typed/packaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned/typed/packaging/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/internalpackaging	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/internalpackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/kappctrl	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/kappctrl/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/packaging	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions/packaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/listers/internalpackaging/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/listers/kappctrl/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/listers/packaging/v1alpha1	[no test files]
=== RUN   Test_GetConfig_ReturnsSecret_WhenBothConfigMapAndSecretExist
--- PASS: Test_GetConfig_ReturnsSecret_WhenBothConfigMapAndSecretExist (0.00s)
=== RUN   Test_GetConfig_ReturnsConfigMap_WhenOnlyConfigMapExists
--- PASS: Test_GetConfig_ReturnsConfigMap_WhenOnlyConfigMapExists (0.00s)
=== RUN   Test_GetConfig_ReturnsSecret_WhenOnlySecretExists
--- PASS: Test_GetConfig_ReturnsSecret_WhenOnlySecretExists (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/config	0.405s
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/deploy	[no test files]
=== RUN   TestNewFlagFromString
--- PASS: TestNewFlagFromString (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec	0.307s
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/fetch	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/memdir	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/metrics	[no test files]
=== RUN   Test_PackageInstallDeletion
=== RUN   Test_PackageInstallDeletion/ensures_that_deletion_related_fields_on_App_are_kept_in_sync_with_PackageInstall_even_after_PackageInstall_is_marked_for_deletion
--- PASS: Test_PackageInstallDeletion (0.00s)
    --- PASS: Test_PackageInstallDeletion/ensures_that_deletion_related_fields_on_App_are_kept_in_sync_with_PackageInstall_even_after_PackageInstall_is_marked_for_deletion (0.00s)
=== RUN   Test_PackageInstallVersionDowngrades
=== RUN   Test_PackageInstallVersionDowngrades/succeeds_with_same_version
=== RUN   Test_PackageInstallVersionDowngrades/succeeds_with_higher_version
=== RUN   Test_PackageInstallVersionDowngrades/errors_when_trying_to_install_lower_version
=== RUN   Test_PackageInstallVersionDowngrades/succeeds_when_trying_to_install_lower_version_but_is_allowed_to_downgrade
--- PASS: Test_PackageInstallVersionDowngrades (0.00s)
    --- PASS: Test_PackageInstallVersionDowngrades/succeeds_with_same_version (0.00s)
    --- PASS: Test_PackageInstallVersionDowngrades/succeeds_with_higher_version (0.00s)
    --- PASS: Test_PackageInstallVersionDowngrades/errors_when_trying_to_install_lower_version (0.00s)
    --- PASS: Test_PackageInstallVersionDowngrades/succeeds_when_trying_to_install_lower_version_but_is_allowed_to_downgrade (0.00s)
=== RUN   Test_PackageRefWithPrerelease_IsFound
--- PASS: Test_PackageRefWithPrerelease_IsFound (0.00s)
=== RUN   Test_PackageRefUsesName
--- PASS: Test_PackageRefUsesName (0.00s)
=== RUN   Test_PlaceHolderSecretCreated_WhenPackageHasNoSecretRef
--- PASS: Test_PlaceHolderSecretCreated_WhenPackageHasNoSecretRef (0.00s)
=== RUN   Test_PlaceHolderSecretsCreated_WhenPackageHasMultipleFetchStages
--- PASS: Test_PlaceHolderSecretsCreated_WhenPackageHasMultipleFetchStages (0.00s)
=== RUN   Test_PlaceHolderSecretsNotCreated_WhenFetchStagesHaveSecrets
--- PASS: Test_PlaceHolderSecretsNotCreated_WhenFetchStagesHaveSecrets (0.00s)
=== RUN   Test_PlaceHolderSecretCreated_WhenPackageInstallUpdated
--- PASS: Test_PlaceHolderSecretCreated_WhenPackageInstallUpdated (0.00s)
=== RUN   TestAppExtPathsFromSecretNameAnn
--- PASS: TestAppExtPathsFromSecretNameAnn (0.00s)
=== RUN   TestAppHelmOverlaysFromAnn
--- PASS: TestAppHelmOverlaysFromAnn (0.00s)
=== RUN   TestAppExtYttDataValuesOverlaysAnn
--- PASS: TestAppExtYttDataValuesOverlaysAnn (0.00s)
=== RUN   TestAppYttValues
--- PASS: TestAppYttValues (0.00s)
=== RUN   TestAppHelmTemplateValues
--- PASS: TestAppHelmTemplateValues (0.00s)
=== RUN   TestAppManuallyControlled
--- PASS: TestAppManuallyControlled (0.00s)
=== RUN   TestAppCustomFetchSecretNames
--- PASS: TestAppCustomFetchSecretNames (0.00s)
=== RUN   TestOnlyEligiblePackagesAreEnqueued
--- PASS: TestOnlyEligiblePackagesAreEnqueued (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/packageinstall	0.975s
=== RUN   Test_NoInspectReconcile_IfNoDeployAttempted
--- PASS: Test_NoInspectReconcile_IfNoDeployAttempted (0.02s)
=== RUN   Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty
--- PASS: Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty (0.03s)
=== RUN   TestNewPackageRepoApp
--- PASS: TestNewPackageRepoApp (0.00s)
=== RUN   TestSucceededDurationUntilReady
--- PASS: TestSucceededDurationUntilReady (0.00s)
=== RUN   TestFailureSyncMathOverflowGuard
--- PASS: TestFailureSyncMathOverflowGuard (0.00s)
=== RUN   TestConsecutiveFailuresOverflowGuard
--- PASS: TestConsecutiveFailuresOverflowGuard (0.00s)
=== RUN   TestFailedDurationUntilReady
--- PASS: TestFailedDurationUntilReady (0.00s)
=== RUN   TestSucceededIsReadyAt
--- PASS: TestSucceededIsReadyAt (0.00s)
=== RUN   TestFailedIsReadyAt
--- PASS: TestFailedIsReadyAt (0.00s)
=== RUN   TestIsReadyAtWithStaleDeployTime
--- PASS: TestIsReadyAtWithStaleDeployTime (0.00s)
=== RUN   Test_SecretRefs_RetrievesAllSecretRefs
--- PASS: Test_SecretRefs_RetrievesAllSecretRefs (0.00s)
=== RUN   Test_SecretRefs_RetrievesNoSecretRefs_WhenNonePresent
--- PASS: Test_SecretRefs_RetrievesNoSecretRefs_WhenNonePresent (0.00s)
=== RUN   Test_PlaceholderSecretCreated_WhenPackageRepositoryHasNoSecret
--- PASS: Test_PlaceholderSecretCreated_WhenPackageRepositoryHasNoSecret (0.00s)
=== RUN   Test_PlaceholderSecretNotCreated_WhenPackageRepositoryHasSecret
--- PASS: Test_PlaceholderSecretNotCreated_WhenPackageRepositoryHasSecret (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/pkgrepository	1.279s
?   	github.com/vmware-tanzu/carvel-kapp-controller/pkg/reconciler	[no test files]
=== RUN   Test_AddAppForRef_AddsApp_WhenRefNotInMap
--- PASS: Test_AddAppForRef_AddsApp_WhenRefNotInMap (0.00s)
=== RUN   Test_RemoveAppFromAllRefs_RemovesApp
--- PASS: Test_RemoveAppFromAllRefs_RemovesApp (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/reftracker	0.181s
=== RUN   TestHelmTemplateCmdLookup
--- PASS: TestHelmTemplateCmdLookup (0.00s)
PASS
ok  	github.com/vmware-tanzu/carvel-kapp-controller/pkg/template	0.329s
?   	github.com/vmware-tanzu/carvel-kapp-controller/cmd	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/cmd/controller	[no test files]
?   	github.com/vmware-tanzu/carvel-kapp-controller/cmd/controllerinit	[no test files]
+ echo UNIT SUCCESS
UNIT SUCCESS
```
