### PR TITLE
Add descriptions to all CRD fields

### DIFF
--- a/config/crds.yml
+++ b/config/crds.yml
@@ -26,16 +26,21 @@ spec:
           spec:
             properties:
               categories:
+                description: Classifiers of the package (optional; Array of strings)
                 items:
                   type: string
                 type: array
               displayName:
+                description: Human friendly name of the package (optional; string)
                 type: string
               iconSVGBase64:
+                description: Base64 encoded icon (optional; string)
                 type: string
               longDescription:
+                description: Long description of the package (optional; string)
                 type: string
               maintainers:
+                description: List of maintainer info for the package. Currently only supports the name key. (optional; array of maintner info)
                 items:
                   properties:
                     name:
@@ -43,10 +48,13 @@ spec:
                   type: object
                 type: array
               providerName:
+                description: Name of the entity distributing the package (optional; string)
                 type: string
               shortDescription:
+                description: Short desription of the package (optional; string)
                 type: string
               supportDescription:
+                description: Description of the support available for the package (optional; string)
                 type: string
             type: object
         required:
@@ -85,16 +93,21 @@ spec:
           spec:
             properties:
               capacityRequirementsDescription:
+                description: 'System requirements needed to install the package. Note: these requirements will not be verified by kapp-controller on installation. (optional; string)'
                 type: string
               licenses:
+                description: Description of the licenses that apply to the package software (optional; Array of strings)
                 items:
                   type: string
                 type: array
               refName:
+                description: The name of the PackageMetadata associated with this version Must be a valid PackageMetadata name (see PackageMetadata CR for details) Cannot be empty
                 type: string
               releaseNotes:
+                description: Version release notes (optional; string)
                 type: string
               releasedAt:
+                description: Timestamp of release (iso8601 formatted string; optional)
                 format: date-time
                 nullable: true
                 type: string
@@ -103,46 +116,59 @@ spec:
                   spec:
                     properties:
                       canceled:
-                        description: Canceled when set to true will stop all active changes
+                        description: Cancels current and future reconciliations (optional; default=false)
                         type: boolean
                       cluster:
+                        description: Specifies that app should be deployed to destination cluster; by default, cluster is same as where this resource resides (optional; v0.5.0+)
                         properties:
                           kubeconfigSecretRef:
+                            description: Specifies secret containing kubeconfig (required)
                             properties:
                               key:
+                                description: Specifies key that contains kubeconfig (optional)
                                 type: string
                               name:
+                                description: Specifies secret name within app's namespace (required)
                                 type: string
                             type: object
                           namespace:
+                            description: Specifies namespace in destination cluster (optional)
                             type: string
                         type: object
                       deploy:
                         items:
                           properties:
                             kapp:
+                              description: Use kapp to deploy resources
                               properties:
                                 delete:
+                                  description: Configuration for delete command (optional)
                                   properties:
                                     rawOptions:
+                                      description: Pass through options to kapp delete (optional)
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 inspect:
+                                  description: 'Configuration for inspect command (optional) as of kapp-controller v0.31.0, inspect is disabled by default add rawOptions or use an empty inspect config like `inspect: {}` to enable'
                                   properties:
                                     rawOptions:
+                                      description: Pass through options to kapp inspect (optional)
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 intoNs:
+                                  description: Override namespace for all resources (optional)
                                   type: string
                                 mapNs:
+                                  description: Provide custom namespace override mapping (optional)
                                   items:
                                     type: string
                                   type: array
                                 rawOptions:
+                                  description: Pass through options to kapp deploy (optional)
                                   items:
                                     type: string
                                   type: array
@@ -153,12 +179,16 @@ spec:
                         items:
                           properties:
                             git:
+                              description: Uses git to clone repository
                               properties:
                                 lfsSkipSmudge:
+                                  description: Skip lfs download (optional)
                                   type: boolean
                                 ref:
+                                  description: Branch, tag, commit; origin is the name of the remote (optional)
                                   type: string
                                 refSelection:
+                                  description: Specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
                                   properties:
                                     semver:
                                       properties:
@@ -174,18 +204,21 @@ spec:
                                       type: object
                                   type: object
                                 secretRef:
-                                  description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                                  description: 'Secret with auth details. allowed keys: ssh-privatekey, ssh-knownhosts, username, password (optional) (if ssh-knownhosts is not specified, git will not perform strict host checking)'
                                   properties:
                                     name:
                                       description: Object is expected to be within same namespace
                                       type: string
                                   type: object
                                 subPath:
+                                  description: Grab only portion of repository (optional)
                                   type: string
                                 url:
+                                  description: http or ssh urls are supported (required)
                                   type: string
                               type: object
                             helmChart:
+                              description: Uses helm fetch to fetch specified chart
                               properties:
                                 name:
                                   description: 'Example: stable/redis'
@@ -199,40 +232,47 @@ spec:
                                           type: string
                                       type: object
                                     url:
+                                      description: Repository url; scheme of oci:// will fetch experimental helm oci chart (v0.19.0+) (required)
                                       type: string
                                   type: object
                                 version:
                                   type: string
                               type: object
                             http:
+                              description: Uses http library to fetch file
                               properties:
                                 secretRef:
-                                  description: 'Secret may include one or more keys: username, password'
+                                  description: 'Secret to provide auth details (optional) Secret may include one or more keys: username, password'
                                   properties:
                                     name:
                                       description: Object is expected to be within same namespace
                                       type: string
                                   type: object
                                 sha256:
+                                  description: Checksum to verify after download (optional)
                                   type: string
                                 subPath:
+                                  description: Grab only portion of download (optional)
                                   type: string
                                 url:
-                                  description: 'URL can point to one of following formats: text, tgz, zip'
+                                  description: 'URL can point to one of following formats: text, tgz, zip http and https url are supported; plain file, tgz and tar types are supported (required)'
                                   type: string
                               type: object
                             image:
+                              description: Pulls content from Docker/OCI registry
                               properties:
                                 secretRef:
-                                  description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                  description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication.'
                                   properties:
                                     name:
                                       description: Object is expected to be within same namespace
                                       type: string
                                   type: object
                                 subPath:
+                                  description: Grab only portion of image (optional)
                                   type: string
                                 tagSelection:
+                                  description: Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key
                                   properties:
                                     semver:
                                       properties:
@@ -248,21 +288,24 @@ spec:
                                       type: object
                                   type: object
                                 url:
-                                  description: 'Example: username/app1-config:v0.1.0'
+                                  description: 'Docker image url; unqualified, tagged, or digest references supported (required) Example: username/app1-config:v0.1.0'
                                   type: string
                               type: object
                             imgpkgBundle:
+                              description: Pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
                               properties:
                                 image:
+                                  description: Docker image url; unqualified, tagged, or digest references supported (required)
                                   type: string
                                 secretRef:
-                                  description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                  description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication.'
                                   properties:
                                     name:
                                       description: Object is expected to be within same namespace
                                       type: string
                                   type: object
                                 tagSelection:
+                                  description: Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key
                                   properties:
                                     semver:
                                       properties:
@@ -279,17 +322,21 @@ spec:
                                   type: object
                               type: object
                             inline:
+                              description: Pulls content from within this resource; or other resources in the cluster
                               properties:
                                 paths:
                                   additionalProperties:
                                     type: string
+                                  description: Specifies mapping of paths to their content; not recommended for sensitive values as CR is not encrypted (optional)
                                   type: object
                                 pathsFrom:
+                                  description: Specifies content via secrets and config maps; data values are recommended to be placed in secrets (optional)
                                   items:
                                     properties:
                                       configMapRef:
                                         properties:
                                           directoryPath:
+                                            description: Specifies where to place files found in secret (optional)
                                             type: string
                                           name:
                                             type: string
@@ -297,6 +344,7 @@ spec:
                                       secretRef:
                                         properties:
                                           directoryPath:
+                                            description: Specifies where to place files found in secret (optional)
                                             type: string
                                           name:
                                             type: string
@@ -307,28 +355,34 @@ spec:
                           type: object
                         type: array
                       noopDelete:
-                        description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                        description: Deletion requests for the App will result in the App CR being deleted, but its associated resources will not be deleted (optional; default=false; v0.18.0+)
                         type: boolean
                       paused:
-                        description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                        description: Pauses _future_ reconcilation; does _not_ affect currently running reconciliation (optional; default=false)
                         type: boolean
                       serviceAccountName:
+                        description: Specifies that app should be deployed authenticated via given service account, found in this namespace (optional; v0.6.0+)
                         type: string
                       syncPeriod:
-                        description: Controls frequency of app reconciliation
+                        description: Specifies the length of time to wait, in time + unit format, before reconciling. Always >= 30s. If value below 30s is specified, 30s will be used. (optional; v0.9.0+; default=30s)
                         type: string
                       template:
                         items:
                           properties:
                             helmTemplate:
+                              description: Use helm template command to render helm chart
                               properties:
                                 name:
+                                  description: Set name explicitly, default is App CR's name (optional; v0.13.0+)
                                   type: string
                                 namespace:
+                                  description: Set namespace explicitly, default is App CR's namespace (optional; v0.13.0+)
                                   type: string
                                 path:
+                                  description: Path to chart (optional; v0.13.0+)
                                   type: string
                                 valuesFrom:
+                                  description: One or more secrets, config maps, paths that provide values (optional)
                                   items:
                                     properties:
                                       configMapRef:
@@ -350,6 +404,7 @@ spec:
                               description: TODO implement jsonnet
                               type: object
                             kbld:
+                              description: Use kbld to resolve image references to use digests
                               properties:
                                 paths:
                                   items:
@@ -360,22 +415,27 @@ spec:
                               description: TODO implement kustomize
                               type: object
                             sops:
+                              description: Use sops to decrypt *.sops.yml files (optional; v0.11.0+)
                               properties:
                                 age:
                                   properties:
                                     privateKeysSecretRef:
+                                      description: Secret with private armored PGP private keys (required)
                                       properties:
                                         name:
                                           type: string
                                       type: object
                                   type: object
                                 paths:
+                                  description: Lists paths to decrypt explicitly (optional; v0.13.0+)
                                   items:
                                     type: string
                                   type: array
                                 pgp:
+                                  description: Use PGP to decrypt files (required)
                                   properties:
                                     privateKeysSecretRef:
