### PR TITLE
Allow deleting deploying apps

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -88,7 +88,7 @@ func (a *App) flushUpdateStatus(desc string) error {
 	return nil
 }
 
-func (a *App) newCancelCh() (chan struct{}, func()) {
+func (a *App) newCancelCh(conditions ...cancelCondition) (chan struct{}, func()) {
 	var cancelOnce sync.Once
 	cancelCh := make(chan struct{})
 
@@ -98,8 +98,11 @@ func (a *App) newCancelCh() (chan struct{}, func()) {
 	}
 
 	cancelFuncOnApp := func(app v1alpha1.App) {
-		if app.Spec.Canceled {
-			cancelFunc()
+		for _, condition := range conditions {
+			if condition(app) {
+				cancelFunc()
+				return
+			}
 		}
 	}
 

--- a/test/e2e/kappcontroller/cancel_test.go
+++ b/test/e2e/kappcontroller/cancel_test.go
@@ -49,6 +49,7 @@ spec:
                   image: busybox
                   command: ['sh', '-c', 'sleep 60']
                 restartPolicy: Never
+                terminationGracePeriodSeconds: 0
   template:
   - ytt: {}
   deploy:
@@ -90,6 +91,7 @@ spec:
                   image: busybox
                   command: ['sh', '-c', 'sleep 60']
                 restartPolicy: Never
+                terminationGracePeriodSeconds: 0
   template:
   - ytt: {}
   deploy:

--- a/test/e2e/kappcontroller/delete_test.go
+++ b/test/e2e/kappcontroller/delete_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kappcontroller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
+)
+
+func TestDeleteCancelsDeploys(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
+
+	appYaml := `---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: delete-while-deploying
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - inline:
+      paths:
+        file.yml: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: sleep
+          spec:
+            containers:
+             - name: nginx
+               image: nginx
+               readinessProbe:
+                 httpGet:
+                   port: 8080
+            terminationGracePeriodSeconds: 0
+  template:
+  - ytt: {}
+  deploy:
+  - kapp: {}
+` + sas.ForNamespaceYAML()
+
+	name := "delete-while-deploying"
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUp()
+	t.Cleanup(cleanUp)
+
+	logger.Section("begin deploy", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--wait=false"},
+			e2e.RunOpts{IntoNs: true, StdinReader: strings.NewReader(appYaml)})
+
+		waitForDeployToStart(name, kapp, t)
+	})
+
+	logger.Section("delete", func() {
+		kapp.RunWithOpts([]string{"delete", "-a", name, "--filter-kind", "App"}, e2e.RunOpts{})
+	})
+}

--- a/test/e2e/kappcontroller/pause_test.go
+++ b/test/e2e/kappcontroller/pause_test.go
@@ -22,10 +22,6 @@ func Test_AppPause(t *testing.T) {
 	name := "app-pause"
 
 	cleanUp := func() {
-		// Need to make sure App is not paused
-		// so need to create as part of deletion.
-		appYaml := appYAML(name, env.Namespace, "original", false)
-		kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
 		kapp.Run([]string{"delete", "-a", name})
 	}
 	cleanUp()


### PR DESCRIPTION
#### What this PR does / why we need it:
Automatically cancels any pending `deploy` or `inspect` commands if an app is being deleted. More likely to be the `deploy`s that cause this problem, but I figured it was consistent to also interrupt `inspect`.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes (the remaining part of) #566

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Apps stuck in deploying will no longer cause deletions to hang
```
