### PR TITLE
rbac: add permissions for flowcontrol prioritylevelconfigurations and…

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -41,6 +41,7 @@ type Options struct {
 	APIRequestTimeout  time.Duration
 	PackagingGloablNS  string
 	MetricsBindAddress string
+	APIPriorityAndFairness bool
 }
 
 // Based on https://github.com/kubernetes-sigs/controller-runtime/blob/8f633b179e1c704a6e40440b528252f147a3362a/examples/builtins/main.go
@@ -99,7 +100,7 @@ func Run(opts Options, runLog logr.Logger) error {
 		return fmt.Errorf("Expected to find %s env var", kappctrlAPIPORTEnvKey)
 	}
 
-	server, err := apiserver.NewAPIServer(restConfig, coreClient, kcClient, opts.PackagingGloablNS, bindPort)
+	server, err := apiserver.NewAPIServer(restConfig, coreClient, kcClient, opts, bindPort)
 	if err != nil {
 		return fmt.Errorf("Building API server: %s", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,8 +27,9 @@ func main() {
 	flag.StringVar(&ctrlOpts.PackagingGloablNS, "packaging-global-namespace", "", "The namespace used for global packaging resources")
 	flag.StringVar(&ctrlOpts.MetricsBindAddress, "metrics-bind-address", ":8080", "Address for metrics server. If 0, then metrics server doesnt listen on any port.")
 	flag.BoolVar(&ctrlOpts.EnablePprof, "dangerous-enable-pprof", false, "If set to true, enable pprof on "+controller.PprofListenAddr)
-	flag.DurationVar(&ctrlOpts.APIRequestTimeout, "api-request-timeout", time.Duration(0), "HTTP timeout for Kubernetes API requests")
 	flag.BoolVar(&runController, controllerinit.InternalControllerFlag, false, "[Internal] run the controller code")
+	flag.BoolVar(&ctrlOpts.APIPriorityAndFairness, "api-priority-and-fairness", true, "Enable/disable APIPriorityAndFairness feature gate for apiserver.")
+	flag.DurationVar(&ctrlOpts.APIRequestTimeout, "api-request-timeout", time.Duration(0), "HTTP timeout for Kubernetes API requests")
 	flag.Parse()
 
 	log := logf.Log.WithName("kc")

--- a/config/rbac.yml
+++ b/config/rbac.yml
@@ -60,6 +60,9 @@ rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
+- apiGroups: ["flowcontrol.apiserver.k8s.io"]
+  resources: ["prioritylevelconfigurations", "flowschemas"]
+  verbs: ["list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -10,27 +10,27 @@ import (
 	"os"
 	"time"
 
-	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/openapi"
-
+	"github.com/vmware-tanzu/carvel-kapp-controller/cmd/controller"
 	kcinstall "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/install"
-	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
-
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging"
 	datapkginginstall "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/install"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/openapi"
 	packagerest "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/registry/datapackaging"
+	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	genericopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/apiserver/pkg/features"
 	apirest "k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	genericopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
 	"k8s.io/klog"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
@@ -74,13 +74,13 @@ type APIServer struct {
 	aggClient aggregatorclient.Interface
 }
 
-func NewAPIServer(clientConfig *rest.Config, coreClient kubernetes.Interface, kcClient kcclient.Interface, globalNamespace string, bindPort int) (*APIServer, error) {
+func NewAPIServer(clientConfig *rest.Config, coreClient kubernetes.Interface, kcClient kcclient.Interface, ctrlOpts controller.Options, bindPort int) (*APIServer, error) {
 	aggClient, err := aggregatorclient.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("building aggregation client: %v", err)
 	}
 
-	config, err := newServerConfig(aggClient, bindPort)
+	config, err := newServerConfig(aggClient, ctrlOpts, bindPort)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func NewAPIServer(clientConfig *rest.Config, coreClient kubernetes.Interface, kc
 		return nil, err
 	}
 
-	packageMetadatasStorage := packagerest.NewPackageMetadataCRDREST(kcClient, coreClient, globalNamespace)
-	packageStorage := packagerest.NewPackageCRDREST(kcClient, coreClient, globalNamespace)
+	packageMetadatasStorage := packagerest.NewPackageMetadataCRDREST(kcClient, coreClient, ctrlOpts.PackagingGloablNS)
+	packageStorage := packagerest.NewPackageCRDREST(kcClient, coreClient, ctrlOpts.PackagingGloablNS)
 
 	pkgGroup := genericapiserver.NewDefaultAPIGroupInfo(datapackaging.GroupName, Scheme, metav1.ParameterCodec, Codecs)
 	pkgv1alpha1Storage := map[string]apirest.Storage{}
@@ -147,7 +147,7 @@ func (as *APIServer) isReady() (bool, error) {
 	return false, nil
 }
 
-func newServerConfig(aggClient aggregatorclient.Interface, bindPort int) (*genericapiserver.RecommendedConfig, error) {
+func newServerConfig(aggClient aggregatorclient.Interface, ctrlOpts controller.Options, bindPort int) (*genericapiserver.RecommendedConfig, error) {
 	recommendedOptions := genericoptions.NewRecommendedOptions("", Codecs.LegacyCodec(v1alpha1.SchemeGroupVersion))
 	recommendedOptions.Etcd = nil
 
@@ -172,6 +172,17 @@ func newServerConfig(aggClient aggregatorclient.Interface, bindPort int) (*gener
 
 	if err := updateAPIService(aggClient, caContentProvider); err != nil {
 		return nil, fmt.Errorf("error updating api service with generated certs: %v", err)
+	}
+
+	// This was done since is causes logging issues for k8s cluster <=1.19.
+	// The logs occurred since this feature gate was not enabled in 1.19
+	// but is by default for 1.20. It causes k8s.io/apiserver 1.20 and up to
+	// make use of resources not available in 1.19 (i.e. flowcontrol API group).
+	if !ctrlOpts.APIPriorityAndFairness {
+		err := feature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.APIPriorityAndFairness))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	serverConfig := genericapiserver.NewRecommendedConfig(Codecs)


### PR DESCRIPTION
Closes #460 

#### What this PR does / why we need it:

turns out when we upgraded k8s libraries something in the libraries really wanted to Watch these flowcontrol resources. I'm not sure what it is or why it needs to, and also we seem to ~work regardless, so there's definitely another angle that could be explored here of whether we could opt-out from that component. 

However, if you don't like seeing these errors on k8s clusters version > 1.20:
```
k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1beta1.PriorityLevelConfiguration: failed to list *v1beta1.PriorityLevelConfiguration: prioritylevelconfigurations.flowcontrol.apiserver.k8s.io is forbidden: User "system:serviceaccount:kapp-controller:kapp-controller-sa" cannot list resource "prioritylevelconfigurations" in API group "flowcontrol.apiserver.k8s.io" at the cluster scope
E1215 21:54:59.994620      17 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1beta1.FlowSchema: failed to list *v1beta1.FlowSchema: flowschemas.flowcontrol.apiserver.k8s.io is forbidden: User "system:serviceaccount:kapp-controller:kapp-controller-sa" cannot list resource "flowschemas" in API group "flowcontrol.apiserver.k8s.io" at the cluster scope
```

but you DO like seeing these other errors on clusters version <= 1.19 : 
```
E1216 19:53:15.293473      17 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1beta1.PriorityLevelConfiguration: failed to list *v1beta1.PriorityLevelConfiguration: the server could not find the requested resource (get prioritylevelconfigurations.flowcontrol.apiserver.k8s.io)
E1216 19:53:36.083622      17 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1beta1.FlowSchema: failed to list *v1beta1.FlowSchema: the server could not find the requested resource (get flowschemas.flowcontrol.apiserver.k8s.io)
E1216 19:54:12.208215      17 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1beta1.PriorityLevelConfiguration: failed to list *v1beta1.PriorityLevelConfiguration: the server could not find the requested resource (get prioritylevelconfigurations.flowcontrol.apiserver.k8s.io)
E1216 19:54:16.746485      17 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1beta1.FlowSchema: failed to list *v1beta1.FlowSchema: the server could not find the requested resource (get flowschemas.flowcontrol.apiserver.k8s.io)
```

THEN this is the pull-request for you, lemme tell ya.

#### Which issue(s) this PR fixes:
the issue was the noise in the logs (didn't observe broken functionality but who knows)


