### PR TITLE
Allow CRDs to show up with "kubectl get all"

### DIFF
--- a/config/crds.yml
+++ b/config/crds.yml
@@ -472,6 +472,9 @@ metadata:
 spec:
   group: kappctrl.k14s.io
   names:
+    categories:
+    - all
+    - carvel
     kind: App
     listKind: AppList
     plural: apps
@@ -958,6 +961,9 @@ metadata:
 spec:
   group: packaging.carvel.dev
   names:
+    categories:
+    - all
+    - carvel
     kind: PackageInstall
     listKind: PackageInstallList
     plural: packageinstalls
@@ -1105,6 +1111,9 @@ metadata:
 spec:
   group: packaging.carvel.dev
   names:
+    categories:
+    - all
+    - carvel
     kind: PackageRepository
     listKind: PackageRepositoryList
     plural: packagerepositories

--- a/pkg/apis/kappctrl/v1alpha1/types.go
+++ b/pkg/apis/kappctrl/v1alpha1/types.go
@@ -10,6 +10,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories={all,carvel}
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 // +kubebuilder:printcolumn:name=Since-Deploy,JSONPath=.status.deploy.startedAt,description=Last time app started being deployed. Does not mean anything was changed.,type=date
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date

--- a/pkg/apis/packaging/v1alpha1/package_install.go
+++ b/pkg/apis/packaging/v1alpha1/package_install.go
@@ -12,7 +12,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=pkgi
+// +kubebuilder:resource:shortName=pkgi,categories={all,carvel}
 // +kubebuilder:printcolumn:name=Package name,JSONPath=.spec.packageRef.refName,description=PackageMetadata name,type=string
 // +kubebuilder:printcolumn:name=Package version,JSONPath=.status.version,description=PackageMetadata version,type=string
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string

--- a/pkg/apis/packaging/v1alpha1/package_repository.go
+++ b/pkg/apis/packaging/v1alpha1/package_repository.go
@@ -11,7 +11,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=pkgr
+// +kubebuilder:resource:shortName=pkgr,categories={all,carvel}
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 type PackageRepository struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow CRDs to show up with `kubectl get all`. `App`, `PackageInstall`, and `PackageRepository` seemed appropriate for user-facing CRDs, I wasn't sure about the role/desired visibility of the others. `kubectl get carvel` will also be available now.

#### Which issue(s) this PR fixes:
Fixes #482

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
PackageInstalls, PackageRepositories, and Apps will be shown from `kubectl get all` and `kubectl get carvel`.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

Open to suggestions as to whether we want to add tests, documentation, or anything else.