### PR TITLE
Add trivy scan daily build

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -34,25 +34,17 @@ jobs:
           git clone --depth 1 https://github.com/aquasecurity/trivy
       - name: Run Trivy Reports
         run: |
-          # kapp-controller binary - sarif
-          trivy rootfs --ignore-unfixed --format template --template "@trivy/contrib/sarif.tpl" \
-            --output trivy-results-binary.sarif --severity "MEDIUM,HIGH,CRITICAL" \
-            "controller"
+          export TRIVY_IGNORE_UNFIXED=true
+          export TRIVY_SEVERITY="MEDIUM,HIGH,CRITICAL"
+          export TRIVY_TEMPLATE="@trivy/contrib/sarif.tpl"
 
-          # kapp-controller docker image - sarif
-          trivy image --ignore-unfixed --format template --template "@trivy/contrib/sarif.tpl" \
-            --output trivy-results-image.sarif --severity "MEDIUM,HIGH,CRITICAL" \
-            "docker.io/carvel/kapp-controller:${{ github.sha }}"
+          # kapp-controller binary - output in sarif and json
+          trivy rootfs --format template --output trivy-results-binary.sarif "controller"
+          trivy rootfs --format json --output trivy-results-binary.json "controller"
 
-          # kapp-controller docker image - json
-          trivy rootfs --ignore-unfixed --format json \
-            --output trivy-results-binary.json --severity "MEDIUM,HIGH,CRITICAL" \
-            "controller"
-
-          # kapp-controller docker image - json
-          trivy image --ignore-unfixed --format json \
-            --output trivy-results-image.json --severity "MEDIUM,HIGH,CRITICAL" \
-            "docker.io/carvel/kapp-controller:${{ github.sha }}"
+          # kapp-controller docker image - output in sarif and json
+          trivy image --format template --output trivy-results-image.sarif "docker.io/carvel/kapp-controller:${{ github.sha }}"
+          trivy image --format json --output trivy-results-image.json "docker.io/carvel/kapp-controller:${{ github.sha }}"
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,99 @@
+name: Trivy CVE Dependency Scanner
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  scan-all:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.17"
+      - name: Install Carvel Tools
+        uses: vmware-tanzu/carvel-setup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          only: ytt, kapp, kbld, vendir
+          ytt: v0.37.0
+          kapp: v0.42.0
+          kbld: v0.31.0
+          vendir: v0.23.0
+      - name: Build the kapp-controller binary file
+        run: |
+          ./hack/build.sh
+      - name: Run Trivy vulnerability scanner for kapp-controller binary
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'rootfs'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-binary.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Build image from Dockerfile
+        run: |
+          docker build -t docker.io/carvel/kapp-controller:${{ github.sha }} .
+      - name: Run Trivy vulnerability scanner for docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/carvel/kapp-controller:${{ github.sha }}'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-image.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: '.'
+      - name: Run Trivy to generate report for slack Notification - binary
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'rootfs'
+          ignore-unfixed: true
+          format: json
+          output: 'results-binary.json'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Run Trivy to generate report for slack Notification - dockerfile
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/carvel/kapp-controller:${{ github.sha }}'
+          ignore-unfixed: true
+          format: json
+          output: 'results-image.json'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Create Issues Summary
+        run: |
+          summary_binary=$(jq '.[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' results-binary.json | tr -d \\)
+          summary_image=$(jq '.[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' results-image.json | tr -d \\)
+          summary_all="$summary_binary $summary_image"
+          if [ -z $summary_all ]
+          then
+            summary="0 Issues"
+          fi
+          echo "SUMMARY=$summary_all" >> $GITHUB_ENV
+      - name: Send Slack Notification
+        uses: slackapi/slack-github-action@v1.15.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: G01FTP43JMQ
+          slack-message: "Trivy Scan Summary is: ${{ env.SUMMARY }} "
+      - name: Send Failure notification
+        if: always() && job.status == 'failure'
+        uses: slackapi/slack-github-action@v1.15.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: G01FTP43JMQ
+          slack-message: "Trivy scan failed. Please check the latest github action run for trivy scanner."

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -19,81 +19,70 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: "1.17"
-      - name: Install Carvel Tools
-        uses: vmware-tanzu/carvel-setup-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          only: ytt, kapp, kbld, vendir
-          ytt: v0.37.0
-          kapp: v0.42.0
-          kbld: v0.31.0
-          vendir: v0.23.0
-      - name: Build the kapp-controller binary file
+      - name: Build the kapp-controller artifacts
         run: |