+                                      description: Secret with private armored PGP private keys (required)
                                       properties:
                                         name:
                                           type: string
@@ -383,25 +443,32 @@ spec:
                                   type: object
                               type: object
                             ytt:
+                              description: Use ytt to template configuration
                               properties:
                                 fileMarks:
+                                  description: Control metadata about input files passed to ytt (optional; v0.18.0+) see https://carvel.dev/ytt/docs/latest/file-marks/ for more details
                                   items:
                                     type: string
                                   type: array
                                 ignoreUnknownComments:
+                                  description: Ignores comments that ytt doesn't recognize (optional; default=false)
                                   type: boolean
                                 inline:
+                                  description: Specify additional files, including data values (optional)
                                   properties:
                                     paths:
                                       additionalProperties:
                                         type: string
+                                      description: Specifies mapping of paths to their content; not recommended for sensitive values as CR is not encrypted (optional)
                                       type: object
                                     pathsFrom:
+                                      description: Specifies content via secrets and config maps; data values are recommended to be placed in secrets (optional)
                                       items:
                                         properties:
                                           configMapRef:
                                             properties:
                                               directoryPath:
+                                                description: Specifies where to place files found in secret (optional)
                                                 type: string
                                               name:
                                                 type: string
@@ -409,6 +476,7 @@ spec:
                                           secretRef:
                                             properties:
                                               directoryPath:
+                                                description: Specifies where to place files found in secret (optional)
                                                 type: string
                                               name:
                                                 type: string
@@ -417,12 +485,15 @@ spec:
                                       type: array
                                   type: object
                                 paths:
+                                  description: Lists paths to provide to ytt explicitly (optional)
                                   items:
                                     type: string
                                   type: array
                                 strict:
+                                  description: Forces strict mode https://github.com/k14s/ytt/blob/develop/docs/strict.md (optional; default=false)
                                   type: boolean
                                 valuesFrom:
+                                  description: Provide values via ytt's --data-values-file (optional; v0.19.0-alpha.9)
                                   items:
                                     properties:
                                       configMapRef:
@@ -455,6 +526,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               version:
+                description: Package version; Referenced by PackageInstall; Must be valid semver (required) Cannot be empty
                 type: string
             type: object
         required:
@@ -497,6 +569,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: 'An App is a set of Kubernetes resources. These resources could span any number of namespaces or could be cluster-wide (e.g. CRDs). An App is represented in kapp-controller using a App CR. The App CR comprises of three main sections: spec.fetch – declare source for fetching configuration and OCI images spec.template – declare templating tool and values spec.deploy – declare deployment tool and any deploy specific configuration'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -509,46 +582,59 @@ spec:
           spec:
             properties:
               canceled:
-                description: Canceled when set to true will stop all active changes
+                description: Cancels current and future reconciliations (optional; default=false)
                 type: boolean
               cluster:
+                description: Specifies that app should be deployed to destination cluster; by default, cluster is same as where this resource resides (optional; v0.5.0+)
                 properties:
                   kubeconfigSecretRef:
+                    description: Specifies secret containing kubeconfig (required)
                     properties:
                       key:
+                        description: Specifies key that contains kubeconfig (optional)
                         type: string
                       name:
+                        description: Specifies secret name within app's namespace (required)
                         type: string
                     type: object
                   namespace:
+                    description: Specifies namespace in destination cluster (optional)
                     type: string
                 type: object
               deploy:
                 items:
                   properties:
                     kapp:
+                      description: Use kapp to deploy resources
                       properties:
                         delete:
+                          description: Configuration for delete command (optional)
                           properties:
                             rawOptions:
+                              description: Pass through options to kapp delete (optional)
                               items:
                                 type: string
                               type: array
                           type: object
                         inspect:
+                          description: 'Configuration for inspect command (optional) as of kapp-controller v0.31.0, inspect is disabled by default add rawOptions or use an empty inspect config like `inspect: {}` to enable'
                           properties:
                             rawOptions:
+                              description: Pass through options to kapp inspect (optional)
                               items:
                                 type: string
                               type: array
                           type: object
                         intoNs:
+                          description: Override namespace for all resources (optional)
                           type: string
                         mapNs:
+                          description: Provide custom namespace override mapping (optional)
                           items:
                             type: string
                           type: array
                         rawOptions:
+                          description: Pass through options to kapp deploy (optional)
                           items:
                             type: string
                           type: array
@@ -559,12 +645,16 @@ spec:
                 items:
                   properties:
                     git:
+                      description: Uses git to clone repository
                       properties:
                         lfsSkipSmudge:
+                          description: Skip lfs download (optional)
                           type: boolean
                         ref:
+                          description: Branch, tag, commit; origin is the name of the remote (optional)
                           type: string
                         refSelection:
+                          description: Specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
                           properties:
                             semver:
                               properties:
@@ -580,18 +670,21 @@ spec:
                               type: object
                           type: object
                         secretRef:
-                          description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                          description: 'Secret with auth details. allowed keys: ssh-privatekey, ssh-knownhosts, username, password (optional) (if ssh-knownhosts is not specified, git will not perform strict host checking)'
                           properties:
                             name:
                               description: Object is expected to be within same namespace
                               type: string
                           type: object
                         subPath:
+                          description: Grab only portion of repository (optional)
                           type: string
                         url:
+                          description: http or ssh urls are supported (required)
                           type: string
                       type: object
                     helmChart:
+                      description: Uses helm fetch to fetch specified chart
                       properties:
                         name:
                           description: 'Example: stable/redis'
@@ -605,40 +698,47 @@ spec:
                                   type: string
                               type: object
                             url:
+                              description: Repository url; scheme of oci:// will fetch experimental helm oci chart (v0.19.0+) (required)
                               type: string
                           type: object
                         version:
                           type: string
                       type: object
                     http:
+                      description: Uses http library to fetch file
                       properties:
                         secretRef:
-                          description: 'Secret may include one or more keys: username, password'
+                          description: 'Secret to provide auth details (optional) Secret may include one or more keys: username, password'
                           properties:
                             name:
                               description: Object is expected to be within same namespace
                               type: string
                           type: object
                         sha256:
+                          description: Checksum to verify after download (optional)
                           type: string
                         subPath:
+                          description: Grab only portion of download (optional)
                           type: string
                         url:
-                          description: 'URL can point to one of following formats: text, tgz, zip'
+                          description: 'URL can point to one of following formats: text, tgz, zip http and https url are supported; plain file, tgz and tar types are supported (required)'
                           type: string
                       type: object
                     image:
+                      description: Pulls content from Docker/OCI registry
                       properties:
                         secretRef:
-                          description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                          description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication.'
                           properties:
                             name:
                               description: Object is expected to be within same namespace
                               type: string
                           type: object
                         subPath:
+                          description: Grab only portion of image (optional)
                           type: string
                         tagSelection:
+                          description: Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key
                           properties:
                             semver:
                               properties:
@@ -654,21 +754,24 @@ spec:
                               type: object
                           type: object
                         url:
-                          description: 'Example: username/app1-config:v0.1.0'
+                          description: 'Docker image url; unqualified, tagged, or digest references supported (required) Example: username/app1-config:v0.1.0'
                           type: string
                       type: object
                     imgpkgBundle:
+                      description: Pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
                       properties:
                         image:
+                          description: Docker image url; unqualified, tagged, or digest references supported (required)
                           type: string
                         secretRef:
-                          description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                          description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication.'
                           properties:
                             name:
                               description: Object is expected to be within same namespace
                               type: string
                           type: object
                         tagSelection:
+                          description: Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key
                           properties:
                             semver:
                               properties:
@@ -685,17 +788,21 @@ spec:
                           type: object
                       type: object
                     inline:
+                      description: Pulls content from within this resource; or other resources in the cluster
                       properties:
                         paths:
                           additionalProperties:
                             type: string
+                          description: Specifies mapping of paths to their content; not recommended for sensitive values as CR is not encrypted (optional)
                           type: object
                         pathsFrom:
+                          description: Specifies content via secrets and config maps; data values are recommended to be placed in secrets (optional)
                           items:
                             properties:
                               configMapRef:
                                 properties:
                                   directoryPath:
+                                    description: Specifies where to place files found in secret (optional)
                                     type: string
                                   name:
                                     type: string
@@ -703,6 +810,7 @@ spec:
                               secretRef:
                                 properties:
                                   directoryPath:
+                                    description: Specifies where to place files found in secret (optional)
                                     type: string
                                   name:
                                     type: string
@@ -713,28 +821,34 @@ spec:
                   type: object
                 type: array
               noopDelete:
-                description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                description: Deletion requests for the App will result in the App CR being deleted, but its associated resources will not be deleted (optional; default=false; v0.18.0+)
                 type: boolean
               paused:
-                description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                description: Pauses _future_ reconcilation; does _not_ affect currently running reconciliation (optional; default=false)
                 type: boolean
               serviceAccountName:
+                description: Specifies that app should be deployed authenticated via given service account, found in this namespace (optional; v0.6.0+)
                 type: string
               syncPeriod:
-                description: Controls frequency of app reconciliation
+                description: Specifies the length of time to wait, in time + unit format, before reconciling. Always >= 30s. If value below 30s is specified, 30s will be used. (optional; v0.9.0+; default=30s)
                 type: string
               template:
                 items:
                   properties:
                     helmTemplate:
+                      description: Use helm template command to render helm chart
                       properties:
                         name:
+                          description: Set name explicitly, default is App CR's name (optional; v0.13.0+)
                           type: string
                         namespace:
+                          description: Set namespace explicitly, default is App CR's namespace (optional; v0.13.0+)
                           type: string
                         path:
+                          description: Path to chart (optional; v0.13.0+)
                           type: string
                         valuesFrom:
+                          description: One or more secrets, config maps, paths that provide values (optional)
                           items:
                             properties:
                               configMapRef:
@@ -756,6 +870,7 @@ spec:
                       description: TODO implement jsonnet
                       type: object
                     kbld:
+                      description: Use kbld to resolve image references to use digests
                       properties:
                         paths:
                           items:
@@ -766,22 +881,27 @@ spec:
                       description: TODO implement kustomize
                       type: object
                     sops:
