### PR TITLE
app status test assertions

### DIFF
--- a/test/e2e/kappcontroller/app_status_test.go
+++ b/test/e2e/kappcontroller/app_status_test.go
@@ -62,9 +62,9 @@ spec:
 		out, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml), AllowError: true})
 		// it's supposed to error, but it's also supposed to create the three supporting resources successfully:
 		assert.Error(t, err)
-		assert.Contains(t, out, "ok: reconcile role/kappctrl-e2e-ns-role (rbac.authorization.k8s.io/v1) namespace: kappctrl-test")
-		assert.Contains(t, out, "ok: reconcile rolebinding/kappctrl-e2e-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: kappctrl-test")
-		assert.Contains(t, out, "ok: reconcile serviceaccount/kappctrl-e2e-ns-sa (v1) namespace: kappctrl-test")
+		assert.Contains(t, out, "ok: reconcile role/kappctrl-e2e-ns-role")
+		assert.Contains(t, out, "ok: reconcile rolebinding/kappctrl-e2e-ns-role-binding")
+		assert.Contains(t, out, "ok: reconcile serviceaccount/kappctrl-e2e-ns-sa")
 
 	})
 

--- a/test/e2e/kappcontroller/app_status_test.go
+++ b/test/e2e/kappcontroller/app_status_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
@@ -58,10 +59,17 @@ spec:
 	defer cleanUpApp()
 
 	logger.Section("deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml), AllowError: true})
+		out, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml), AllowError: true})
+		// it's supposed to error, but it's also supposed to create the three supporting resources successfully:
+		assert.Error(t, err)
+		assert.Contains(t, out, "ok: reconcile role/kappctrl-e2e-ns-role (rbac.authorization.k8s.io/v1) namespace: kappctrl-test")
+		assert.Contains(t, out, "ok: reconcile rolebinding/kappctrl-e2e-ns-role-binding (rbac.authorization.k8s.io/v1) namespace: kappctrl-test")
+		assert.Contains(t, out, "ok: reconcile serviceaccount/kappctrl-e2e-ns-sa (v1) namespace: kappctrl-test")
+
 	})
 
 	out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
+	assert.Greater(t, len(out), 1000) // the output yaml should be non-trivial (observed len ~2.7k)
 
 	var cr v1alpha1.App
 	err := yaml.Unmarshal([]byte(out), &cr)

--- a/test/e2e/kappcontroller/app_status_test.go
+++ b/test/e2e/kappcontroller/app_status_test.go
@@ -65,7 +65,6 @@ spec:
 		assert.Contains(t, out, "ok: reconcile role/kappctrl-e2e-ns-role")
 		assert.Contains(t, out, "ok: reconcile rolebinding/kappctrl-e2e-ns-role-binding")
 		assert.Contains(t, out, "ok: reconcile serviceaccount/kappctrl-e2e-ns-sa")
-
 	})
 
 	out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
I think this test just happens to run first (`go test` has an undefined order, technically) but because the first thing that happens is a `kapp deploy` with an allowError=true, it means that you can get some funny errors if there's stale testing apps deployed in your test namespace. This is especially obscured if you happen to be making a change to the App Status object because then you'll really be wondering what you broke.  So these assertions will hopefully help someone recognize the root cause of the errors they're seeing faster than I did today.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
