### PR TITLE
Disable kapp inspect for App CRs by default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,4 +18,4 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
-  new-from-rev: a95f826ff25ddb5968e0dd4e53818a9a35baf016 # only enforce for commits after Jul 15 2021, allows us to phase-in godoc compliance
+  new-from-rev: c1a0a1445615c515f3b6f5006b857b8f426308ef # only enforce for commits after Jan 11 2022, allows us to phase-in godoc compliance

--- a/pkg/app/app_deploy.go
+++ b/pkg/app/app_deploy.go
@@ -98,15 +98,17 @@ func (a *App) inspect() exec.CmdRunResult {
 	for _, dep := range a.app.Spec.Deploy {
 		switch {
 		case dep.Kapp != nil:
-			cancelCh, closeCancelCh := a.newCancelCh()
-			defer closeCancelCh()
+			if dep.Kapp.Inspect != nil {
+				cancelCh, closeCancelCh := a.newCancelCh()
+				defer closeCancelCh()
 
-			kapp, err := a.newKapp(*dep.Kapp, cancelCh)
-			if err != nil {
-				return exec.NewCmdRunResultWithErr(fmt.Errorf("Preparing kapp: %s", err))
+				kapp, err := a.newKapp(*dep.Kapp, cancelCh)
+				if err != nil {
+					return exec.NewCmdRunResultWithErr(fmt.Errorf("Preparing kapp: %s", err))
+				}
+
+				result = kapp.Inspect()
 			}
-
-			result = kapp.Inspect()
 
 		default:
 			result.AttachErrorf("%s", fmt.Errorf("Unsupported way to inspect"))

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -198,6 +198,8 @@ func (a *App) reconcileInspect() error {
 			Error:     inspectResult.ErrorStr(),
 			UpdatedAt: metav1.NewTime(time.Now().UTC()),
 		}
+	} else {
+		a.app.Status.Inspect = nil
 	}
 
 	return a.updateStatus("marking inspect completed")

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -84,9 +84,9 @@ func (a *App) reconcileDeploy() error {
 
 	// Reconcile inspect regardless of deploy success
 	// but don't inspect if deploy never attempted
-	if a.app.Status.Deploy != nil {
-		_ = a.reconcileInspect()
-	}
+	// if a.app.Status.Deploy != nil {
+	// 	_ = a.reconcileInspect()
+	// }
 
 	return a.updateStatus("marking reconcile completed")
 }

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -84,9 +84,9 @@ func (a *App) reconcileDeploy() error {
 
 	// Reconcile inspect regardless of deploy success
 	// but don't inspect if deploy never attempted
-	// if a.app.Status.Deploy != nil {
-	// 	_ = a.reconcileInspect()
-	// }
+	if a.app.Status.Deploy != nil {
+		_ = a.reconcileInspect()
+	}
 
 	return a.updateStatus("marking reconcile completed")
 }
@@ -190,12 +190,14 @@ func (a *App) resetLastDeployStartedAt() {
 func (a *App) reconcileInspect() error {
 	inspectResult := a.inspect().WithFriendlyYAMLStrings()
 
-	a.app.Status.Inspect = &v1alpha1.AppStatusInspect{
-		Stdout:    inspectResult.Stdout,
-		Stderr:    inspectResult.Stderr,
-		ExitCode:  inspectResult.ExitCode,
-		Error:     inspectResult.ErrorStr(),
-		UpdatedAt: metav1.NewTime(time.Now().UTC()),
+	if !inspectResult.IsEmpty() {
+		a.app.Status.Inspect = &v1alpha1.AppStatusInspect{
+			Stdout:    inspectResult.Stdout,
+			Stderr:    inspectResult.Stderr,
+			ExitCode:  inspectResult.ExitCode,
+			Error:     inspectResult.ErrorStr(),
+			UpdatedAt: metav1.NewTime(time.Now().UTC()),
+		}
 	}
 
 	return a.updateStatus("marking inspect completed")

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -65,8 +65,5 @@ func (r CmdRunResult) WithFriendlyYAMLStrings() CmdRunResult {
 
 // IsEmpty returns true if CmdRunResult is empty, otherwise returns false
 func (r CmdRunResult) IsEmpty() bool {
-	if r == (CmdRunResult{}) {
-		return true
-	}
-	return false
+	return r == (CmdRunResult{})
 }

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -63,6 +63,7 @@ func (r CmdRunResult) WithFriendlyYAMLStrings() CmdRunResult {
 	}
 }
 
+// IsEmpty returns true if CmdRunResult is empty, otherwise returns false
 func (r CmdRunResult) IsEmpty() bool {
 	if r == (CmdRunResult{}) {
 		return true

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -62,3 +62,10 @@ func (r CmdRunResult) WithFriendlyYAMLStrings() CmdRunResult {
 		Finished: r.Finished,
 	}
 }
+
+func (r CmdRunResult) IsEmpty() bool {
+	if r == (CmdRunResult{}) {
+		return true
+	}
+	return false
+}

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -63,7 +63,6 @@ func (r CmdRunResult) WithFriendlyYAMLStrings() CmdRunResult {
 	}
 }
 
-// IsEmpty returns true if CmdRunResult is empty, otherwise returns false
 func (r CmdRunResult) IsEmpty() bool {
 	return r == (CmdRunResult{})
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

- Disable kapp inspect by default. 
- This is required to reduce the number of calls made by kapp in cases of large number of packages

#### Which issue(s) this PR fixes:
<!--

-->
Fixes #
https://github.com/vmware-tanzu/carvel-kapp-controller/issues/467

#### Does this PR introduce a user-facing change?
<!--
Yes

-->
```release-note
kapp inspect will now be disabled by default for app cr deployments to reduce number of api calls.
```

#### Additional Notes for your reviewer:
ToDo
- [x] Add tests
