### PR TITLE
Remove GOPATH related workarounds

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -21,10 +21,8 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: "1.17.6"
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v1
-      with:
-        path: src/github.com/${{ github.repository }}
     - name: Install Carvel Tools
       uses: vmware-tanzu/carvel-setup-action@v1
       with:
@@ -37,8 +35,6 @@ jobs:
     - name: Run Tests
       run: |
         set -e -x
-        export GOPATH=$(echo `pwd`/../../../../)
-
         mkdir /tmp/bin
         export PATH=/tmp/bin:$PATH
 

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -21,10 +21,8 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: "1.17"
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v1
-      with:
-        path: src/github.com/${{ github.repository }}
     - name: Install Carvel Tools
       uses: vmware-tanzu/carvel-setup-action@v1
       with:
@@ -37,7 +35,6 @@ jobs:
     - name: Run Tests
       run: |
         set -e -x
-        export GOPATH=$(echo `pwd`/../../../../)
 
         mkdir /tmp/bin
         export PATH=/tmp/bin:$PATH

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -21,10 +21,8 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: "1.17.6"
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
-        with:
-          path: src/github.com/${{ github.repository }}
       - name: Install Carvel Tools
         uses: vmware-tanzu/carvel-setup-action@v1
         with:
@@ -36,7 +34,6 @@ jobs:
       - name: Run Upgrade Test
         run: |
           set -e -x
-          export GOPATH=$(echo `pwd`/../../../../)
 
           mkdir /tmp/bin
           export PATH=/tmp/bin:$PATH

--- a/hack/gen-apiserver.sh
+++ b/hack/gen-apiserver.sh
@@ -5,7 +5,6 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-export GOPATH=$(cd ../../../../; pwd)
 KC_PKG="github.com/vmware-tanzu/carvel-kapp-controller"
 
 # Following patch allows us to name gen-s with a name Package
@@ -65,9 +64,6 @@ go run vendor/k8s.io/code-generator/cmd/openapi-gen/main.go \
 
 # Undo naming change
 git checkout vendor/k8s.io/gengo/namer/namer.go
-
-# Below protogen is configured to work without GOPATH var set
-unset GOPATH
 
 # Install protoc binary as directed by https://github.com/gogo/protobuf#installation
 # (Chosen: https://github.com/protocolbuffers/protobuf/releases/download/v3.0.2/protoc-3.0.2-osx-x86_64.zip)

--- a/hack/gen.sh
+++ b/hack/gen.sh
@@ -5,10 +5,6 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Note if you are not seeing generated code, most likely it's being placed into a different folder
-# (e.g. Do you have GOPATH directory structure correctly named for this project?)
-
-export GOPATH=$(cd ../../../../; pwd)
 KC_PKG="github.com/vmware-tanzu/carvel-kapp-controller"
 
 rm -rf pkg/client


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove GOPATH manipulation/setup from GHA workflows and `hack/gen` scripts. I was trying to diagnose why things were failing in https://github.com/vmware-tanzu/carvel-kapp-controller/pull/506 and when I tried running `hack/verify-no-dirty-files.sh` it failed because I don't have my code on a GOPATH.

We don't need to do any GOPATH stuff anymore since Go modules were introduced.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```