### PR TITLE
Update photon to 4.0 to resolve CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM photon:3.0
+FROM photon:4.0
 
 ARG KCTRL_VER=development
 
@@ -54,7 +54,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -ldflags="-X 'main.Version=$KCTRL_VER' -buildid=" -trimpath -o controller ./cmd/main.go
 
 # --- run image ---
-FROM photon:3.0
+FROM photon:4.0
 
 RUN tdnf install -y git openssh-clients shadow-tools sed
 


### PR DESCRIPTION
Scan of photon:3.0

```
$ trivy image photon:3.0

2021-12-14T17:23:17.161-0600	INFO	Detected OS: photon
2021-12-14T17:23:17.161-0600	INFO	Detecting Photon Linux vulnerabilities...
2021-12-14T17:23:17.162-0600	INFO	Number of language-specific files: 0

photon:3.0 (photon 3.0)
=======================
Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 3, CRITICAL: 0)

+---------+------------------+----------+-------------------+---------------+---------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+---------+------------------+----------+-------------------+---------------+---------------------------------------+
| krb5    | CVE-2020-28196   | HIGH     | 1.17-1.ph3        | 1.17-2.ph3    | krb5: unbounded recursion via an      |
|         |                  |          |                   |               | ASN.1-encoded Kerberos message        |
|         |                  |          |                   |               | in lib/krb5/asn.1/asn1_encode.c       |
|         |                  |          |                   |               | may lead...                           |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-28196 |
+         +------------------+          +                   +               +---------------------------------------+
|         | CVE-2021-36222   |          |                   |               | krb5: Sending a request containing    |
|         |                  |          |                   |               | PA-ENCRYPTED-CHALLENGE padata         |
|         |                  |          |                   |               | element without using FAST could...   |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36222 |
+         +------------------+          +                   +               +---------------------------------------+
|         | CVE-2021-37750   |          |                   |               | krb5: NULL pointer dereference        |
|         |                  |          |                   |               | in process_tgs_req() in               |
|         |                  |          |                   |               | kdc/do_tgs_req.c via a FAST inner...  |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-37750 |
```

Scan of photon:4.0
```
$ trivy image photon:4.0

2021-12-14T17:24:26.625-0600	WARN	No OS package is detected. Make sure you haven't deleted any files that contain information about the installed packages.
2021-12-14T17:24:26.626-0600	WARN	e.g. files under "/lib/apk/db/", "/var/lib/dpkg/" and "/var/lib/rpm"
2021-12-14T17:24:26.626-0600	INFO	Detected OS: photon
2021-12-14T17:24:26.626-0600	INFO	Detecting Photon Linux vulnerabilities...
2021-12-14T17:24:26.626-0600	INFO	Number of language-specific files: 0

photon:4.0 (photon 4.0)
=======================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

#### What this PR does / why we need it:

Addresses CVEs revealed in trivy scan. 

#### Which issue(s) this PR fixes:

[CVE-2020-28196](https://github.com/vmware-tanzu/carvel-kapp-controller/security/code-scanning/27?query=ref%3Arefs%2Fheads%2Fdevelop)
[CVE-2021-36222](https://github.com/vmware-tanzu/carvel-kapp-controller/security/code-scanning/28?query=ref%3Arefs%2Fheads%2Fdevelop)
[CVE-2021-37750](https://github.com/vmware-tanzu/carvel-kapp-controller/security/code-scanning/29?query=ref%3Arefs%2Fheads%2Fdevelop)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
