### PR TITLE
Allow gen scripts to work without GOPATH

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -10,10 +10,8 @@ jobs:
     name: kapp-controller release
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
-        with:
-          path: src/github.com/${{ github.repository }}
 
       - name: Install Carvel Tools
         uses: vmware-tanzu/carvel-setup-action@v1

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -21,17 +21,13 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: "1.17.6"
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v1
-      with:
-        path: src/github.com/${{ github.repository }}
     - name: Install Carvel Tools
       run: ./hack/install-deps.sh
     - name: Run Tests
       run: |
         set -e -x
-        export GOPATH=$(echo `pwd`/../../../../)
-
         mkdir /tmp/bin
         export PATH=/tmp/bin:$PATH
 

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -21,10 +21,8 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: "1.17"
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v1
-      with:
-        path: src/github.com/${{ github.repository }}
     - name: Install Carvel Tools
       uses: vmware-tanzu/carvel-setup-action@v1
       with:
@@ -37,7 +35,6 @@ jobs:
     - name: Run Tests
       run: |
         set -e -x
-        export GOPATH=$(echo `pwd`/../../../../)
 
         mkdir /tmp/bin
         export PATH=/tmp/bin:$PATH

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -21,16 +21,13 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: "1.17.6"
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v1
-        with:
-          path: src/github.com/${{ github.repository }}
       - name: Install Carvel Tools
         run: ./hack/install-deps.sh
       - name: Run Upgrade Test
         run: |
           set -e -x
-          export GOPATH=$(echo `pwd`/../../../../)
 
           mkdir /tmp/bin
           export PATH=/tmp/bin:$PATH

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -14,10 +14,6 @@ For windows users, please download the binaries from the respective GitHub repos
 * https://github.com/vmware-tanzu/carvel-kbld
 * https://github.com/vmware-tanzu/carvel-kapp
 
-**NOTE:** It is recommended to have the kapp-controller repository cloned to your `$GOPATH`.
-This is because kapp-controller's [code generator scripts](#code-generation) expect the project
-to be along the `$GOPATH`.
-
 ### Build
 
 To build the kapp-controller project locally, run the following:
@@ -191,9 +187,6 @@ to be checked in.
 #### Prerequisite
 
 Make sure to have [protoc installed](https://grpc.io/docs/protoc-installation/).
-
-It is recommended work with the kapp-controller repository on your `$GOPATH` as this is 
-where the non-CRD generators currently output generated code.
 
 #### Run All Generators at Once
 

--- a/hack/gen-apiserver-namer.patch
+++ b/hack/gen-apiserver-namer.patch
@@ -1,6 +1,8 @@
---- /tmp/namer.go	2021-08-21 14:34:17.000000000 -0400
-+++ /Users/dk/workspace/k14s-go/src/github.com/vmware-tanzu/carvel-kapp-controller/vendor/k8s.io/gengo/namer/namer.go	2021-08-21 14:41:09.000000000 -0400
-@@ -59,6 +59,7 @@
+diff --git a/vendor/k8s.io/gengo/namer/namer.go b/vendor/k8s.io/gengo/namer/namer.go
+index 6feb2d0c..5ae36b12 100644
+--- a/vendor/k8s.io/gengo/namer/namer.go
++++ b/vendor/k8s.io/gengo/namer/namer.go
+@@ -61,6 +61,7 @@ func NewPublicNamer(prependPackageNames int, ignoreWords ...string) *NameStrateg
  // arguments to this constructor.
  func NewPrivateNamer(prependPackageNames int, ignoreWords ...string) *NameStrategy {
  	n := &NameStrategy{

--- a/hack/gen.sh
+++ b/hack/gen.sh
@@ -5,10 +5,9 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Note if you are not seeing generated code, most likely it's being placed into a different folder
-# (e.g. Do you have GOPATH directory structure correctly named for this project?)
-
-export GOPATH=$(cd ../../../../; pwd)
+source hack/utils.sh
+export GOPATH="$(go_mod_gopath_hack)"
+trap "rm -rf ${GOPATH}" EXIT
 KC_PKG="github.com/vmware-tanzu/carvel-kapp-controller"
 
 rm -rf pkg/client

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,0 +1,14 @@
+# Return a GOPATH to a temp directory. Works around the out-of-GOPATH issues
+# for k8s client gen mixed with go mod.
+# Intended to be used like:
+#   export GOPATH=$(go_mod_gopath_hack)
+function go_mod_gopath_hack() {
+  local tmp_dir=$(mktemp -d)
+  local module="$(go list -m)"
+
+  local tmp_repo="${tmp_dir}/src/${module}"
+  mkdir -p "$(dirname ${tmp_repo})"
+  ln -s "$PWD" "${tmp_repo}"
+
+  echo "${tmp_dir}"
+}


### PR DESCRIPTION
Use a workaround borrowed from https://github.com/knative/hack/blob/9b303d690fc95249480482d31c383ed08ce13a70/library.sh#L680

I changed the patch to a git format patch since `patch` on my machine was always leaving behind a `vendor/k8s.io/gengo/namer/namer.go.orig` file. I suspect it has something to do with OSX vs Linux `patch`.