### PR TITLE
Dump app yaml when test-examples.sh fails

### DIFF
--- a/hack/test-examples.sh
+++ b/hack/test-examples.sh
@@ -2,6 +2,11 @@
 
 set -e -x -u
 
+function dump {
+  kubectl get apps -o yaml
+}
+trap dump ERR
+
 kapp deploy -y -a rbac -f examples/rbac/
 
 time kapp deploy -y -a simple-app -f examples/simple-app-git/1.yml


### PR DESCRIPTION
#### What this PR does / why we need it:
Dumps out all apps as YAML when a test app from `test-examples.sh` fails.

When this test [fails](https://github.com/vmware-tanzu/carvel-kapp-controller/runs/5395208957?check_suite_focus=true) it's pretty hard to diagnose what could be going wrong. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```
