### PR TITLE
Fix apiserver watch timeouts

### DIFF
--- a/pkg/apiserver/watchers/translation_watcher.go
+++ b/pkg/apiserver/watchers/translation_watcher.go
@@ -43,7 +43,7 @@ func (tw *TranslationWatcher) ResultChan() <-chan watch.Event {
 }
 
 func (tw *TranslationWatcher) Stop() {
-	tw.stopCh <- struct{}{}
+	close(tw.stopCh)
 	tw.proxiedWatcher.Stop()
 }
 

--- a/pkg/apiserver/watchers/translation_watcher_test.go
+++ b/pkg/apiserver/watchers/translation_watcher_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package watchers
+
+import (
+	"testing"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestTranslationWatcher(t *testing.T) {
+	proxiedWatcher := watch.NewFake()
+
+	w := NewTranslationWatcher(func(e watch.Event) watch.Event {
+		pkg := e.Object.(*datapackaging.Package)
+		pkg.Name = "transformed"
+		return e
+	}, func(e watch.Event) bool {
+		if e.Type == watch.Error {
+			return false
+		}
+		return true
+	}, proxiedWatcher)
+
+	proxiedWatcher.Add(&datapackaging.Package{})
+	event := <-w.ResultChan()
+	pkg := event.Object.(*datapackaging.Package)
+	if pkg.Name != "transformed" {
+		t.Fatal("expected object to be transformed")
+	}
+
+	proxiedWatcher.Error(&datapackaging.Package{})
+	proxiedWatcher.Delete(&datapackaging.Package{})
+	event = <-w.ResultChan()
+	if event.Type == watch.Error {
+		t.Fatal("expected error event to be filtered out")
+	}
+
+	proxiedWatcher.Stop()
+	w.Stop()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Fixes deadlock that was causing our API server's watches to never complete.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #560

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