+                      description: Use sops to decrypt *.sops.yml files (optional; v0.11.0+)
                       properties:
                         age:
                           properties:
                             privateKeysSecretRef:
+                              description: Secret with private armored PGP private keys (required)
                               properties:
                                 name:
                                   type: string
                               type: object
                           type: object
                         paths:
+                          description: Lists paths to decrypt explicitly (optional; v0.13.0+)
                           items:
                             type: string
                           type: array
                         pgp:
+                          description: Use PGP to decrypt files (required)
                           properties:
                             privateKeysSecretRef:
+                              description: Secret with private armored PGP private keys (required)
                               properties:
                                 name:
                                   type: string
@@ -789,25 +909,32 @@ spec:
                           type: object
                       type: object
                     ytt:
+                      description: Use ytt to template configuration
                       properties:
                         fileMarks:
+                          description: Control metadata about input files passed to ytt (optional; v0.18.0+) see https://carvel.dev/ytt/docs/latest/file-marks/ for more details
                           items:
                             type: string
                           type: array
                         ignoreUnknownComments:
+                          description: Ignores comments that ytt doesn't recognize (optional; default=false)
                           type: boolean
                         inline:
+                          description: Specify additional files, including data values (optional)
                           properties:
                             paths:
                               additionalProperties:
                                 type: string
+                              description: Specifies mapping of paths to their content; not recommended for sensitive values as CR is not encrypted (optional)
                               type: object
                             pathsFrom:
+                              description: Specifies content via secrets and config maps; data values are recommended to be placed in secrets (optional)
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       directoryPath:
+                                        description: Specifies where to place files found in secret (optional)
                                         type: string
                                       name:
                                         type: string
@@ -815,6 +942,7 @@ spec:
                                   secretRef:
                                     properties:
                                       directoryPath:
+                                        description: Specifies where to place files found in secret (optional)
                                         type: string
                                       name:
                                         type: string
@@ -823,12 +951,15 @@ spec:
                               type: array
                           type: object
                         paths:
+                          description: Lists paths to provide to ytt explicitly (optional)
                           items:
                             type: string
                           type: array
                         strict:
+                          description: Forces strict mode https://github.com/k14s/ytt/blob/develop/docs/strict.md (optional; default=false)
                           type: boolean
                         valuesFrom:
+                          description: Provide values via ytt's --data-values-file (optional; v0.19.0-alpha.9)
                           items:
                             properties:
                               configMapRef:
@@ -929,6 +1060,7 @@ spec:
               managedAppName:
                 type: string
               observedGeneration:
+                description: Populated based on metadata.generation when controller observes a change to the resource; if this value is out of data, other status fields do not reflect latest state
                 format: int64
                 type: integer
               template:
@@ -992,6 +1124,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: A Package Install is an actual installation of a package and its underlying resources on a Kubernetes cluster. It is represented in kapp-controller by a PackageInstall CR. A PackageInstall CR must reference a Package CR.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -1007,21 +1140,27 @@ spec:
                 description: Canceled when set to true will stop all active changes
                 type: boolean
               cluster:
+                description: Specifies that Package should be deployed to destination cluster; by default, cluster is same as where this resource resides (optional)
                 properties:
                   kubeconfigSecretRef:
+                    description: Specifies secret containing kubeconfig (required)
                     properties:
                       key:
+                        description: Specifies key that contains kubeconfig (optional)
                         type: string
                       name:
+                        description: Specifies secret name within app's namespace (required)
                         type: string
                     type: object
                   namespace:
+                    description: Specifies namespace in destination cluster (optional)
                     type: string
                 type: object
               noopDelete:
                 description: When NoopDelete set to true, PackageInstall deletion should delete PackageInstall/App CR but preserve App's associated resources.
                 type: boolean
               packageRef:
+                description: Specifies the name of the package to install (required)
                 properties:
                   refName:
                     type: string
@@ -1042,11 +1181,13 @@ spec:
                 description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
                 type: boolean
               serviceAccountName:
+                description: Specifies service account that will be used to install underlying package contents
                 type: string
               syncPeriod:
                 description: Controls frequency of App reconciliation in time + unit format. Always >= 30s. If value below 30s is specified, 30s will be used.
                 type: string
               values:
+                description: Values to be included in package's templating step (currently only included in the first templating step) (optional)
                 items:
                   properties:
                     secretRef:
@@ -1086,6 +1227,7 @@ spec:
                 description: LastAttemptedVersion specifies what version was last attempted to be installed. It does _not_ indicate it was successfully installed.
                 type: string
               observedGeneration:
+                description: Populated based on metadata.generation when controller observes a change to the resource; if this value is out of data, other status fields do not reflect latest state
                 format: int64
                 type: integer
               usefulErrorMessage:
@@ -1134,6 +1276,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: A package repository is a collection of packages and their metadata. Similar to a maven repository or a rpm repository, adding a package repository to a cluster gives users of that cluster the ability to install any of the packages from that repository.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -1148,12 +1291,16 @@ spec:
               fetch:
                 properties:
                   git:
+                    description: Uses git to clone repository containing package list
                     properties:
                       lfsSkipSmudge:
+                        description: Skip lfs download (optional)
                         type: boolean
                       ref:
+                        description: Branch, tag, commit; origin is the name of the remote (optional)
                         type: string
                       refSelection:
+                        description: Specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
                         properties:
                           semver:
                             properties:
@@ -1169,46 +1316,54 @@ spec:
                             type: object
                         type: object
                       secretRef:
-                        description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                        description: 'Secret with auth details. allowed keys: ssh-privatekey, ssh-knownhosts, username, password (optional) (if ssh-knownhosts is not specified, git will not perform strict host checking)'
                         properties:
                           name:
                             description: Object is expected to be within same namespace
                             type: string
                         type: object
                       subPath:
+                        description: Grab only portion of repository (optional)
                         type: string
                       url:
+                        description: http or ssh urls are supported (required)
                         type: string
                     type: object
                   http:
+                    description: Uses http library to fetch file containing packages
                     properties:
                       secretRef:
-                        description: 'Secret may include one or more keys: username, password'
+                        description: 'Secret to provide auth details (optional) Secret may include one or more keys: username, password'
                         properties:
                           name:
                             description: Object is expected to be within same namespace
                             type: string
                         type: object
                       sha256:
+                        description: Checksum to verify after download (optional)
                         type: string
                       subPath:
+                        description: Grab only portion of download (optional)
                         type: string
                       url:
-                        description: 'URL can point to one of following formats: text, tgz, zip'
+                        description: 'URL can point to one of following formats: text, tgz, zip http and https url are supported; plain file, tgz and tar types are supported (required)'
                         type: string
                     type: object
                   image:
+                    description: Image url; unqualified, tagged, or digest references supported (required)
                     properties:
                       secretRef:
-                        description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                        description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication.'
                         properties:
                           name:
                             description: Object is expected to be within same namespace
                             type: string
                         type: object
                       subPath:
+                        description: Grab only portion of image (optional)
                         type: string
                       tagSelection:
+                        description: Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key
                         properties:
                           semver:
                             properties:
@@ -1224,21 +1379,24 @@ spec:
                             type: object
                         type: object
                       url:
-                        description: 'Example: username/app1-config:v0.1.0'
+                        description: 'Docker image url; unqualified, tagged, or digest references supported (required) Example: username/app1-config:v0.1.0'
                         type: string
                     type: object
                   imgpkgBundle:
+                    description: Pulls imgpkg bundle from Docker/OCI registry
                     properties:
                       image:
+                        description: Docker image url; unqualified, tagged, or digest references supported (required)
                         type: string
                       secretRef:
-                        description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                        description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication.'
                         properties:
                           name:
                             description: Object is expected to be within same namespace
                             type: string
                         type: object
                       tagSelection:
+                        description: Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key
                         properties:
                           semver:
                             properties:
@@ -1255,17 +1413,21 @@ spec:
                         type: object
                     type: object
                   inline:
+                    description: Pull content from within this resource; or other resources in the cluster
                     properties:
                       paths:
                         additionalProperties:
                           type: string
+                        description: Specifies mapping of paths to their content; not recommended for sensitive values as CR is not encrypted (optional)
                         type: object
                       pathsFrom:
+                        description: Specifies content via secrets and config maps; data values are recommended to be placed in secrets (optional)
                         items:
                           properties:
                             configMapRef:
                               properties:
                                 directoryPath:
+                                  description: Specifies where to place files found in secret (optional)
                                   type: string
                                 name:
                                   type: string
@@ -1273,6 +1435,7 @@ spec:
                             secretRef:
                               properties:
                                 directoryPath:
+                                  description: Specifies where to place files found in secret (optional)
                                   type: string
                                 name:
                                   type: string
@@ -1354,6 +1517,7 @@ spec:
               friendlyDescription:
                 type: string
               observedGeneration:
+                description: Populated based on metadata.generation when controller observes a change to the resource; if this value is out of data, other status fields do not reflect latest state
                 format: int64
                 type: integer
               template:

--- a/pkg/apis/kappctrl/v1alpha1/generated.proto
+++ b/pkg/apis/kappctrl/v1alpha1/generated.proto
@@ -15,18 +15,22 @@ option go_package = "v1alpha1";
 
 // +k8s:openapi-gen=true
 message AppCluster {
+  // Specifies namespace in destination cluster (optional)
   // +optional
   optional string namespace = 1;
 
+  // Specifies secret containing kubeconfig (required)
   // +optional
   optional AppClusterKubeconfigSecretRef kubeconfigSecretRef = 2;
 }
 
 // +k8s:openapi-gen=true
 message AppClusterKubeconfigSecretRef {
+  // Specifies secret name within app's namespace (required)
   // +optional
   optional string name = 1;
 
+  // Specifies key that contains kubeconfig (optional)
   // +optional
   optional string key = 2;
 }
