### PR TITLE
Add ability to auto populate adding KUBERNETES_SERVICE_HOST to noProxy

### DIFF
--- a/config-test/secret-config.yml
+++ b/config-test/secret-config.yml
@@ -42,8 +42,8 @@ stringData:
   #! Uncomment and fill in a value to test with https proxy
   #! httpsProxy: ""
 
-  #! must match the value in proxy_test.go and service dns in test/e2e/assests/registry/registry.yml
-  noProxy: github.com,docker.io,registry-svc.registry.svc.cluster.local
+  #! must match the service dns in test/e2e/assests/registry/registry.yml
+  noProxy: github.com,docker.io,registry-svc.registry.svc.cluster.local,KAPPCTRL_KUBERNETES_SERVICE_HOST
 
   #! second index (split on .) needs to match serverNamespace in http_test.go's skip tls test
   dangerousSkipTLSVerify: registry-svc.registry.svc.cluster.local


### PR DESCRIPTION
#### What this PR does / why we need it:

Auto populates `KUBERNETES_SERVICE_HOST` by adding it to `noProxy` list of kapp-controller Secret config. 

#### Which issue(s) this PR fixes:

Fixes #391 

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:

Will add small note to carvel.dev once UX is solidified. 
