### PR TITLE
hack/test-e2e: tee test output also to a file

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -25,7 +25,7 @@ To build the kapp-controller project locally, run the following:
 
 The kapp-controller source can be built and deployed to a Kubernetes cluster using one of the options below.
 
-#### minikube 
+#### minikube
 
 ```
 eval $(minikube docker-env)
@@ -83,6 +83,10 @@ export KAPPCTRL_E2E_NAMESPACE=kappctrl-test
 # run e2e test suite
 ./hack/test-all.sh
 ```
+
+The `hack/test-e2e.sh` script (also run by `test-all`) will tee its output
+to both your stdout and the (gitignored) file `tmp/e2eoutput.txt` so that you
+can more easily grep/search/parse the output.
 
 ### Troubleshooting tips
 

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -6,10 +6,10 @@ go clean -testcache
 
 # create ns if not exists because the `apply -f -` won't complain on a no-op if the ns already exists.
 kubectl create ns $KAPPCTRL_E2E_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-go test ./test/e2e/kappcontroller -timeout 60m -test.v $@
+go test ./test/e2e/kappcontroller -timeout 60m -test.v $@ | tee tmp/e2eoutput.txt
 
 if [ "$KAPPCTRL_E2E_SECRETGEN_CONTROLLER" == "true" ]; then
-  go test ./test/e2e/secretgencontroller -timeout 60m -test.v $@
+  go test ./test/e2e/secretgencontroller -timeout 60m -test.v $@ | tee -a tmp/e2eoutput.txt
 fi
 
 echo E2E SUCCESS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

tees test output to a file so that we can see it in stdout but also then retrospectively grep through it if we want to.

#### Which issue(s) this PR fixes

I have an issue where maybe 2-3 e2e tests fail and I wish i could track them, so in other words
I want to both see the whole e2e test output on the screen, and also be able to grep it for just the 
"FAILED" tests.  I think I can accomplish all my dreams by tee-ing the test output to a file.

#### Does this PR introduce a user-facing change?
only for users who run the e2e tests.
```release-note

```

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
