### PR TITLE
Pin trivy src cloning to v0.22.0

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -77,7 +77,7 @@ jobs:
           brew install aquasecurity/trivy/trivy
 
           # download the sarif format template
-          git clone --depth 1 https://github.com/aquasecurity/trivy
+          git clone --depth 1 -b "v0.22.0" https://github.com/aquasecurity/trivy
       - name: Run Trivy Reports
         run: |
           export TRIVY_IGNORE_UNFIXED=true


### PR DESCRIPTION
We can remove this and the git clone code once trivy release v0.23.0

- there was a breaking change introduced on the trivy develop branch that moved the sarif template into go code and introduced the --format serif flag. Once they release that we can move to using it

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Fixes currently broken trivy scanning workflow

#### Which issue(s) this PR fixes:
Fixes currently broken trivy scanning workflow

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
