### PR TITLE
PackageRepository: supports inline fetch step

### DIFF
--- a/config/crds.yml
+++ b/config/crds.yml
@@ -1245,6 +1245,32 @@ spec:
                             type: object
                         type: object
                     type: object
+                  inline:
+                    properties:
+                      paths:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      pathsFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                directoryPath:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                            secretRef:
+                              properties:
+                                directoryPath:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                    type: object
                 type: object
               paused:
                 description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied

--- a/examples/packaging-with-repo/inline-repo.yml
+++ b/examples/packaging-with-repo/inline-repo.yml
@@ -1,0 +1,63 @@
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: probably-tap-or-something.tanzu.carvel.dev
+  # Adds it to global namespace (as defined by kapp-controller)
+  # which makes packages available in all namespaces
+  namespace: kapp-controller-packaging-global
+spec:
+  fetch:
+    inline:
+      paths:
+        .imgpkg/images.yml: |
+          ---
+          apiVersion: imgpkg.carvel.dev/v1alpha1
+          images:
+          - annotations:
+              kbld.carvel.dev/id: k8slt/kctrl-example-pkg:v2.0.0
+            image: index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a
+          kind: ImagesLock
+        packages/pkg.test.carvel.dev/pkg.test.carvel.dev.2.0.0.yml: |
+          ---
+          apiVersion: data.packaging.carvel.dev/v1alpha1
+          kind: Package
+          metadata:
+            name: pkg.test.carvel.dev.2.0.0
+            annotations:
+              pkg.test.carvel.dev/real-version-ann: "inline-repo-3"
+          spec:
+            refName: pkg.test.carvel.dev
+            version: 2.0.0
+            capacityRequirementsDescription: "cpu: 1,RAM: 2, Disk: 3"
+            template:
+              spec:
+                fetch:
+                - imgpkgBundle:
+                    image: k8slt/kctrl-example-pkg:v2.0.0
+                template:
+                - ytt:
+                    paths:
+                    - config-step-2-template
+                    - config-step-2a-overlays
+                - kbld:
+                    paths:
+                    - "-"
+                    - ".imgpkg/images.yml"
+                deploy:
+                - kapp: {}
+            valuesSchema:
+              openAPIv3:
+                properties:
+                  svc_port:
+                    type: integer
+                    description: Service port
+                    default: 80
+                  app_port:
+                    type: integer
+                    description: App port
+                    default: 80
+                  hello_msg:
+                    type: string
+                    description: Hello msg for the app
+                    default: "stranger"

--- a/pkg/apis/packaging/v1alpha1/package_repository.go
+++ b/pkg/apis/packaging/v1alpha1/package_repository.go
@@ -56,6 +56,8 @@ type PackageRepositoryFetch struct {
 	Git *v1alpha1.AppFetchGit `json:"git,omitempty"`
 	// +optional
 	ImgpkgBundle *v1alpha1.AppFetchImgpkgBundle `json:"imgpkgBundle,omitempty"`
+	// +optional
+	Inline *v1alpha1.AppFetchInline `json:"inline,omitempty"`
 }
 
 type PackageRepositoryStatus struct {

--- a/pkg/apis/packaging/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/packaging/v1alpha1/zz_generated.deepcopy.go
@@ -237,6 +237,11 @@ func (in *PackageRepositoryFetch) DeepCopyInto(out *PackageRepositoryFetch) {
 		*out = new(kappctrlv1alpha1.AppFetchImgpkgBundle)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Inline != nil {
+		in, out := &in.Inline, &out.Inline
+		*out = new(kappctrlv1alpha1.AppFetchInline)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/pkgrepository/package_repo_app.go
+++ b/pkg/pkgrepository/package_repo_app.go
@@ -57,6 +57,7 @@ func NewPackageRepoApp(pkgRepository *pkgingv1alpha1.PackageRepository) (*kcv1al
 	desiredApp.Spec = kcv1alpha1.AppSpec{
 		Fetch: []kcv1alpha1.AppFetch{{
 			Image:        pkgRepository.Spec.Fetch.Image,
+			Inline:       pkgRepository.Spec.Fetch.Inline,
 			Git:          pkgRepository.Spec.Fetch.Git,
 			HTTP:         pkgRepository.Spec.Fetch.HTTP,
 			ImgpkgBundle: pkgRepository.Spec.Fetch.ImgpkgBundle,


### PR DESCRIPTION
#### What this PR does / why we need it:
package repositories support inline fetch

- makes some kinds of e2e tests easier
- someone will probably find a good use for this

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
package repositories support inline fetch
```

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:
probably should add some related line in the docs / update the CRD on carvel.dev
separate PR pending.
```docs
package repositories support inline fetch
```
