### PR TITLE
accept values over stdin in helm template

### DIFF
--- a/pkg/template/values.go
+++ b/pkg/template/values.go
@@ -55,9 +55,13 @@ func (t Values) AsPaths(dirPath string) ([]string, func(), error) {
 			paths, err = t.writeFromConfigMap(valuesDir.Path(), *source.ConfigMapRef)
 
 		case len(source.Path) > 0:
-			checkedPath, err := memdir.ScopedPath(dirPath, source.Path)
-			if err == nil {
-				paths = append(paths, checkedPath)
+			if source.Path == stdinPath {
+				paths = append(paths, stdinPath)
+			} else {
+				checkedPath, err := memdir.ScopedPath(dirPath, source.Path)
+				if err == nil {
+					paths = append(paths, checkedPath)
+				}
 			}
 
 		default:


### PR DESCRIPTION
is useful for mangling values via ytt before sending them to helm as values. this may be used to limit allowed configurations for example.

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

