### PR TITLE
Fix trivy slack channel

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          channel-id: C02MTA7F2G1
+          channel-id: G01FTP43JMQ
           slack-message: "${{ env.SUMMARY }}"
       - name: Send Failure notification
         if: failure()


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the Slack channel to which Trivy notifications are sent for the latest release

cc @neil-hickey 