@@ -51,64 +55,86 @@ message AppCondition {
 
 // +k8s:openapi-gen=true
 message AppDeploy {
+  // Use kapp to deploy resources
   optional AppDeployKapp kapp = 1;
 }
 
 // +k8s:openapi-gen=true
 message AppDeployKapp {
+  // Override namespace for all resources (optional)
   optional string intoNs = 1;
 
+  // Provide custom namespace override mapping (optional)
   repeated string mapNs = 2;
 
+  // Pass through options to kapp deploy (optional)
   repeated string rawOptions = 3;
 
+  // Configuration for inspect command (optional)
+  // as of kapp-controller v0.31.0, inspect is disabled by default
+  // add rawOptions or use an empty inspect config like `inspect: {}` to enable
   optional AppDeployKappInspect inspect = 4;
 
+  // Configuration for delete command (optional)
   optional AppDeployKappDelete delete = 5;
 }
 
 // +k8s:openapi-gen=true
 message AppDeployKappDelete {
+  // Pass through options to kapp delete (optional)
   repeated string rawOptions = 1;
 }
 
 // +k8s:openapi-gen=true
 message AppDeployKappInspect {
+  // Pass through options to kapp inspect (optional)
   repeated string rawOptions = 1;
 }
 
 // +k8s:openapi-gen=true
 message AppFetch {
+  // Pulls content from within this resource; or other resources in the cluster
   optional AppFetchInline inline = 1;
 
+  // Pulls content from Docker/OCI registry
   optional AppFetchImage image = 2;
 
+  // Uses http library to fetch file
   optional AppFetchHTTP http = 3;
 
+  // Uses git to clone repository
   optional AppFetchGit git = 4;
 
+  // Uses helm fetch to fetch specified chart
   optional AppFetchHelmChart helmChart = 5;
 
+  // Pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
   optional AppFetchImgpkgBundle imgpkgBundle = 6;
 }
 
 // +k8s:openapi-gen=true
 message AppFetchGit {
+  // http or ssh urls are supported (required)
   optional string url = 1;
 
+  // Branch, tag, commit; origin is the name of the remote (optional)
   // +optional
   optional string ref = 2;
 
+  // Specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
   // +optional
   optional github.com.vmware_tanzu.carvel_vendir.pkg.vendir.versions.v1alpha1.VersionSelection refSelection = 6;
 
-  // Secret may include one or more keys: ssh-privatekey, ssh-knownhosts
+  // Secret with auth details. allowed keys: ssh-privatekey, ssh-knownhosts, username, password (optional)
+  // (if ssh-knownhosts is not specified, git will not perform strict host checking)
   // +optional
   optional AppFetchLocalRef secretRef = 3;
 
+  // Grab only portion of repository (optional)
   // +optional
   optional string subPath = 4;
 
+  // Skip lfs download (optional)
   // +optional
   optional bool lfsSkipSmudge = 5;
 }
@@ -116,15 +142,20 @@ message AppFetchGit {
 // +k8s:openapi-gen=true
 message AppFetchHTTP {
   // URL can point to one of following formats: text, tgz, zip
+  // http and https url are supported;
+  // plain file, tgz and tar types are supported (required)
   optional string url = 1;
 
+  // Checksum to verify after download (optional)
   // +optional
   optional string sha256 = 2;
 
+  // Secret to provide auth details (optional)
   // Secret may include one or more keys: username, password
   // +optional
   optional AppFetchLocalRef secretRef = 3;
 
+  // Grab only portion of download (optional)
   // +optional
   optional string subPath = 4;
 }
@@ -140,8 +171,10 @@ message AppFetchHelmChart {
   optional AppFetchHelmChartRepo repository = 3;
 }
 
-// +k8s:openapi-gen=true
 message AppFetchHelmChartRepo {
+  // Repository url;
+  // scheme of oci:// will fetch experimental helm oci chart (v0.19.0+)
+  // (required)
   optional string url = 1;
 
   // +optional
@@ -150,40 +183,51 @@ message AppFetchHelmChartRepo {
 
 // +k8s:openapi-gen=true
 message AppFetchImage {
+  // Docker image url; unqualified, tagged, or
+  // digest references supported (required)
   // Example: username/app1-config:v0.1.0
   optional string url = 1;
 
+  // Specifies a strategy to choose a tag (optional; v0.24.0+)
+  // if specified, do not include a tag in url key
   // +optional
   optional github.com.vmware_tanzu.carvel_vendir.pkg.vendir.versions.v1alpha1.VersionSelection tagSelection = 4;
 
   // Secret may include one or more keys: username, password, token.
   // By default anonymous access is used for authentication.
-  // TODO support docker config formated secret
   // +optional
   optional AppFetchLocalRef secretRef = 2;
 
+  // Grab only portion of image (optional)
   // +optional
   optional string subPath = 3;
 }
 
 // +k8s:openapi-gen=true
 message AppFetchImgpkgBundle {
+  // Docker image url; unqualified, tagged, or
+  // digest references supported (required)
   optional string image = 1;
 
+  // Specifies a strategy to choose a tag (optional; v0.24.0+)
+  // if specified, do not include a tag in url key
   // +optional
   optional github.com.vmware_tanzu.carvel_vendir.pkg.vendir.versions.v1alpha1.VersionSelection tagSelection = 3;
 
   // Secret may include one or more keys: username, password, token.
   // By default anonymous access is used for authentication.
-  // TODO support docker config formated secret
   // +optional
   optional AppFetchLocalRef secretRef = 2;
 }
 
 // +k8s:openapi-gen=true
 message AppFetchInline {
+  // Specifies mapping of paths to their content;
+  // not recommended for sensitive values as CR is not encrypted (optional)
   map<string, string> paths = 1;
 
+  // Specifies content via secrets and config maps;
+  // data values are recommended to be placed in secrets (optional)
   repeated AppFetchInlineSource pathsFrom = 2;
 }
 
@@ -196,6 +240,7 @@ message AppFetchInlineSource {
 
 // +k8s:openapi-gen=true
 message AppFetchInlineSourceRef {
+  // Specifies where to place files found in secret (optional)
   optional string directoryPath = 2;
 
   optional string name = 1;
@@ -209,9 +254,13 @@ message AppFetchLocalRef {
 
 // +k8s:openapi-gen=true
 message AppSpec {
+  // Specifies that app should be deployed authenticated via
+  // given service account, found in this namespace (optional; v0.6.0+)
   // +optional
   optional string serviceAccountName = 1;
 
+  // Specifies that app should be deployed to destination cluster;
+  // by default, cluster is same as where this resource resides (optional; v0.5.0+)
   // +optional
   optional AppCluster cluster = 2;
 
@@ -224,48 +273,59 @@ message AppSpec {
   // +optional
   repeated AppDeploy deploy = 5;
 
-  // Paused when set to true will ignore all pending changes,
-  // once it set back to false, pending changes will be applied
+  // Pauses _future_ reconcilation; does _not_ affect
+  // currently running reconciliation (optional; default=false)
   // +optional
   optional bool paused = 6;
 
-  // Canceled when set to true will stop all active changes
+  // Cancels current and future reconciliations (optional; default=false)
   // +optional
   optional bool canceled = 7;
 
-  // Controls frequency of app reconciliation
+  // Specifies the length of time to wait, in time + unit
+  // format, before reconciling. Always >= 30s. If value below
+  // 30s is specified, 30s will be used. (optional; v0.9.0+; default=30s)
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration syncPeriod = 8;
 
-  // When NoopDeletion set to true, App deletion should
-  // delete App CR but preserve App's associated resources
+  // Deletion requests for the App will result in the App CR being
+  // deleted, but its associated resources will not be deleted
+  // (optional; default=false; v0.18.0+)
   // +optional
   optional bool noopDelete = 9;
 }
 
 // +k8s:openapi-gen=true
 message AppTemplate {
+  // Use ytt to template configuration
   optional AppTemplateYtt ytt = 1;
 
+  // Use kbld to resolve image references to use digests
   optional AppTemplateKbld kbld = 2;
 
+  // Use helm template command to render helm chart
   optional AppTemplateHelmTemplate helmTemplate = 3;
 
   optional AppTemplateKustomize kustomize = 4;
 
   optional AppTemplateJsonnet jsonnet = 5;
 
+  // Use sops to decrypt *.sops.yml files (optional; v0.11.0+)
   optional AppTemplateSops sops = 6;
 }
 
 // +k8s:openapi-gen=true
 message AppTemplateHelmTemplate {
+  // Set name explicitly, default is App CR's name (optional; v0.13.0+)
   optional string name = 1;
 
+  // Set namespace explicitly, default is App CR's namespace (optional; v0.13.0+)
   optional string namespace = 2;
 
+  // Path to chart (optional; v0.13.0+)
   optional string path = 3;
 
+  // One or more secrets, config maps, paths that provide values (optional)
   repeated AppTemplateValuesSource valuesFrom = 4;
 }
 
@@ -286,8 +346,10 @@ message AppTemplateKustomize {
 
 // +k8s:openapi-gen=true
 message AppTemplateSops {
+  // Use PGP to decrypt files (required)
   optional AppTemplateSopsPGP pgp = 1;
 
+  // Lists paths to decrypt explicitly (optional; v0.13.0+)
   repeated string paths = 2;
 
   optional AppTemplateSopsAge age = 3;
@@ -295,11 +357,13 @@ message AppTemplateSops {
 
 // +k8s:openapi-gen=true
 message AppTemplateSopsAge {
+  // Secret with private armored PGP private keys (required)
   optional AppTemplateSopsPrivateKeysSecretRef privateKeysSecretRef = 1;
 }
 
 // +k8s:openapi-gen=true
 message AppTemplateSopsPGP {
+  // Secret with private armored PGP private keys (required)
   optional AppTemplateSopsPrivateKeysSecretRef privateKeysSecretRef = 1;
 }
 
@@ -324,20 +388,32 @@ message AppTemplateValuesSourceRef {
 
 // +k8s:openapi-gen=true
 message AppTemplateYtt {
+  // Ignores comments that ytt doesn't recognize
+  // (optional; default=false)
   optional bool ignoreUnknownComments = 1;
 
+  // Forces strict mode https://github.com/k14s/ytt/blob/develop/docs/strict.md
+  // (optional; default=false)
   optional bool strict = 2;
 
+  // Specify additional files, including data values (optional)
   optional AppFetchInline inline = 3;
 
+  // Lists paths to provide to ytt explicitly (optional)
   repeated string paths = 4;
 
+  // Control metadata about input files passed to ytt (optional; v0.18.0+)
+  // see https://carvel.dev/ytt/docs/latest/file-marks/ for more details
   repeated string fileMarks = 5;
 
+  // Provide values via ytt's --data-values-file (optional; v0.19.0-alpha.9)
   repeated AppTemplateValuesSource valuesFrom = 6;
 }
 
 message GenericStatus {
+  // Populated based on metadata.generation when controller
+  // observes a change to the resource; if this value is
+  // out of data, other status fields do not reflect latest state
   // +optional
   optional int64 observedGeneration = 1;
 

--- a/pkg/apis/kappctrl/v1alpha1/generated.proto
+++ b/pkg/apis/kappctrl/v1alpha1/generated.proto
@@ -171,6 +171,7 @@ message AppFetchHelmChart {
   optional AppFetchHelmChartRepo repository = 3;
 }
 
+// +k8s:openapi-gen=true
 message AppFetchHelmChartRepo {
   // Repository url;
   // scheme of oci:// will fetch experimental helm oci chart (v0.19.0+)

--- a/pkg/apis/kappctrl/v1alpha1/status.go
+++ b/pkg/apis/kappctrl/v1alpha1/status.go
@@ -24,8 +24,6 @@ type GenericStatus struct {
 type AppConditionType string
 
 const (
-	// "Reconciling" indicates that fetch/template/deploy is happening;
-	// it does not mean that any resource has changed
 	Reconciling        AppConditionType = "Reconciling"
 	ReconcileFailed    AppConditionType = "ReconcileFailed"
 	ReconcileSucceeded AppConditionType = "ReconcileSucceeded"

--- a/pkg/apis/kappctrl/v1alpha1/status.go
+++ b/pkg/apis/kappctrl/v1alpha1/status.go
@@ -8,6 +8,9 @@ import (
 )
 
 type GenericStatus struct {
+	// Populated based on metadata.generation when controller
+	// observes a change to the resource; if this value is
+	// out of data, other status fields do not reflect latest state
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration" protobuf:"varint,1,opt,name=observedGeneration"`
 	// +optional
@@ -21,6 +24,8 @@ type GenericStatus struct {
 type AppConditionType string
 
 const (
+	// "Reconciling" indicates that fetch/template/deploy is happening;
+	// it does not mean that any resource has changed
 	Reconciling        AppConditionType = "Reconciling"
 	ReconcileFailed    AppConditionType = "ReconcileFailed"
 	ReconcileSucceeded AppConditionType = "ReconcileSucceeded"

--- a/pkg/apis/kappctrl/v1alpha1/types.go
+++ b/pkg/apis/kappctrl/v1alpha1/types.go
@@ -15,6 +15,11 @@ import (
 // +kubebuilder:printcolumn:name=Since-Deploy,JSONPath=.status.deploy.startedAt,description=Last time app started being deployed. Does not mean anything was changed.,type=date
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
 // +protobuf=false
+// An App is a set of Kubernetes resources. These resources could span any number of namespaces or could be cluster-wide (e.g. CRDs). An App is represented in kapp-controller using a App CR.
+// The App CR comprises of three main sections:
+// spec.fetch – declare source for fetching configuration and OCI images
+// spec.template – declare templating tool and values
+// spec.deploy – declare deployment tool and any deploy specific configuration
 type App struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
@@ -40,8 +45,12 @@ type AppList struct {
 
 // +k8s:openapi-gen=true
 type AppSpec struct {
+	// Specifies that app should be deployed authenticated via
+	// given service account, found in this namespace (optional; v0.6.0+)
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty" protobuf:"bytes,1,opt,name=serviceAccountName"`
+	// Specifies that app should be deployed to destination cluster;
+	// by default, cluster is same as where this resource resides (optional; v0.5.0+)
 	// +optional
 	Cluster *AppCluster `json:"cluster,omitempty" protobuf:"bytes,2,opt,name=cluster"`
 	// +optional
@@ -50,34 +59,41 @@ type AppSpec struct {
 	Template []AppTemplate `json:"template,omitempty" protobuf:"bytes,4,rep,name=template"`
 	// +optional
 	Deploy []AppDeploy `json:"deploy,omitempty" protobuf:"bytes,5,rep,name=deploy"`
-	// Paused when set to true will ignore all pending changes,
-	// once it set back to false, pending changes will be applied
+	// Pauses _future_ reconcilation; does _not_ affect
+	// currently running reconciliation (optional; default=false)
 	// +optional
 	Paused bool `json:"paused,omitempty" protobuf:"varint,6,opt,name=paused"`
-	// Canceled when set to true will stop all active changes
+	// Cancels current and future reconciliations (optional; default=false)
 	// +optional
 	Canceled bool `json:"canceled,omitempty" protobuf:"varint,7,opt,name=canceled"`
-	// Controls frequency of app reconciliation
+	// Specifies the length of time to wait, in time + unit
+	// format, before reconciling. Always >= 30s. If value below
+	// 30s is specified, 30s will be used. (optional; v0.9.0+; default=30s)
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty" protobuf:"bytes,8,opt,name=syncPeriod"`
-	// When NoopDeletion set to true, App deletion should
-	// delete App CR but preserve App's associated resources
+	// Deletion requests for the App will result in the App CR being
+	// deleted, but its associated resources will not be deleted
+	// (optional; default=false; v0.18.0+)
 	// +optional
 	NoopDelete bool `json:"noopDelete,omitempty" protobuf:"varint,9,opt,name=noopDelete"`
 }
 
 // +k8s:openapi-gen=true
 type AppCluster struct {
+	// Specifies namespace in destination cluster (optional)
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
+	// Specifies secret containing kubeconfig (required)
 	// +optional
 	KubeconfigSecretRef *AppClusterKubeconfigSecretRef `json:"kubeconfigSecretRef,omitempty" protobuf:"bytes,2,opt,name=kubeconfigSecretRef"`
 }
 
 // +k8s:openapi-gen=true
 type AppClusterKubeconfigSecretRef struct {
+	// Specifies secret name within app's namespace (required)
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	// Specifies key that contains kubeconfig (optional)
 	// +optional
 	Key string `json:"key,omitempty" protobuf:"bytes,2,opt,name=key"`
 }

--- a/pkg/apis/kappctrl/v1alpha1/types_deploy.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_deploy.go
@@ -5,25 +5,35 @@ package v1alpha1
 
 // +k8s:openapi-gen=true
 type AppDeploy struct {
+	// Use kapp to deploy resources
 	Kapp *AppDeployKapp `json:"kapp,omitempty" protobuf:"bytes,1,opt,name=kapp"`
 }
 
 // +k8s:openapi-gen=true
 type AppDeployKapp struct {
-	IntoNs     string   `json:"intoNs,omitempty" protobuf:"bytes,1,opt,name=intoNs"`
-	MapNs      []string `json:"mapNs,omitempty" protobuf:"bytes,2,rep,name=mapNs"`
+	// Override namespace for all resources (optional)
+	IntoNs string `json:"intoNs,omitempty" protobuf:"bytes,1,opt,name=intoNs"`
+	// Provide custom namespace override mapping (optional)
+	MapNs []string `json:"mapNs,omitempty" protobuf:"bytes,2,rep,name=mapNs"`
+	// Pass through options to kapp deploy (optional)
 	RawOptions []string `json:"rawOptions,omitempty" protobuf:"bytes,3,rep,name=rawOptions"`
 
+	// Configuration for inspect command (optional)
+	// as of kapp-controller v0.31.0, inspect is disabled by default
+	// add rawOptions or use an empty inspect config like `inspect: {}` to enable
 	Inspect *AppDeployKappInspect `json:"inspect,omitempty" protobuf:"bytes,4,opt,name=inspect"`
-	Delete  *AppDeployKappDelete  `json:"delete,omitempty" protobuf:"bytes,5,opt,name=delete"`
+	// Configuration for delete command (optional)
+	Delete *AppDeployKappDelete `json:"delete,omitempty" protobuf:"bytes,5,opt,name=delete"`
 }
 
 // +k8s:openapi-gen=true
 type AppDeployKappInspect struct {
+	// Pass through options to kapp inspect (optional)
 	RawOptions []string `json:"rawOptions,omitempty" protobuf:"bytes,1,rep,name=rawOptions"`
 }
 
 // +k8s:openapi-gen=true
 type AppDeployKappDelete struct {
+	// Pass through options to kapp delete (optional)
 	RawOptions []string `json:"rawOptions,omitempty" protobuf:"bytes,1,rep,name=rawOptions"`
 }

--- a/pkg/apis/kappctrl/v1alpha1/types_fetch.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_fetch.go
@@ -115,7 +115,6 @@ type AppFetchHelmChart struct {
 }
 
 // +k8s:openapi-gen=true
-
 type AppFetchHelmChartRepo struct {
 	// Repository url;
 	// scheme of oci:// will fetch experimental helm oci chart (v0.19.0+)

--- a/pkg/apis/kappctrl/v1alpha1/types_fetch.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_fetch.go
@@ -9,17 +9,27 @@ import (
 
 // +k8s:openapi-gen=true
 type AppFetch struct {
-	Inline       *AppFetchInline       `json:"inline,omitempty" protobuf:"bytes,1,opt,name=inline"`
-	Image        *AppFetchImage        `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
-	HTTP         *AppFetchHTTP         `json:"http,omitempty" protobuf:"bytes,3,opt,name=http"`
-	Git          *AppFetchGit          `json:"git,omitempty" protobuf:"bytes,4,opt,name=git"`
-	HelmChart    *AppFetchHelmChart    `json:"helmChart,omitempty" protobuf:"bytes,5,opt,name=helmChart"`
+	// Pulls content from within this resource; or other resources in the cluster
+	Inline *AppFetchInline `json:"inline,omitempty" protobuf:"bytes,1,opt,name=inline"`
+	// Pulls content from Docker/OCI registry
+	Image *AppFetchImage `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
+	// Uses http library to fetch file
+	HTTP *AppFetchHTTP `json:"http,omitempty" protobuf:"bytes,3,opt,name=http"`
+	// Uses git to clone repository
+	Git *AppFetchGit `json:"git,omitempty" protobuf:"bytes,4,opt,name=git"`
+	// Uses helm fetch to fetch specified chart
+	HelmChart *AppFetchHelmChart `json:"helmChart,omitempty" protobuf:"bytes,5,opt,name=helmChart"`
+	// Pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
 	ImgpkgBundle *AppFetchImgpkgBundle `json:"imgpkgBundle,omitempty" protobuf:"bytes,6,opt,name=imgpkgBundle"`
 }
 
 // +k8s:openapi-gen=true
 type AppFetchInline struct {
-	Paths     map[string]string      `json:"paths,omitempty" protobuf:"bytes,1,rep,name=paths"`
+	// Specifies mapping of paths to their content;
+	// not recommended for sensitive values as CR is not encrypted (optional)
+	Paths map[string]string `json:"paths,omitempty" protobuf:"bytes,1,rep,name=paths"`
+	// Specifies content via secrets and config maps;
+	// data values are recommended to be placed in secrets (optional)
 	PathsFrom []AppFetchInlineSource `json:"pathsFrom,omitempty" protobuf:"bytes,2,rep,name=pathsFrom"`
 }
 
@@ -31,21 +41,26 @@ type AppFetchInlineSource struct {
 
 // +k8s:openapi-gen=true
 type AppFetchInlineSourceRef struct {
+	// Specifies where to place files found in secret (optional)
 	DirectoryPath string `json:"directoryPath,omitempty" protobuf:"bytes,2,opt,name=directoryPath"`
 	Name          string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 }
 
 // +k8s:openapi-gen=true
 type AppFetchImage struct {
+	// Docker image url; unqualified, tagged, or
+	// digest references supported (required)
 	// Example: username/app1-config:v0.1.0
 	URL string `json:"url,omitempty" protobuf:"bytes,1,opt,name=url"`
+	// Specifies a strategy to choose a tag (optional; v0.24.0+)
+	// if specified, do not include a tag in url key
 	// +optional
 	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty" protobuf:"bytes,4,opt,name=tagSelection"`
 	// Secret may include one or more keys: username, password, token.
 	// By default anonymous access is used for authentication.
-	// TODO support docker config formated secret
 	// +optional
 	SecretRef *AppFetchLocalRef `json:"secretRef,omitempty" protobuf:"bytes,2,opt,name=secretRef"`
+	// Grab only portion of image (optional)
 	// +optional
 	SubPath string `json:"subPath,omitempty" protobuf:"bytes,3,opt,name=subPath"`
 }
@@ -53,28 +68,39 @@ type AppFetchImage struct {
 // +k8s:openapi-gen=true
 type AppFetchHTTP struct {
 	// URL can point to one of following formats: text, tgz, zip
+	// http and https url are supported;
+	// plain file, tgz and tar types are supported (required)
 	URL string `json:"url,omitempty" protobuf:"bytes,1,opt,name=url"`
+	// Checksum to verify after download (optional)
 	// +optional
 	SHA256 string `json:"sha256,omitempty" protobuf:"bytes,2,opt,name=sha256"`
+	// Secret to provide auth details (optional)
 	// Secret may include one or more keys: username, password
 	// +optional
 	SecretRef *AppFetchLocalRef `json:"secretRef,omitempty" protobuf:"bytes,3,opt,name=secretRef"`
+	// Grab only portion of download (optional)
 	// +optional
 	SubPath string `json:"subPath,omitempty" protobuf:"bytes,4,opt,name=subPath"`
 }
 
 // +k8s:openapi-gen=true
 type AppFetchGit struct {
+	// http or ssh urls are supported (required)
 	URL string `json:"url,omitempty" protobuf:"bytes,1,opt,name=url"`
+	// Branch, tag, commit; origin is the name of the remote (optional)
 	// +optional
 	Ref string `json:"ref,omitempty" protobuf:"bytes,2,opt,name=ref"`
+	// Specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
 	// +optional
 	RefSelection *versions.VersionSelection `json:"refSelection,omitempty" protobuf:"bytes,6,opt,name=refSelection"`
-	// Secret may include one or more keys: ssh-privatekey, ssh-knownhosts
+	// Secret with auth details. allowed keys: ssh-privatekey, ssh-knownhosts, username, password (optional)
+	// (if ssh-knownhosts is not specified, git will not perform strict host checking)
 	// +optional
 	SecretRef *AppFetchLocalRef `json:"secretRef,omitempty" protobuf:"bytes,3,opt,name=secretRef"`
+	// Grab only portion of repository (optional)
 	// +optional
 	SubPath string `json:"subPath,omitempty" protobuf:"bytes,4,opt,name=subPath"`
+	// Skip lfs download (optional)
 	// +optional
 	LFSSkipSmudge bool `json:"lfsSkipSmudge,omitempty" protobuf:"varint,5,opt,name=lfsSkipSmudge"`
 }
@@ -89,7 +115,11 @@ type AppFetchHelmChart struct {
 }
 
 // +k8s:openapi-gen=true
+
 type AppFetchHelmChartRepo struct {
+	// Repository url;
+	// scheme of oci:// will fetch experimental helm oci chart (v0.19.0+)
+	// (required)
 	URL string `json:"url,omitempty" protobuf:"bytes,1,opt,name=url"`
 	// +optional
 	SecretRef *AppFetchLocalRef `json:"secretRef,omitempty" protobuf:"bytes,2,opt,name=secretRef"`
@@ -103,12 +133,15 @@ type AppFetchLocalRef struct {
 
 // +k8s:openapi-gen=true
 type AppFetchImgpkgBundle struct {
+	// Docker image url; unqualified, tagged, or
+	// digest references supported (required)
 	Image string `json:"image,omitempty" protobuf:"bytes,1,opt,name=image"`
+	// Specifies a strategy to choose a tag (optional; v0.24.0+)
+	// if specified, do not include a tag in url key
 	// +optional
 	TagSelection *versions.VersionSelection `json:"tagSelection,omitempty" protobuf:"bytes,3,opt,name=tagSelection"`
 	// Secret may include one or more keys: username, password, token.
 	// By default anonymous access is used for authentication.
-	// TODO support docker config formated secret
 	// +optional
 	SecretRef *AppFetchLocalRef `json:"secretRef,omitempty" protobuf:"bytes,2,opt,name=secretRef"`
 }

--- a/pkg/apis/kappctrl/v1alpha1/types_template.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_template.go
@@ -6,22 +6,35 @@ package v1alpha1
 
 // +k8s:openapi-gen=true
 type AppTemplate struct {
-	Ytt          *AppTemplateYtt          `json:"ytt,omitempty" protobuf:"bytes,1,opt,name=ytt"`
-	Kbld         *AppTemplateKbld         `json:"kbld,omitempty" protobuf:"bytes,2,opt,name=kbld"`
+	// Use ytt to template configuration
+	Ytt *AppTemplateYtt `json:"ytt,omitempty" protobuf:"bytes,1,opt,name=ytt"`
+	// Use kbld to resolve image references to use digests
+	Kbld *AppTemplateKbld `json:"kbld,omitempty" protobuf:"bytes,2,opt,name=kbld"`
+	// Use helm template command to render helm chart
 	HelmTemplate *AppTemplateHelmTemplate `json:"helmTemplate,omitempty" protobuf:"bytes,3,opt,name=helmTemplate"`
 	Kustomize    *AppTemplateKustomize    `json:"kustomize,omitempty" protobuf:"bytes,4,opt,name=kustomize"`
 	Jsonnet      *AppTemplateJsonnet      `json:"jsonnet,omitempty" protobuf:"bytes,5,opt,name=jsonnet"`
-	Sops         *AppTemplateSops         `json:"sops,omitempty" protobuf:"bytes,6,opt,name=sops"`
+	// Use sops to decrypt *.sops.yml files (optional; v0.11.0+)
+	Sops *AppTemplateSops `json:"sops,omitempty" protobuf:"bytes,6,opt,name=sops"`
 }
 
 // +k8s:openapi-gen=true
 type AppTemplateYtt struct {
-	IgnoreUnknownComments bool                      `json:"ignoreUnknownComments,omitempty" protobuf:"varint,1,opt,name=ignoreUnknownComments"`
-	Strict                bool                      `json:"strict,omitempty" protobuf:"varint,2,opt,name=strict"`
-	Inline                *AppFetchInline           `json:"inline,omitempty" protobuf:"bytes,3,opt,name=inline"`
-	Paths                 []string                  `json:"paths,omitempty" protobuf:"bytes,4,rep,name=paths"`
-	FileMarks             []string                  `json:"fileMarks,omitempty" protobuf:"bytes,5,rep,name=fileMarks"`
-	ValuesFrom            []AppTemplateValuesSource `json:"valuesFrom,omitempty" protobuf:"bytes,6,rep,name=valuesFrom"`
+	// Ignores comments that ytt doesn't recognize
+	// (optional; default=false)
+	IgnoreUnknownComments bool `json:"ignoreUnknownComments,omitempty" protobuf:"varint,1,opt,name=ignoreUnknownComments"`
+	// Forces strict mode https://github.com/k14s/ytt/blob/develop/docs/strict.md
+	// (optional; default=false)
+	Strict bool `json:"strict,omitempty" protobuf:"varint,2,opt,name=strict"`
+	// Specify additional files, including data values (optional)
+	Inline *AppFetchInline `json:"inline,omitempty" protobuf:"bytes,3,opt,name=inline"`
+	// Lists paths to provide to ytt explicitly (optional)
+	Paths []string `json:"paths,omitempty" protobuf:"bytes,4,rep,name=paths"`
+	// Control metadata about input files passed to ytt (optional; v0.18.0+)
+	// see https://carvel.dev/ytt/docs/latest/file-marks/ for more details
+	FileMarks []string `json:"fileMarks,omitempty" protobuf:"bytes,5,rep,name=fileMarks"`
+	// Provide values via ytt's --data-values-file (optional; v0.19.0-alpha.9)
+	ValuesFrom []AppTemplateValuesSource `json:"valuesFrom,omitempty" protobuf:"bytes,6,rep,name=valuesFrom"`
 }
 
 // +k8s:openapi-gen=true
@@ -31,9 +44,13 @@ type AppTemplateKbld struct {
 
 // +k8s:openapi-gen=true
 type AppTemplateHelmTemplate struct {
-	Name       string                    `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	Namespace  string                    `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
-	Path       string                    `json:"path,omitempty" protobuf:"bytes,3,opt,name=path"`
+	// Set name explicitly, default is App CR's name (optional; v0.13.0+)
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	// Set namespace explicitly, default is App CR's namespace (optional; v0.13.0+)
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
+	// Path to chart (optional; v0.13.0+)
+	Path string `json:"path,omitempty" protobuf:"bytes,3,opt,name=path"`
+	// One or more secrets, config maps, paths that provide values (optional)
 	ValuesFrom []AppTemplateValuesSource `json:"valuesFrom,omitempty" protobuf:"bytes,4,rep,name=valuesFrom"`
 }
 
@@ -59,18 +76,22 @@ type AppTemplateJsonnet struct{}
 
 // +k8s:openapi-gen=true
 type AppTemplateSops struct {
-	PGP   *AppTemplateSopsPGP `json:"pgp,omitempty" protobuf:"bytes,1,opt,name=pgp"`
+	// Use PGP to decrypt files (required)
+	PGP *AppTemplateSopsPGP `json:"pgp,omitempty" protobuf:"bytes,1,opt,name=pgp"`
+	// Lists paths to decrypt explicitly (optional; v0.13.0+)
 	Paths []string            `json:"paths,omitempty" protobuf:"bytes,2,rep,name=paths"`
 	Age   *AppTemplateSopsAge `json:"age,omitempty" protobuf:"bytes,3,opt,name=age"`
 }
 
 // +k8s:openapi-gen=true
 type AppTemplateSopsPGP struct {
+	// Secret with private armored PGP private keys (required)
 	PrivateKeysSecretRef *AppTemplateSopsPrivateKeysSecretRef `json:"privateKeysSecretRef,omitempty" protobuf:"bytes,1,opt,name=privateKeysSecretRef"`
 }
 
 // +k8s:openapi-gen=true
 type AppTemplateSopsAge struct {
+	// Secret with private armored PGP private keys (required)
 	PrivateKeysSecretRef *AppTemplateSopsPrivateKeysSecretRef `json:"privateKeysSecretRef,omitempty" protobuf:"bytes,1,opt,name=privateKeysSecretRef"`
 }
 

--- a/pkg/apis/packaging/v1alpha1/package_install.go
+++ b/pkg/apis/packaging/v1alpha1/package_install.go
@@ -17,6 +17,9 @@ import (
 // +kubebuilder:printcolumn:name=Package version,JSONPath=.status.version,description=PackageMetadata version,type=string
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
+// A Package Install is an actual installation of a package and its underlying resources on a Kubernetes cluster.
+// It is represented in kapp-controller by a PackageInstall CR.
+// A PackageInstall CR must reference a Package CR.
 type PackageInstall struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
@@ -41,12 +44,18 @@ type PackageInstallList struct {
 }
 
 type PackageInstallSpec struct {
+	// Specifies service account that will be used to install underlying package contents
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	// Specifies that Package should be deployed to destination cluster;
+	// by default, cluster is same as where this resource resides (optional)
 	// +optional
 	Cluster *v1alpha1.AppCluster `json:"cluster,omitempty"`
+	// Specifies the name of the package to install (required)
 	// +optional
 	PackageRef *PackageRef `json:"packageRef,omitempty"`
+	// Values to be included in package's templating step
+	// (currently only included in the first templating step) (optional)
 	// +optional
 	Values []PackageInstallValues `json:"values,omitempty"`
 	// Paused when set to true will ignore all pending changes,

--- a/pkg/apis/packaging/v1alpha1/package_repository.go
+++ b/pkg/apis/packaging/v1alpha1/package_repository.go
@@ -14,6 +14,8 @@ import (
 // +kubebuilder:resource:shortName=pkgr,categories={all,carvel}
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
+// A package repository is a collection of packages and their metadata.
+// Similar to a maven repository or a rpm repository, adding a package repository to a cluster gives users of that cluster the ability to install any of the packages from that repository.
 type PackageRepository struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
@@ -48,14 +50,20 @@ type PackageRepositorySpec struct {
 }
 
 type PackageRepositoryFetch struct {
+	// Image url; unqualified, tagged, or
+	// digest references supported (required)
 	// +optional
 	Image *v1alpha1.AppFetchImage `json:"image,omitempty"`
+	// Uses http library to fetch file containing packages
 	// +optional
 	HTTP *v1alpha1.AppFetchHTTP `json:"http,omitempty"`
+	// Uses git to clone repository containing package list
 	// +optional
 	Git *v1alpha1.AppFetchGit `json:"git,omitempty"`
+	// Pulls imgpkg bundle from Docker/OCI registry
 	// +optional
 	ImgpkgBundle *v1alpha1.AppFetchImgpkgBundle `json:"imgpkgBundle,omitempty"`
+	// Pull content from within this resource; or other resources in the cluster
 	// +optional
 	Inline *v1alpha1.AppFetchInline `json:"inline,omitempty"`
 }

--- a/pkg/apiserver/apis/datapackaging/types.go
+++ b/pkg/apiserver/apis/datapackaging/types.go
@@ -11,6 +11,8 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// Package Metadata are attributes of a single package that do not change frequently and that are shared across multiple versions of a single package.
+// It contains information similar to a project’s README.md.
 type PackageMetadata struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -23,6 +25,8 @@ type PackageMetadata struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// A package is a combination of configuration metadata and OCI images that informs the package manager what software it holds and how to install itself onto a Kubernetes cluster.
+// For example, an nginx-ingress package would instruct the package manager where to download the nginx container image, how to configure the associated Deployment, and install it into a cluster.
 type Package struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -58,14 +62,27 @@ type PackageMetadataList struct {
 }
 
 type PackageSpec struct {
-	RefName  string   `json:"refName,omitempty"`
-	Version  string   `json:"version,omitempty"`
+	// The name of the PackageMetadata associated with this version
+	// Must be a valid PackageMetadata name (see PackageMetadata CR for details)
+	// Cannot be empty
+	RefName string `json:"refName,omitempty"`
+	// Package version; Referenced by PackageInstall;
+	// Must be valid semver (required)
+	// Cannot be empty
+	Version string `json:"version,omitempty"`
+	// Description of the licenses that apply to the package software
+	// (optional; Array of strings)
 	Licenses []string `json:"licenses,omitempty"`
+	// Timestamp of release (iso8601 formatted string; optional)
 	// +optional
 	// +nullable
-	ReleasedAt                      metav1.Time `json:"releasedAt,omitempty"`
-	CapactiyRequirementsDescription string      `json:"capacityRequirementsDescription,omitempty"`
-	ReleaseNotes                    string      `json:"releaseNotes,omitempty"`
+	ReleasedAt metav1.Time `json:"releasedAt,omitempty"`
+	// System requirements needed to install the package.
+	// Note: these requirements will not be verified by kapp-controller on
+	// installation. (optional; string)
+	CapactiyRequirementsDescription string `json:"capacityRequirementsDescription,omitempty"`
+	// Version release notes (optional; string)
+	ReleaseNotes string `json:"releaseNotes,omitempty"`
 
 	Template AppTemplateSpec `json:"template,omitempty"`
 
@@ -77,14 +94,23 @@ type PackageSpec struct {
 }
 
 type PackageMetadataSpec struct {
-	DisplayName        string       `json:"displayName,omitempty"`
-	LongDescription    string       `json:"longDescription,omitempty"`
-	ShortDescription   string       `json:"shortDescription,omitempty"`
-	IconSVGBase64      string       `json:"iconSVGBase64,omitempty"`
-	ProviderName       string       `json:"providerName,omitempty"`
-	Maintainers        []Maintainer `json:"maintainers,omitempty"`
-	Categories         []string     `json:"categories,omitempty"`
-	SupportDescription string       `json:"supportDescription,omitempty"`
+	// Human friendly name of the package (optional; string)
+	DisplayName string `json:"displayName,omitempty"`
+	// Long description of the package (optional; string)
+	LongDescription string `json:"longDescription,omitempty"`
+	// Short desription of the package (optional; string)
+	ShortDescription string `json:"shortDescription,omitempty"`
+	// Base64 encoded icon (optional; string)
+	IconSVGBase64 string `json:"iconSVGBase64,omitempty"`
+	// Name of the entity distributing the package (optional; string)
+	ProviderName string `json:"providerName,omitempty"`
+	// List of maintainer info for the package.
+	// Currently only supports the name key. (optional; array of maintner info)
+	Maintainers []Maintainer `json:"maintainers,omitempty"`
+	// Classifiers of the package (optional; Array of strings)
+	Categories []string `json:"categories,omitempty"`
+	// Description of the support available for the package (optional; string)
+	SupportDescription string `json:"supportDescription,omitempty"`
 }
 
 type Maintainer struct {

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -27,6 +27,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchGit":                         schema_pkg_apis_kappctrl_v1alpha1_AppFetchGit(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHTTP":                        schema_pkg_apis_kappctrl_v1alpha1_AppFetchHTTP(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChart":                   schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChart(ref),
+		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChartRepo":               schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChartRepo(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImage":                       schema_pkg_apis_kappctrl_v1alpha1_AppFetchImage(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImgpkgBundle":                schema_pkg_apis_kappctrl_v1alpha1_AppFetchImgpkgBundle(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchInline":                      schema_pkg_apis_kappctrl_v1alpha1_AppFetchInline(ref),
@@ -724,6 +725,32 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChart(ref common.ReferenceCal
 		},
 		Dependencies: []string{
 			"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChartRepo"},
+	}
+}
+
+func schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChartRepo(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"url": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Repository url; scheme of oci:// will fetch experimental helm oci chart (v0.19.0+) (required)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchLocalRef"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchLocalRef"},
 	}
 }
 

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -27,7 +27,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchGit":                         schema_pkg_apis_kappctrl_v1alpha1_AppFetchGit(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHTTP":                        schema_pkg_apis_kappctrl_v1alpha1_AppFetchHTTP(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChart":                   schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChart(ref),
-		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChartRepo":               schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChartRepo(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImage":                       schema_pkg_apis_kappctrl_v1alpha1_AppFetchImage(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImgpkgBundle":                schema_pkg_apis_kappctrl_v1alpha1_AppFetchImgpkgBundle(ref),
 		"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchInline":                      schema_pkg_apis_kappctrl_v1alpha1_AppFetchInline(ref),
@@ -328,13 +327,15 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppCluster(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Specifies namespace in destination cluster (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"kubeconfigSecretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppClusterKubeconfigSecretRef"),
+							Description: "Specifies secret containing kubeconfig (required)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppClusterKubeconfigSecretRef"),
 						},
 					},
 				},
@@ -353,14 +354,16 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppClusterKubeconfigSecretRef(ref common.
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Specifies secret name within app's namespace (required)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Specifies key that contains kubeconfig (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -418,7 +421,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppDeploy(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"kapp": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppDeployKapp"),
+							Description: "Use kapp to deploy resources",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppDeployKapp"),
 						},
 					},
 				},
@@ -437,13 +441,15 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppDeployKapp(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"intoNs": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Override namespace for all resources (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"mapNs": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Provide custom namespace override mapping (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -457,7 +463,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppDeployKapp(ref common.ReferenceCallbac
 					},
 					"rawOptions": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Pass through options to kapp deploy (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -471,12 +478,14 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppDeployKapp(ref common.ReferenceCallbac
 					},
 					"inspect": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppDeployKappInspect"),
+							Description: "Configuration for inspect command (optional) as of kapp-controller v0.31.0, inspect is disabled by default add rawOptions or use an empty inspect config like `inspect: {}` to enable",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppDeployKappInspect"),
 						},
 					},
 					"delete": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppDeployKappDelete"),
+							Description: "Configuration for delete command (optional)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppDeployKappDelete"),
 						},
 					},
 				},
@@ -495,7 +504,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppDeployKappDelete(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"rawOptions": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Pass through options to kapp delete (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -521,7 +531,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppDeployKappInspect(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"rawOptions": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Pass through options to kapp inspect (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -547,32 +558,38 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetch(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"inline": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchInline"),
+							Description: "Pulls content from within this resource; or other resources in the cluster",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchInline"),
 						},
 					},
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImage"),
+							Description: "Pulls content from Docker/OCI registry",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImage"),
 						},
 					},
 					"http": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHTTP"),
+							Description: "Uses http library to fetch file",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHTTP"),
 						},
 					},
 					"git": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchGit"),
+							Description: "Uses git to clone repository",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchGit"),
 						},
 					},
 					"helmChart": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChart"),
+							Description: "Uses helm fetch to fetch specified chart",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchHelmChart"),
 						},
 					},
 					"imgpkgBundle": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImgpkgBundle"),
+							Description: "Pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchImgpkgBundle"),
 						},
 					},
 				},
@@ -591,37 +608,42 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchGit(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "http or ssh urls are supported (required)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"ref": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Branch, tag, commit; origin is the name of the remote (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"refSelection": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1.VersionSelection"),
+							Description: "Specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1.VersionSelection"),
 						},
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Secret may include one or more keys: ssh-privatekey, ssh-knownhosts",
+							Description: "Secret with auth details. allowed keys: ssh-privatekey, ssh-knownhosts, username, password (optional) (if ssh-knownhosts is not specified, git will not perform strict host checking)",
 							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchLocalRef"),
 						},
 					},
 					"subPath": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Grab only portion of repository (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"lfsSkipSmudge": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "Skip lfs download (optional)",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},
@@ -640,27 +662,29 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchHTTP(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Description: "URL can point to one of following formats: text, tgz, zip",
+							Description: "URL can point to one of following formats: text, tgz, zip http and https url are supported; plain file, tgz and tar types are supported (required)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"sha256": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Checksum to verify after download (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Secret may include one or more keys: username, password",
+							Description: "Secret to provide auth details (optional) Secret may include one or more keys: username, password",
 							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchLocalRef"),
 						},
 					},
 					"subPath": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Grab only portion of download (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -703,31 +727,6 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChart(ref common.ReferenceCal
 	}
 }
 
-func schema_pkg_apis_kappctrl_v1alpha1_AppFetchHelmChartRepo(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
-				Properties: map[string]spec.Schema{
-					"url": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"secretRef": {
-						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchLocalRef"),
-						},
-					},
-				},
-			},
-		},
-		Dependencies: []string{
-			"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchLocalRef"},
-	}
-}
-
 func schema_pkg_apis_kappctrl_v1alpha1_AppFetchImage(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -736,14 +735,15 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchImage(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Example: username/app1-config:v0.1.0",
+							Description: "Docker image url; unqualified, tagged, or digest references supported (required) Example: username/app1-config:v0.1.0",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"tagSelection": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1.VersionSelection"),
+							Description: "Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key",
+							Ref:         ref("github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1.VersionSelection"),
 						},
 					},
 					"secretRef": {
@@ -754,8 +754,9 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchImage(ref common.ReferenceCallbac
 					},
 					"subPath": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Grab only portion of image (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -774,13 +775,15 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchImgpkgBundle(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Docker image url; unqualified, tagged, or digest references supported (required)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"tagSelection": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1.VersionSelection"),
+							Description: "Specifies a strategy to choose a tag (optional; v0.24.0+) if specified, do not include a tag in url key",
+							Ref:         ref("github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1.VersionSelection"),
 						},
 					},
 					"secretRef": {
@@ -805,7 +808,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchInline(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"paths": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"object"},
+							Description: "Specifies mapping of paths to their content; not recommended for sensitive values as CR is not encrypted (optional)",
+							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
 								Schema: &spec.Schema{
@@ -820,7 +824,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchInline(ref common.ReferenceCallba
 					},
 					"pathsFrom": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Specifies content via secrets and config maps; data values are recommended to be placed in secrets (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -871,8 +876,9 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppFetchInlineSourceRef(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"directoryPath": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Specifies where to place files found in secret (optional)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"name": {
@@ -914,13 +920,15 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppSpec(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"serviceAccountName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Specifies that app should be deployed authenticated via given service account, found in this namespace (optional; v0.6.0+)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"cluster": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppCluster"),
+							Description: "Specifies that app should be deployed to destination cluster; by default, cluster is same as where this resource resides (optional; v0.5.0+)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppCluster"),
 						},
 					},
 					"fetch": {
@@ -964,27 +972,27 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppSpec(ref common.ReferenceCallback) com
 					},
 					"paused": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied",
+							Description: "Pauses _future_ reconcilation; does _not_ affect currently running reconciliation (optional; default=false)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"canceled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Canceled when set to true will stop all active changes",
+							Description: "Cancels current and future reconciliations (optional; default=false)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"syncPeriod": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Controls frequency of app reconciliation",
+							Description: "Specifies the length of time to wait, in time + unit format, before reconciling. Always >= 30s. If value below 30s is specified, 30s will be used. (optional; v0.9.0+; default=30s)",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 					"noopDelete": {
 						SchemaProps: spec.SchemaProps{
-							Description: "When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources",
+							Description: "Deletion requests for the App will result in the App CR being deleted, but its associated resources will not be deleted (optional; default=false; v0.18.0+)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -1005,17 +1013,20 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplate(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"ytt": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateYtt"),
+							Description: "Use ytt to template configuration",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateYtt"),
 						},
 					},
 					"kbld": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateKbld"),
+							Description: "Use kbld to resolve image references to use digests",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateKbld"),
 						},
 					},
 					"helmTemplate": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateHelmTemplate"),
+							Description: "Use helm template command to render helm chart",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateHelmTemplate"),
 						},
 					},
 					"kustomize": {
@@ -1030,7 +1041,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplate(ref common.ReferenceCallback)
 					},
 					"sops": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSops"),
+							Description: "Use sops to decrypt *.sops.yml files (optional; v0.11.0+)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSops"),
 						},
 					},
 				},
@@ -1049,25 +1061,29 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateHelmTemplate(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Set name explicitly, default is App CR's name (optional; v0.13.0+)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Set namespace explicitly, default is App CR's namespace (optional; v0.13.0+)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"path": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Path to chart (optional; v0.13.0+)",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"valuesFrom": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "One or more secrets, config maps, paths that provide values (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1140,12 +1156,14 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateSops(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"pgp": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSopsPGP"),
+							Description: "Use PGP to decrypt files (required)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSopsPGP"),
 						},
 					},
 					"paths": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Lists paths to decrypt explicitly (optional; v0.13.0+)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1178,7 +1196,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateSopsAge(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"privateKeysSecretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSopsPrivateKeysSecretRef"),
+							Description: "Secret with private armored PGP private keys (required)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSopsPrivateKeysSecretRef"),
 						},
 					},
 				},
