### PR TITLE
do not require prereleases:{} to be set when setting explicit version…

### DIFF
--- a/pkg/packageinstall/packageinstall.go
+++ b/pkg/packageinstall/packageinstall.go
@@ -210,6 +210,16 @@ func (pi *PackageInstallCR) referencedPkgVersion() (datapkgingv1alpha1.Package, 
 		}
 	}
 
+	// If constraint is a single specified version, then we
+	// do not want to force user to manually set prereleases={}
+	if len(semverConfig.Constraints) > 0 && semverConfig.Prereleases == nil {
+		// Will error if it's not a single version
+		singleVer, err := versions.NewSemver(semverConfig.Constraints)
+		if err == nil && len(singleVer.Pre) > 0 {
+			semverConfig.Prereleases = &verv1alpha1.VersionSelectionSemverPrereleases{}
+		}
+	}
+
 	verConfig := verv1alpha1.VersionSelection{Semver: semverConfig}
 
 	selectedVersion, err := versions.HighestConstrainedVersion(versionStrs, verConfig)

--- a/pkg/packageinstall/packageinstall_test.go
+++ b/pkg/packageinstall/packageinstall_test.go
@@ -70,6 +70,41 @@ func Test_PackageRefWithPrerelease_IsFound(t *testing.T) {
 	}
 }
 
+func Test_PackageRefWithPrerelease_DoesNotRequirePrereleaseMarker(t *testing.T) {
+	expectedPackageVersion := datapkgingv1alpha1.Package{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pkg.test.carvel.dev",
+		},
+		Spec: datapkgingv1alpha1.PackageSpec{
+			RefName: "pkg.test.carvel.dev",
+			Version: "3.0.0-rc.1",
+		},
+	}
+
+	fakePkgClient := fakeapiserver.NewSimpleClientset(&expectedPackageVersion)
+
+	ip := PackageInstallCR{
+		model: &pkgingv1alpha1.PackageInstall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "instl-pkg-prerelease",
+			},
+			Spec: pkgingv1alpha1.PackageInstallSpec{
+				PackageRef: &pkgingv1alpha1.PackageRef{
+					RefName: "pkg.test.carvel.dev",
+					VersionSelection: &versions.VersionSelectionSemver{
+						Constraints: "3.0.0-rc.1",
+					},
+				},
+			},
+		},
+		pkgclient: fakePkgClient,
+	}
+
+	out, err := ip.referencedPkgVersion()
+	require.NoError(t, err)
+	require.Equal(t, out, expectedPackageVersion)
+}
+
 func Test_PackageRefUsesName(t *testing.T) {
 	// PackageMetadata with prerelease version
 	expectedPackageVersion := datapkgingv1alpha1.Package{


### PR DESCRIPTION
… in constraints

#### What this PR does / why we need it:

currently if user specifies prerelease version explicitly in constraints field, they need to remember to specify `prereleases: {}` without which version selection wont work. this PR makes it unnecessary to specify prereleases when explicit prerelease version is given.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
