### PR TITLE
bump ytt to v0.38.0

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           only: ytt, kbld
-          ytt: v0.37.0
+          ytt: v0.38.0
           kbld: v0.31.0
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         only: ytt, kapp, kbld, vendir
-        ytt: v0.37.0
+        ytt: v0.38.0
         kapp: v0.44.0
         kbld: v0.32.0
         vendir: v0.24.0

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         only: ytt, kapp, kbld, vendir
-        ytt: v0.35.1
+        ytt: v0.38.0
         kapp: v0.42.0
         kbld: v0.31.0
         vendir: v0.23.0

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           only: ytt, kapp, kbld
-          ytt: v0.37.0
+          ytt: v0.38.0
           kapp: v0.44.0
           kbld: v0.32.0
       - name: Run Upgrade Test

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -25,7 +25,7 @@ install() {
 	exit 1
   fi
 
-  ytt_version=v0.37.0
+  ytt_version=v0.38.0
   kbld_version=v0.32.0
   kapp_version=v0.44.0
   imgpkg_version=v0.24.0
@@ -33,14 +33,14 @@ install() {
 
   if [[ `uname` == Darwin ]]; then
     binary_type=darwin-amd64
-    ytt_checksum=5eef9da11dd4f714495e2cf47041fc6fd413c8c393af4cc5bf3869e075b4e936
+    ytt_checksum=1f84e26457a5efd2470df408072bf2f182c939414e4958f82e19e122d2ee120c
     kbld_checksum=5fc8a491327294717611974c6ab3da2bda3f3809ef3147c1e8472ac62af3ee18
     kapp_checksum=27980ca316c2124fb2e983ff971c9afb12be818ac93d7d63c6b03ddb42d38f97
     imgpkg_checksum=f0c87c8caefb3d2a82e648779b36783403fe5c93930df2d5cbf4968713933392
     vendir_checksum=f3a738d1fe55803ad5faba495f662c48efa230976ccad7a159587dcf9b020f63
   else
     binary_type=linux-amd64
-    ytt_checksum=1aad12386f6bae1a78197acdc7ec9e60c441f82c4ca944df8d3c78625750fe59
+    ytt_checksum=2ca800c561464e0b252e5ee5cacff6aa53831e65e2fb9a09cf388d764013c40d
     kbld_checksum=de546ac46599e981c20ad74cd2deedf2b0f52458885d00b46b759eddb917351a
     kapp_checksum=aaa5162b857868e64a270641b79a2a980e4528d40e88ea7741440b3028637c7c
     imgpkg_checksum=cfcfcb5afc5e3d28ce1f2f67971a4dcd18f514dadf8a63d70c864e49c9ddca7e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

this PR creates world peace and bumps ytt to 0.38.0. The world peace feature is still experimental though.



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
bump ytt to 0.38.0 for all the latest in OpenAPI features
```

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
