### PR TITLE
fetch.vendir.shouldSkipTLSVerify passes the port

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,6 +112,9 @@ func (gc *Config) Apply() error {
 	return nil
 }
 
+// ShouldSkipTLSForDomain compares a candidate host against a stored set of allow-listed hosts.
+// the allow-list is built from the user-facing flag `dangerousSkipTLSVerify`.
+// Note that in some cases the allow-list may contain ports, so the function name could also be ShouldSkipTLSForDomainAndPort
 func (gc *Config) ShouldSkipTLSForDomain(candidateDomain string) bool {
 	if !gc.populated {
 		return false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -138,7 +138,7 @@ func Test_ShouldSkipTLSForAuthority(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string]string{
-			"dangerousSkipTLSVerify": "always.trustworthy.com, selectively.trusted.net:123456",
+			"dangerousSkipTLSVerify": "always.trustworthy.com, selectively.trusted.net:123456, [1fff:0:a88:85a3::ac1f]:8001, 1aaa:0:a88:85a3::ac1f",
 		},
 	}
 	k8scs := k8sfake.NewSimpleClientset(configMap)
@@ -147,6 +147,14 @@ func Test_ShouldSkipTLSForAuthority(t *testing.T) {
 
 	assert.False(t, config.ShouldSkipTLSForAuthority("some.random.org"))
 	assert.True(t, config.ShouldSkipTLSForAuthority("always.trustworthy.com"))
+	assert.True(t, config.ShouldSkipTLSForAuthority("always.trustworthy.com:12345"))
 	assert.False(t, config.ShouldSkipTLSForAuthority("selectively.trusted.net"))
+	assert.False(t, config.ShouldSkipTLSForAuthority("selectively.trusted.net:8888"))
 	assert.True(t, config.ShouldSkipTLSForAuthority("selectively.trusted.net:123456"))
+	assert.True(t, config.ShouldSkipTLSForAuthority("[1fff:0:a88:85a3::ac1f]:8001"))
+	assert.False(t, config.ShouldSkipTLSForAuthority("[1fff:0:a88:85a3::ac1f]:8888"))
+	assert.False(t, config.ShouldSkipTLSForAuthority("1fff:0:a88:85a3::ac1f"))
+	assert.True(t, config.ShouldSkipTLSForAuthority("1aaa:0:a88:85a3::ac1f"))
+	assert.True(t, config.ShouldSkipTLSForAuthority("[1aaa:0:a88:85a3::ac1f]:888"))
+
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -131,7 +131,7 @@ func Test_KubernetesServiceHost_IsSet(t *testing.T) {
 	assert.Equal(t, expected, noProxyActual)
 }
 
-func Test_ShouldSkipTLSForDomain(t *testing.T) {
+func Test_ShouldSkipTLSForAuthority(t *testing.T) {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kapp-controller-config",
@@ -145,8 +145,8 @@ func Test_ShouldSkipTLSForDomain(t *testing.T) {
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.NoError(t, err)
 
-	assert.False(t, config.ShouldSkipTLSForDomain("some.random.org"))
-	assert.True(t, config.ShouldSkipTLSForDomain("always.trustworthy.com"))
-	assert.False(t, config.ShouldSkipTLSForDomain("selectively.trusted.net"))
-	assert.True(t, config.ShouldSkipTLSForDomain("selectively.trusted.net:123456"))
+	assert.False(t, config.ShouldSkipTLSForAuthority("some.random.org"))
+	assert.True(t, config.ShouldSkipTLSForAuthority("always.trustworthy.com"))
+	assert.False(t, config.ShouldSkipTLSForAuthority("selectively.trusted.net"))
+	assert.True(t, config.ShouldSkipTLSForAuthority("selectively.trusted.net:123456"))
 }

--- a/pkg/fetch/factory.go
+++ b/pkg/fetch/factory.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SkipTLSConfig interface {
-	ShouldSkipTLSForDomain(domain string) bool
+	ShouldSkipTLSForAuthority(authority string) bool
 }
 
 type Factory struct {

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -351,18 +351,22 @@ func (v *Vendir) configMapBytes(configMapRef vendirconf.DirectoryContentsLocalRe
 // expand this option to other fetch options, we will need to add hostname
 // extraction for those
 func (v *Vendir) shouldSkipTLSVerify(url string) bool {
-	hostname := v.extractImageRefHostname(url)
+	hostname, hostAndPort := v.extractImageRefHostname(url)
 	skip := v.skipTLSConfig.ShouldSkipTLSForDomain(hostname)
+	if !skip && (hostname != hostAndPort) {
+		// sometimes people want to whitelist only a specific port of a host, so we'll try that as a fallback.
+		return v.skipTLSConfig.ShouldSkipTLSForDomain(hostAndPort)
+	}
 	return skip
 }
 
-func (v *Vendir) extractImageRefHostname(ref string) string {
+func (v *Vendir) extractImageRefHostname(ref string) (string, string) {
 	parsedRef, err := name.ParseReference(ref)
 	if err != nil {
-		return ""
+		return "", ""
 	}
 
 	hostnameAndPort := parsedRef.Context().RegistryStr()
 
-	return strings.Split(hostnameAndPort, ":")[0]
+	return strings.Split(hostnameAndPort, ":")[0], hostnameAndPort
 }

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -64,8 +64,8 @@ func (v *Vendir) AddDir(fetch v1alpha1.AppFetch, dirPath string) error {
 	return nil
 }
 
-// GetConfig is just for accessing (a copy of) the internal config for testing; you probably don't want to call this IRL
-func (v *Vendir) GetConfig() vendirconf.Config {
+// Config is just for accessing (a copy of) the internal config for testing; you probably don't want to call this IRL
+func (v *Vendir) Config() vendirconf.Config {
 	return v.config
 }
 

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -65,6 +65,11 @@ func (v *Vendir) AddDir(fetch v1alpha1.AppFetch, dirPath string) error {
 	return nil
 }
 
+// GetConfig is just for accessing (a copy of) the internal config for testing; you probably don't want to call this IRL
+func (v *Vendir) GetConfig() vendirconf.Config {
+	return v.config
+}
+
 func (v *Vendir) dir(contents vendirconf.DirectoryContents, dirPath string) vendirconf.Directory {
 	return vendirconf.Directory{
 		Path:     dirPath,
@@ -365,8 +370,6 @@ func (v *Vendir) extractImageRefHostname(ref string) (string, string) {
 	if err != nil {
 		return "", ""
 	}
-
 	hostnameAndPort := parsedRef.Context().RegistryStr()
-
 	return strings.Split(hostnameAndPort, ":")[0], hostnameAndPort
 }

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -362,7 +362,6 @@ func (v *Vendir) shouldSkipTLSVerify(url string) bool {
 func (v *Vendir) extractImageRefHostname(ref string) string {
 	parsedRef, err := name.ParseReference(ref)
 	if err != nil {
-		fmt.Println("error extracting image ref hostname: ", err)
 		return ""
 	}
 	return parsedRef.Context().RegistryStr()

--- a/pkg/fetch/vendir_test.go
+++ b/pkg/fetch/vendir_test.go
@@ -50,7 +50,7 @@ func Test_AddDir_skipsTLS(t *testing.T) {
 			"dirpath/0")
 		assert.NoError(t, err)
 
-		vConf := vendir.GetConfig()
+		vConf := vendir.Config()
 		assert.Equal(t, i+1, len(vConf.Directories), "Failed on iteration %d", i)
 		assert.Equal(t, tc.shouldSkipTLS, vConf.Directories[i].Contents[0].Image.DangerousSkipTLSVerify, "Failed with URL %s", tc.URL)
 	}

--- a/pkg/fetch/vendir_test.go
+++ b/pkg/fetch/vendir_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package fetch_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	kcconfig "github.com/vmware-tanzu/carvel-kapp-controller/pkg/config"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/fetch"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_AddDir_skipsTLS(t *testing.T) {
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kapp-controller-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"dangerousSkipTLSVerify": "always.trustworthy.com, selectively.trusted.net:123456",
+		},
+	}
+	k8scs := k8sfake.NewSimpleClientset(configMap)
+	config, err := kcconfig.GetConfig(k8scs)
+	assert.NoError(t, err)
+
+	vendir := fetch.NewVendir("default", k8scs, config)
+
+	type testCase struct {
+		URL           string
+		shouldSkipTLS bool
+	}
+	testCases := []testCase{
+		{"always.trustworthy.com/myrepo/myimage:tag", true},
+		{"never.trustworthy.com/myrepo/myimage:tag", false},
+		{"selectively.trusted.net:123456/myrepo/myimage:tag", true},
+		{"selectively.trusted.net:7777/myrepo/myimage:tag", false},
+	}
+	for i, tc := range testCases {
+		err = vendir.AddDir(v1alpha1.AppFetch{
+			Image: &v1alpha1.AppFetchImage{
+				URL: tc.URL,
+			},
+		},
+			"dirpath/0")
+		assert.NoError(t, err)
+
+		vConf := vendir.GetConfig()
+		assert.Equal(t, i+1, len(vConf.Directories), "Failed on iteration %d", i)
+		assert.Equal(t, tc.shouldSkipTLS, vConf.Directories[i].Contents[0].Image.DangerousSkipTLSVerify, "Failed with URL %s", tc.URL)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #549 

note that this is a more strict version of https://github.com/vmware-tanzu/carvel-kapp-controller/pull/550

In particular the difference is whether we allow all ports to skipTLS (as in #550 ) or enforce the port specified (as in this PR) - see [line 150 of the unit test](https://github.com/vmware-tanzu/carvel-kapp-controller/blob/82c1d7451817a03bcc23b238638d3c898752c7f7/pkg/config/config_test.go#L150)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
