### PR TITLE
Bump go version to 1.17.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v1
         with:
-          go-version: "1.17"
+          go-version: "1.17.6"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v1
       with:
-        go-version: "1.17"
+        go-version: "1.17.6"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v1
         with:
-          go-version: "1.17"
+          go-version: "1.17.6"
       - name: Build the kapp-controller artifacts
         run: |
           ./hack/install-deps.sh

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v1
         with:
-          go-version: "1.17"
+          go-version: "1.17.6"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN tdnf install -y tar wget gzip
 
 # adapted from golang docker image
 ENV PATH /usr/local/go/bin:$PATH
-ENV GOLANG_VERSION 1.17.1
+ENV GOLANG_VERSION 1.17.6
 ENV GO_REL_ARCH linux-amd64
-ENV GO_REL_SHA dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef
+ENV GO_REL_SHA 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
 
 RUN set eux; \
     wget -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.${GO_REL_ARCH}.tar.gz" --progress=dot:giga; \


### PR DESCRIPTION
#### What this PR does / why we need it:

Use latest version of go 1.17. Should include fix for following issue introduced in 1.17.3:  https://github.com/golang/go/issues/38049

#### Which issue(s) this PR fixes:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Bump go version to 1.17.6
```

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

N/A
