### PR TITLE
Bump secretgen-controller to 0.7.1 for e2e tests

### DIFF
--- a/hack/secretgen-controller.sh
+++ b/hack/secretgen-controller.sh
@@ -1,7 +1,7 @@
 deploy_secretgen-controller() {
   if [ "$KAPPCTRL_E2E_SECRETGEN_CONTROLLER" == "true" ]; then
     echo "Deploying secretgen-controller..."
-    kapp deploy -a sg -f https://github.com/vmware-tanzu/carvel-secretgen-controller/releases/download/v0.7.0/release.yml -c -y
+    kapp deploy -a sg -f https://github.com/vmware-tanzu/carvel-secretgen-controller/releases/download/v0.7.1/release.yml -c -y
   else
     echo "Skipping secretgen-controller deployment"
   fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Keeping kapp-controller e2e tests up to date with latest version of secretgen-controller deployed

#### Which issue(s) this PR fixes:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
