### PR TITLE
Switch to floating minikube version in actions

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -49,8 +49,7 @@ jobs:
 
         ./hack/verify-no-dirty-files.sh
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64 > /tmp/bin/minikube
-        echo "5d423a00a24fdfbb95627a3fadbf58540fc4463be2338619257c529f93cf061b  /tmp/bin/minikube" | sha256sum -c -
+        wget -O- https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -49,8 +49,7 @@ jobs:
 
         ./hack/verify-no-dirty-files.sh
 
-        wget -O- https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64 > /tmp/bin/minikube
-        echo "5d423a00a24fdfbb95627a3fadbf58540fc4463be2338619257c529f93cf061b  /tmp/bin/minikube" | sha256sum -c -
+        wget -O- https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 > /tmp/bin/minikube
         chmod +x /tmp/bin/minikube
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -41,8 +41,7 @@ jobs:
           mkdir /tmp/bin
           export PATH=/tmp/bin:$PATH
 
-          wget -O- https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64 > /tmp/bin/minikube
-          echo "5d423a00a24fdfbb95627a3fadbf58540fc4463be2338619257c529f93cf061b  /tmp/bin/minikube" | sha256sum -c -
+          wget -O- https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64 > /tmp/bin/minikube
           chmod +x /tmp/bin/minikube
           minikube start --driver=docker
           eval $(minikube docker-env --shell=bash)


### PR DESCRIPTION
#### What this PR does / why we need it:
Switch to floating our minikube version dependency in our GitHub Actions.

#### Which issue(s) this PR fixes:

Fixes #352

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
I'm not concerned about the checksum since this isn't producing a release artifact and so couldn't a MiTM attack wouldn't be of much use other than messing up our test suite.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

