### PR TITLE
Clear UsefulErrorMessage while reconciling

### DIFF
--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -10,7 +10,6 @@ import (
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type Status struct {
@@ -75,6 +74,7 @@ func (s *Status) SetReconciling(meta metav1.ObjectMeta) {
 	})
 
 	s.S.FriendlyDescription = "Reconciling"
+	s.S.UsefulErrorMessage = ""
 
 	s.UpdateFunc(s.S)
 }
@@ -141,11 +141,6 @@ func (s *Status) friendlyErrMsg(errMsg string) string {
 		errMsgPieces[0] += "..."
 	}
 	return errMsgPieces[0]
-}
-
-func (s *Status) WithReconcileCompleted(result reconcile.Result, err error) (reconcile.Result, error) {
-	s.SetReconcileCompleted(err)
-	return result, err
 }
 
 func (s *Status) markObservedLatest(meta metav1.ObjectMeta) {


### PR DESCRIPTION
#### What this PR does / why we need it:
When a PackageInstall is reconciling it shouldn't still carry the error message from the previous reconcile

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #513 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
The usefulErrorMessage status field is reset when a PackageInstall is being reconciled
```