@@ -1197,7 +1216,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateSopsPGP(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"privateKeysSecretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSopsPrivateKeysSecretRef"),
+							Description: "Secret with private armored PGP private keys (required)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppTemplateSopsPrivateKeysSecretRef"),
 						},
 					},
 				},
@@ -1282,24 +1302,28 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateYtt(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"ignoreUnknownComments": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "Ignores comments that ytt doesn't recognize (optional; default=false)",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"strict": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "Forces strict mode https://github.com/k14s/ytt/blob/develop/docs/strict.md (optional; default=false)",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"inline": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchInline"),
+							Description: "Specify additional files, including data values (optional)",
+							Ref:         ref("github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1.AppFetchInline"),
 						},
 					},
 					"paths": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Lists paths to provide to ytt explicitly (optional)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1313,7 +1337,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateYtt(ref common.ReferenceCallba
 					},
 					"fileMarks": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Control metadata about input files passed to ytt (optional; v0.18.0+) see https://carvel.dev/ytt/docs/latest/file-marks/ for more details",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1327,7 +1352,8 @@ func schema_pkg_apis_kappctrl_v1alpha1_AppTemplateYtt(ref common.ReferenceCallba
 					},
 					"valuesFrom": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Provide values via ytt's --data-values-file (optional; v0.19.0-alpha.9)",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
- This allows kubectl explain to show useful information
- These descriptions are taken verbatim from the docs

Signed-off-by: Neil Hickey <nhickey@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

Allows users to get a description of each field in the CRDs we provide without going to the docs 

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #49

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
All CRDs (Package / PackageInstall / PackageMetadata / PackageRepository) now show documented descriptions when running kubectl explain
```

#### Additional Notes for your reviewer:

Some indentation got changed. This was as a result of running `go fmt` against the files. So I think it's ok. That is what I would expect anyways

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
