### PR TITLE
Support running as arbitrary non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ RUN tdnf install -y git openssh-clients sed
 RUN echo "kapp-controller:x:1000:" > /etc/group && \
     echo "kapp-controller:x:1000:1000::/home/kapp-controller:/usr/sbin/nologin" > /etc/passwd
 
+RUN chmod a+w /etc/pki/tls/certs/ca-bundle.crt
+
 # fetchers
 COPY --from=0 /helm-v2-unpacked/linux-amd64/helm helmv2
 COPY --from=0 /helm-unpacked/linux-amd64/helm .

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -ldflags="-X 'main.Version=$KC
 # --- run image ---
 FROM photon:4.0
 
-RUN tdnf install -y git openssh-clients shadow-tools sed
+RUN tdnf install -y git openssh-clients sed
 
-RUN groupadd -g 2000 kapp-controller && useradd -r -u 1000 --create-home -g kapp-controller kapp-controller
-RUN chmod g+w /etc/pki/tls/certs/ca-bundle.crt && chgrp kapp-controller /etc/pki/tls/certs/ca-bundle.crt
-USER kapp-controller
+RUN echo "kapp-controller:x:1000:" > /etc/group && \
+    echo "kapp-controller:x:1000:1000::/home/kapp-controller:/usr/sbin/nologin" > /etc/passwd
 
 # fetchers
 COPY --from=0 /helm-v2-unpacked/linux-amd64/helm helmv2
@@ -81,5 +80,6 @@ COPY --from=0 /usr/local/bin/kapp .
 # Name it kapp-controller to identify it easier in process tree
 COPY --from=0 /go/src/github.com/vmware-tanzu/carvel-kapp-controller/controller kapp-controller
 
+USER 1000:1000
 ENV PATH="/:${PATH}"
 ENTRYPOINT ["/kapp-controller"]

--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -51,7 +51,7 @@ spec:
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false #! TODO(bmo): don't write to the root ca-bundle
           runAsNonRoot: true
           capabilities:
             drop:

--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -43,19 +43,25 @@ spec:
         volumeMounts:
         - name: template-fs
           mountPath: /etc/kappctrl-mem-tmp
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 2000
+        - name: home
+          mountPath: /home/kapp-controller
         ports:
         - containerPort: #@ data.values.api_port
           name: api
           protocol: TCP
-      securityContext:
-        fsGroup: 3000
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
       volumes:
       - name: template-fs
         emptyDir:
-          #! https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
+          medium: Memory
+      - name: home
+        emptyDir:
           medium: Memory
 
 #@ if/end data.values.dangerous_enable_pprof:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Make our Dockerfile and deployment manifest not specify a UID/GID, but instead just `runAsNonRoot` and some other low privilege specifications.

OpenShift in particular will pick a random UID to run as, so we can't be dependent on file permissions specified in the Dockerfile.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Related to #407

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Container will no longer run as a hard-coded kapp-controller user
```