### PR TITLE
Fix inspect tests

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e -x -u
+set -e -x -u -o pipefail
 
 go clean -testcache
 

--- a/test/e2e/kappcontroller/app_status_test.go
+++ b/test/e2e/kappcontroller/app_status_test.go
@@ -5,11 +5,11 @@ package kappcontroller
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
@@ -47,6 +47,7 @@ spec:
     - ytt: {}
   deploy:
     - kapp:
+        inspect: {}
         intoNs: does-not-exist`, name) + sas.ForNamespaceYAML()
 
 	cleanUpApp := func() {
@@ -77,7 +78,7 @@ spec:
 			}},
 			ObservedGeneration:  1,
 			FriendlyDescription: "Reconcile failed: Deploying: Error (see .status.usefulErrorMessage for details)",
-			UsefulErrorMessage:  "kapp: Error: Checking existence of resource configmap/configmap (v1) namespace: does-not-exist: configmaps \"configmap\" is forbidden:\n  User \"system:serviceaccount:" + env.Namespace + ":kappctrl-e2e-ns-sa\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"does-not-exist\" (reason: Forbidden)",
+			UsefulErrorMessage:  "kapp: Error: Checking existence of resource configmap/configmap (v1) namespace: does-not-exist:\n  API server says: configmaps \"configmap\" is forbidden:\n    User \"system:serviceaccount:" + env.Namespace + ":kappctrl-e2e-ns-sa\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"does-not-exist\" (reason: Forbidden)",
 		},
 		Deploy: &v1alpha1.AppStatusDeploy{
 			ExitCode: 1,
@@ -118,7 +119,5 @@ spec:
 		cr.Status.Template.Stderr = ""
 	}
 
-	if !reflect.DeepEqual(expectedStatus, cr.Status) {
-		t.Fatalf("\nStatus is not same:\nExpected:\n%#v\nGot:\n%#v\n", expectedStatus, cr.Status)
-	}
+	require.Equal(t, expectedStatus, cr.Status)
 }

--- a/test/e2e/kappcontroller/git_test.go
+++ b/test/e2e/kappcontroller/git_test.go
@@ -41,6 +41,7 @@ spec:
   - ytt: {}
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
 `, env.Namespace) + sas.ForNamespaceYAML()
 
@@ -151,6 +152,7 @@ spec:
   - ytt: {}
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
 `, env.Namespace, env.Namespace) + sas.ForNamespaceYAML()
 

--- a/test/e2e/kappcontroller/helm_test.go
+++ b/test/e2e/kappcontroller/helm_test.go
@@ -70,6 +70,7 @@ spec:
           name: test-helm-values
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
       delete:
         rawOptions: ["--apply-ignored=true"]
@@ -105,6 +106,7 @@ spec:
           name: test-helm-values
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
       delete:
         rawOptions: ["--apply-ignored=true"]

--- a/test/e2e/kappcontroller/http_test.go
+++ b/test/e2e/kappcontroller/http_test.go
@@ -39,6 +39,7 @@ spec:
   - ytt: {}
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
 `, env.Namespace) + sas.ForNamespaceYAML()
 
@@ -148,6 +149,7 @@ spec:
   - ytt: {}
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
 `, serverNamespace, env.Namespace) + sas.ForNamespaceYAML()
 

--- a/test/e2e/kappcontroller/imgpkg_bundle_test.go
+++ b/test/e2e/kappcontroller/imgpkg_bundle_test.go
@@ -44,6 +44,7 @@ spec:
       - config.yml
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
 `, env.Namespace) + sas.ForNamespaceYAML()
 
@@ -154,6 +155,7 @@ spec:
   - ytt: {}
   deploy:
   - kapp:
+      inspect: {}
       intoNs: %s
 `, name, registryNamespace, env.Namespace) + sas.ForNamespaceYAML()
 

--- a/test/e2e/kappcontroller/packageinstall_test.go
+++ b/test/e2e/kappcontroller/packageinstall_test.go
@@ -70,7 +70,8 @@ spec:
           - "-"
           - ".imgpkg/images.yml"
       deploy:
-      - kapp: {}
+      - kapp: 
+          inspect: {}
 ---
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall


### PR DESCRIPTION
#### What this PR does / why we need it:

When #468 was introduced, there were test failures that were not surfaced by CI since there was no pipefail set for the test-e2e.sh script. As a result, the pr appeared to be passing all tests even though there were failures.

This fixes all tests in a way to preserve original behavior of the tests, which include inspect in the expected status.

It also adds the pipefail to the script.
