### PR TITLE
Move build and gen out of ./hack/verify-no-dirty-files.sh

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -195,6 +195,10 @@ Make sure to have [protoc installed](https://grpc.io/docs/protoc-installation/).
 It is recommended work with the kapp-controller repository on your `$GOPATH` as this is 
 where the non-CRD generators currently output generated code.
 
+#### Run All Generators at Once
+
+To run all generator scripts before checking changes in, use [`./hack/build-and-all-gen.sh`](../hack/build-and-all-gen.sh). 
+
 #### Custom resource generation 
 
 For CRD generation, kapp-controller makes use of [kubebuilder](https://book.kubebuilder.io/reference/generating-crd.html) 

--- a/hack/build-and-all-gen.sh
+++ b/hack/build-and-all-gen.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+./hack/build.sh
+./hack/gen.sh
+./hack/gen-apiserver.sh

--- a/hack/verify-no-dirty-files.sh
+++ b/hack/verify-no-dirty-files.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-./hack/build.sh
-./hack/gen.sh
-./hack/gen-apiserver.sh
+./hack/build-and-all-gen.sh
 
 if ! git diff --exit-code >/dev/null; then
   echo "Error: Running ./hack/verify-no-dirty-files.sh resulted in non zero exit code from git diff."


### PR DESCRIPTION
#### What this PR does / why we need it:

Before checking in changes, it might be helpful for contributors to just run all code generators at once via one script to avoid running into errors from `./hack/verify-no-dirty-files.sh`.

Open to better name for script itself and if there's a more logical workflow than running this script. 

#### Which issue(s) this PR fixes:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

Added to dev.md