+          ./hack/install-deps.sh
           ./hack/build.sh
-      - name: Run Trivy vulnerability scanner for kapp-controller binary
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'rootfs'
-          ignore-unfixed: true
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results-binary.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-      - name: Build image from Dockerfile
-        run: |
+
+          # docker image
           docker build -t docker.io/carvel/kapp-controller:${{ github.sha }} .
-      - name: Run Trivy vulnerability scanner for docker image
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'docker.io/carvel/kapp-controller:${{ github.sha }}'
-          ignore-unfixed: true
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results-image.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
+      - name: Install Trivy
+        run: |
+          brew install aquasecurity/trivy/trivy
+
+          # download the sarif format template
+          git clone --depth 1 https://github.com/aquasecurity/trivy
+      - name: Run Trivy Reports
+        run: |
+          # kapp-controller binary - sarif
+          trivy rootfs --ignore-unfixed --format template --template "@trivy/contrib/sarif.tpl" \
+            --output trivy-results-binary.sarif --severity "MEDIUM,HIGH,CRITICAL" \
+            "controller"
+
+          # kapp-controller docker image - sarif
+          trivy image --ignore-unfixed --format template --template "@trivy/contrib/sarif.tpl" \
+            --output trivy-results-image.sarif --severity "MEDIUM,HIGH,CRITICAL" \
+            "docker.io/carvel/kapp-controller:${{ github.sha }}"
+
+          # kapp-controller docker image - json
+          trivy rootfs --ignore-unfixed --format json \
+            --output trivy-results-binary.json --severity "MEDIUM,HIGH,CRITICAL" \
+            "controller"
+
+          # kapp-controller docker image - json
+          trivy image --ignore-unfixed --format json \
+            --output trivy-results-image.json --severity "MEDIUM,HIGH,CRITICAL" \
+            "docker.io/carvel/kapp-controller:${{ github.sha }}"
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: '.'
-      - name: Run Trivy to generate report for slack Notification - binary
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'rootfs'
-          ignore-unfixed: true
-          format: json
-          output: 'results-binary.json'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-      - name: Run Trivy to generate report for slack Notification - dockerfile
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'docker.io/carvel/kapp-controller:${{ github.sha }}'
-          ignore-unfixed: true
-          format: json
-          output: 'results-image.json'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-      - name: Create Issues Summary
+      - name: Check for new Vulnerabilities
         run: |
-          summary_binary=$(jq '.[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' results-binary.json | tr -d \\)
-          summary_image=$(jq '.[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' results-image.json | tr -d \\)
-          summary_all="$summary_binary $summary_image"
-          if [ -z $summary_all ]
-          then
-            summary="0 Issues"
+          set -o pipefail
+
+          summary="Trivy scan has found new vulnerabilities - check https://github.com/vmware-tanzu/carvel-kapp-controller/security/code-scanning for more"
+
+          vulnCountBinary=$(jq '[ .Results[].Vulnerabilities ] | length' trivy-results-binary.json)
+          vulnCountImage=$(jq '[ .Results[].Vulnerabilities ] | length' trivy-results-image.json)
+          if [ $vulnCountImage -eq 0 && $vulnCountBinary -eq 0 ]; then
+            summary="Trivy Scan has not found any new Security Issues"
           fi
-          echo "SUMMARY=$summary_all" >> $GITHUB_ENV
+
+          echo "SUMMARY=$summary" >> $GITHUB_ENV
       - name: Send Slack Notification
+        if: success()
         uses: slackapi/slack-github-action@v1.15.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: G01FTP43JMQ
-          slack-message: "Trivy Scan Summary is: ${{ env.SUMMARY }} "
+          slack-message: "${{ env.SUMMARY }}"
       - name: Send Failure notification
-        if: always() && job.status == 'failure'
+        if: failure()
         uses: slackapi/slack-github-action@v1.15.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: G01FTP43JMQ
-          slack-message: "Trivy scan failed. Please check the latest github action run for trivy scanner."
+          slack-message: "Trivy scan workflow failed. Please check the latest github action run for trivy scanner."


### PR DESCRIPTION
- Done as part of https://github.com/vmware-tanzu/carvel-kapp-controller/issues/368
- Add slack notification to triyy scanner

Signed-off-by: Neil Hickey <nhickey@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #368

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
The final step is to add a secret to github that contains the slack bot with write access to the slack channel.

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
