### PR TITLE
Include downgrade annotation in downgrade error message

### DIFF
--- a/pkg/packageinstall/packageinstall.go
+++ b/pkg/packageinstall/packageinstall.go
@@ -112,7 +112,8 @@ func (pi *PackageInstallCR) reconcile(modelStatus *reconciler.Status) (reconcile
 
 		if matchedVers.Len() == 0 {
 			errMsg := fmt.Sprintf(
-				"Stopped installing matched version '%s' since last attempted version '%s' is higher",
+				"Stopped installing matched version '%s' since last attempted version '%s' is higher."+
+					"\nhint: Add annotation packaging.carvel.dev/downgradable: \"\" to PackageInstall to proceed with downgrade",
 				pkg.Spec.Version, pi.model.Status.LastAttemptedVersion)
 			modelStatus.SetUsefulErrorMessage(errMsg)
 			modelStatus.SetReconcileCompleted(fmt.Errorf("Error (see .status.usefulErrorMessage for details)"))

--- a/pkg/packageinstall/packageinstall_downgrade_test.go
+++ b/pkg/packageinstall/packageinstall_downgrade_test.go
@@ -188,7 +188,7 @@ func Test_PackageInstallVersionDowngrades(t *testing.T) {
 					Message: "Error (see .status.usefulErrorMessage for details)",
 				}},
 				FriendlyDescription: "Reconcile failed: Error (see .status.usefulErrorMessage for details)",
-				UsefulErrorMessage:  "Stopped installing matched version '1.0.0' since last attempted version '2.0.0' is higher",
+				UsefulErrorMessage:  "Stopped installing matched version '1.0.0' since last attempted version '2.0.0' is higher.\nhint: Add annotation packaging.carvel.dev/downgradable: \"\" to PackageInstall to proceed with downgrade",
 			},
 		}, getPackageInstall(t, appClient, "instl-pkg").Status)
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds additional information to the error message when attempting to downgrade a PackageInstall (i.e. change PackageInstall version to a lower Package version). This will provide the user with additional information on what to do if they actually want to proceed with downgrading.

#### Which issue(s) this PR fixes:

Fixes #466 

#### Does this PR introduce a user-facing change?

```release-note
Add information on downgrade annotation to allow user to proceed with downgrade.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

N/A
