### PR TITLE
Bump vendir version to 0.24.0

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -29,7 +29,7 @@ install() {
   kbld_version=v0.31.0
   kapp_version=v0.43.0
   imgpkg_version=v0.22.0
-  vendir_version=v0.23.0
+  vendir_version=v0.24.0
 
   if [[ `uname` == Darwin ]]; then
     binary_type=darwin-amd64
@@ -37,14 +37,14 @@ install() {
     kbld_checksum=d3b0a30bf3a79bedeb25d8548a91254954b99cd4a0c03f3a810b331fc4d1f071
     kapp_checksum=c5c7f34399293ccda62dc7b809535a8e2f2afb9901147429281c0f4884b13483
     imgpkg_checksum=bc2819d73c6680c402a1ff4a51de07a5decafaef70b34662b46460c9a5eccc4c
-    vendir_checksum=aef3233128727c01ffac6561533c9f60a49307f41decc1baa18688a4a250b15f
+    vendir_checksum=f3a738d1fe55803ad5faba495f662c48efa230976ccad7a159587dcf9b020f63
   else
     binary_type=linux-amd64
     ytt_checksum=1aad12386f6bae1a78197acdc7ec9e60c441f82c4ca944df8d3c78625750fe59
     kbld_checksum=ba0be56d9e74b067f3e659de0b79100b0b9df86a2e3e0e6ff533b1e019c22c23
     kapp_checksum=f8669039dfba001081c94576c898d10aba28ecceffcd98708e8f2c87c13109e4
     imgpkg_checksum=d34a06097a781ed15a4f04d6fe72b41ccf9dae835c821ec524a99b6c4e647f03
-    vendir_checksum=c6a65e7e8e589e25bf5554e9575ab247e55ae71920d3d366ffd84b1571fe34ac
+    vendir_checksum=b7bfd227aa2e6df602f8e79edf725bb0a944b68d207005f42f46f061c4ecd55a
   fi
 
   echo "Installing ${binary_type} binaries..."


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps vendir to 0.24.0. 

#### Which issue(s) this PR fixes:

Fixes #432 
