### PR TITLE
Cue templater no longer globs

### DIFF
--- a/examples/cue.yml
+++ b/examples/cue.yml
@@ -9,6 +9,8 @@ spec:
   - inline:
       paths:
         app.cue: |
+            package app
+
             output: {
                 apiVersion: "v1"
                 kind:       "List"

--- a/pkg/template/cue.go
+++ b/pkg/template/cue.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	goexec "os/exec"
-	"path/filepath"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
@@ -45,11 +44,7 @@ func (c *cue) template(dirPath string, input io.Reader) exec.CmdRunResult {
 	var stdoutBs, stderrBs bytes.Buffer
 	args := []string{"export", "--out", "yaml"}
 	if len(c.opts.Paths) == 0 {
-		paths, err := filepath.Glob(filepath.Join(dirPath, "*.cue"))
-		if err != nil {
-			return exec.NewCmdRunResultWithErr(fmt.Errorf("Reading files: %w", err))
-		}
-		args = append(args, paths...)
+		args = append(args, ".")
 	} else {
 		for _, path := range c.opts.Paths {
 			_, err := memdir.ScopedPath(dirPath, path)

--- a/test/e2e/kappcontroller/template_test.go
+++ b/test/e2e/kappcontroller/template_test.go
@@ -288,11 +288,23 @@ spec:
             metadata:
               name: "cm-result"
             data:
-              values: "cool"
+              value: "cool"
   template:
-    - cue: {}
+  - cue:
+      inputExpression: "data:"
+      valuesFrom:
+      - secretRef:
+          name: secret-values
   deploy:
     - kapp: {}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: secret-values
+stringData:
+  password.yaml: |
+    password: "wow"
 ` + sas.ForNamespaceYAML()
 
 	cleanUp := func() {
@@ -316,10 +328,11 @@ spec:
 			t.Fatalf("Unmarshaling result config map: %s", err)
 		}
 
-		expectedOut := `cool`
-
-		if cm.Data["values"] != expectedOut {
-			t.Fatalf("Values '%s' does not match expected value", cm.Data["values"])
+		if cm.Data["value"] != "cool" {
+			t.Fatalf("Value '%s' does not match expected value", cm.Data["value"])
+		}
+		if cm.Data["password"] != "wow" {
+			t.Fatalf("Password '%s' does not match expected value", cm.Data["password"])
 		}
 	})
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes the way our Cue templating works to no longer glob all `*.cue` files, instead using the Cue CLI's default behavior of exporting the current directory/package. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

I figured since we haven't really documented/announced cue support yet it's not worth a release note