### PR TITLE
Add rbac permission for packageinstall finalizers

### DIFF
--- a/config/rbac.yml
+++ b/config/rbac.yml
@@ -22,7 +22,7 @@ rules:
   resources: ["apps", "apps/status"]
   verbs: ["*"]
 - apiGroups: ["packaging.carvel.dev"]
-  resources: ["packageinstalls", "packageinstalls/status"]
+  resources: ["packageinstalls", "packageinstalls/status", "packageinstalls/finalizers"]
   verbs: ["*"]
 - apiGroups: ["packaging.carvel.dev"]
   resources: ["packagerepositories", "packagerepositories/status"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
The [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission controller enforces that you need the update perm for the finalizers subresource to make an object be owned by it. We create Apps that are owned by PackageInstalls, and therefore need to be able to update the packageinstalls/finalizers.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
This is on by default on OpenShift clusters