### PR TITLE
Avoid retrying image-based app installs when nothing has changed

### DIFF
--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
@@ -194,10 +193,10 @@ func (v *Vendir) localRefConf(ref *v1alpha1.AppFetchLocalRef) *vendirconf.Direct
 	}
 }
 
-// ConfigReader generates config yaml bytes and wraps them in a bytes.Reader.
-// These bytes could be written to a file and then passed to vendir
-// but can also be mapped to stdin of the vendir process.
-func (v *Vendir) ConfigReader() (io.Reader, error) {
+// ConfigBytes fetches all the referenced Secrets & ConfigMaps and returns the
+// multi-document YAML-encoded config that vendir consumes.
+// https://github.com/vmware-tanzu/carvel-vendir/blob/develop/examples/secrets/vendir.yml
+func (v *Vendir) ConfigBytes() ([]byte, error) {
 	var resourcesYaml [][]byte
 	for _, dir := range v.config.Directories {
 		for _, contents := range dir.Contents {
@@ -217,7 +216,7 @@ func (v *Vendir) ConfigReader() (io.Reader, error) {
 
 	finalConfig := bytes.Join(append(resourcesYaml, vendirConfBytes), []byte("---\n"))
 
-	return bytes.NewReader(finalConfig), nil
+	return finalConfig, nil
 }
 
 func (v *Vendir) requiredResourcesYaml(contents vendirconf.DirectoryContents) ([][]byte, error) {

--- a/pkg/pkgrepository/app_fetch.go
+++ b/pkg/pkgrepository/app_fetch.go
@@ -6,7 +6,6 @@ package pkgrepository
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"strconv"
@@ -37,13 +36,13 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 		}
 	}
 
-	confReader, err := vendir.ConfigReader()
+	conf, err := vendir.ConfigBytes()
 	if err != nil {
 		result.AttachErrorf("Fetching: %v", err)
 		return "", result
 	}
 
-	result = a.runVendir(confReader, dstPath)
+	result = a.runVendir(conf, dstPath)
 	// retry if error occurs before reporting failure.
 	// This is mainly done to support private registry
 	// authentication for images/bundles since placeholder
@@ -55,12 +54,16 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 			// Sleep for 2 seconds to allow secretgen-controller
 			// to update placeholder secret(s).
 			time.Sleep(2 * time.Second)
-			confReader, err = vendir.ConfigReader()
+			newConf, err := vendir.ConfigBytes()
 			if err != nil {
 				result.AttachErrorf("Fetching: %v", err)
 				return "", result
 			}
-			result = a.runVendir(confReader, dstPath)
+			if bytes.Equal(conf, newConf) {
+				// no secrets/configmaps have changed, no point in retrying
+				continue
+			}
+			result = a.runVendir(newConf, dstPath)
 			if result.Error == nil {
 				break
 			}
@@ -78,11 +81,11 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 	return dstPath, result
 }
 
-func (a *App) runVendir(confReader io.Reader, workingDir string) exec.CmdRunResult {
+func (a *App) runVendir(conf []byte, workingDir string) exec.CmdRunResult {
 	var stdoutBs, stderrBs bytes.Buffer
 	cmd := goexec.Command("vendir", "sync", "-f", "-", "--lock-file", os.DevNull)
 	cmd.Dir = workingDir
-	cmd.Stdin = confReader
+	cmd.Stdin = bytes.NewReader(conf)
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
We introduced retrying for image-based apps in #331 to handle the race condition between image pull secrets getting populated and us running `vendir sync`. However this results in unnecessary churn/repository traffic when the configmaps and secrets haven't changed, since there's not going to be any different outcome.

