### PR TITLE
Log klog through our zap logger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/cmd/controller"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cmd/controllerinit"
+	"k8s.io/klog/v2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -32,9 +33,9 @@ func main() {
 	flag.BoolVar(&ctrlOpts.APIPriorityAndFairness, "enable-api-priority-and-fairness", true, "Enable/disable APIPriorityAndFairness feature gate for apiserver. Recommended to disable for <= k8s 1.19.")
 	flag.Parse()
 
-	log := logf.Log.WithName("kc")
-
-	logf.SetLogger(zap.New(zap.UseDevMode(false)))
+	log := zap.New(zap.UseDevMode(false)).WithName("kc")
+	logf.SetLogger(log)
+	klog.SetLogger(log)
 
 	mainLog := log.WithName("main")
 	mainLog.Info("kapp-controller", "version", Version)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 require (
 	github.com/go-logr/logr v0.4.0
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.9.0
 )
 
 require (
@@ -115,7 +116,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.22.2 // indirect
 	k8s.io/component-base v0.22.4 // indirect
 	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c // indirect
-	k8s.io/klog/v2 v2.9.0 // indirect
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes our logging so that we don't get unstructured logs still coming through. client-go uses klog, which we need to configure to use our logger so we don't end up with lines like 

```
I0302 15:37:41.743012      21 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I0302 15:37:41.743016      21 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I0302 15:37:41.743023      21 shared_informer.go:247] Caches are synced for RequestHeaderAuthRequestController
I0302 15:37:41.743911      21 apf_controller.go:317] Running API Priority and Fairness config worker
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```
