### PR TITLE
pkgr: add annotation showing source pkgr to created resources.

### DIFF
--- a/test/e2e/kappcontroller/package_repo_test.go
+++ b/test/e2e/kappcontroller/package_repo_test.go
@@ -176,9 +176,14 @@ spec:
 	})
 
 	logger.Section("check PackageMetadata/Packages created", func() {
-		kubectl.Run([]string{"get", "pkgm/pkg.test.carvel.dev"})
-		kubectl.Run([]string{"get", "pkg/pkg.test.carvel.dev.1.0.0"})
-		kubectl.Run([]string{"get", "pkg/pkg.test.carvel.dev.2.0.0"})
+		verify := func(resourceName string) {
+			kctlOutput := kubectl.Run([]string{"get", resourceName, "-o", "yaml"})
+			assert.Contains(t, kctlOutput, "kapp.k14s.io/identity:")
+			assert.Contains(t, kctlOutput, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
+		}
+		verify("pkgm/pkg.test.carvel.dev")
+		verify("pkg/pkg.test.carvel.dev.1.0.0")
+		verify("pkg/pkg.test.carvel.dev.2.0.0")
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
adds an annotation showing the source-pkgr to the packages etc. created
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes # https://github.com/vmware-tanzu/carvel-kapp-controller/issues/124

#### Does this PR introduce a user-facing change?
it adds an annotation showing source pkgr to the created resources
```release-note
Packages and Package Metadatas created by a PackageRepository now include an annotation `packaging.carvel.dev/pkgr:` with the value being the package repository's name.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
