### PR TITLE
Allow dynamic KC config updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ COPY --from=0 /usr/local/bin/kapp .
 # Name it kapp-controller to identify it easier in process tree
 COPY --from=0 /go/src/github.com/vmware-tanzu/carvel-kapp-controller/controller kapp-controller
 
+# Copy the ca-bundle so we have an original
+RUN cp /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt.orig
+
 # Run as kapp-controller by default, will be overridden to a random uid on OpenShift
 USER 1000
 ENV PATH="/:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,9 @@ RUN tdnf install -y git openssh-clients sed
 
 # Create the kapp-controller user in the root group, the home directory will be mounted as a volume
 RUN echo "kapp-controller:x:1000:0:/home/kapp-controller:/usr/sbin/nologin" > /etc/passwd
-# Give the root group write access to openssh's root bundle so we can append custom roots at runtime
-RUN chmod g+w /etc/pki/tls/certs/ca-bundle.crt
+# Give the root group write access to the openssh's root bundle directory
+# so we can rename the certs file with our dynamic config, and append custom roots at runtime
+RUN chmod g+w /etc/pki/tls/certs
 
 # fetchers
 COPY --from=0 /helm-unpacked/linux-amd64/helm .

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -122,10 +122,7 @@ func Run(opts Options, runLog logr.Logger) error {
 		reconciler := kcconfig.NewReconciler(coreClient, runLog.WithName("config"))
 
 		ctrl, err := controller.New("Config", mgr, controller.Options{
-			Reconciler: NewUniqueReconciler(&ErrReconciler{
-				delegate: reconciler,
-				log:      runLog.WithName("er"),
-			}),
+			Reconciler:              reconciler,
 			MaxConcurrentReconciles: 1,
 		})
 		if err != nil {

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -129,7 +129,12 @@ func Run(opts Options, runLog logr.Logger) error {
 			return fmt.Errorf("Setting up Config reconciler: %s", err)
 		}
 
-		err = reconciler.AttachWatches(ctrl)
+		ns := os.Getenv("KAPPCTRL_SYSTEM_NAMESPACE")
+		if ns == "" {
+			return fmt.Errorf("Cannot get kapp-controller namespace")
+		}
+
+		err = reconciler.AttachWatches(ctrl, ns)
 		if err != nil {
 			return fmt.Errorf("Setting up Config reconciler watches: %s", err)
 		}

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -121,7 +121,7 @@ func Run(opts Options, runLog logr.Logger) error {
 	{ // add controller for config
 		reconciler := kcconfig.NewReconciler(coreClient, runLog.WithName("config"))
 
-		ctrl, err := controller.New("Config", mgr, controller.Options{
+		ctrl, err := controller.New("config", mgr, controller.Options{
 			Reconciler:              reconciler,
 			MaxConcurrentReconciles: 1,
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -158,7 +158,7 @@ func (gc *Config) addTrustedCerts(certChain string) (err error) {
 		return fmt.Errorf("Opening original certs file: %s", err)
 	}
 
-	tmpFile, err := os.CreateTemp("/tmp", "tmp-ca-bundle-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "tmp-ca-bundle-")
 	if err != nil {
 		return fmt.Errorf("Creating tmp certs file: %s", err)
 	}
@@ -171,7 +171,7 @@ func (gc *Config) addTrustedCerts(certChain string) (err error) {
 	_, err = tmpFile.Write([]byte("\n" + certChain))
 	if err != nil {
 		_ = backupFile.Close()
-		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
 		return err
 	}
 
@@ -185,7 +185,7 @@ func (gc *Config) addTrustedCerts(certChain string) (err error) {
 		return err
 	}
 
-	return tmpFile.Close()
+	return os.Remove(tmpFile.Name())
 }
 
 func (gc *Config) configureProxies() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	httpsProxy    string
 	noProxy       string
 	skipTLSVerify string
+	SkipCertCheck bool
 }
 
 // findExternalConfig will populate exactly one of its return values and the others will be nil.
@@ -142,6 +143,10 @@ func (gc *Config) ShouldSkipTLSForAuthority(candidateAuthority string) bool {
 }
 
 func (gc *Config) addTrustedCerts(certChain string) (err error) {
+	if gc.SkipCertCheck {
+		return nil
+	}
+
 	src, err := os.OpenFile(systemCertsFile+".orig", os.O_RDONLY, os.ModeExclusive)
 	if err != nil {
 		return fmt.Errorf("Opening original certs file: %s", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -180,12 +180,7 @@ func (gc *Config) addTrustedCerts(certChain string) (err error) {
 		return fmt.Errorf("renaming certs file: %s", err)
 	}
 
-	err = backupFile.Close()
-	if err != nil {
-		return err
-	}
-
-	return os.Remove(tmpFile.Name())
+	return backupFile.Close()
 }
 
 func (gc *Config) configureProxies() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,7 @@ func Test_GetConfig_ReturnsSecret_WhenBothConfigMapAndSecretExist(t *testing.T) 
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
+	config.SkipCertCheck = true
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -67,6 +68,7 @@ func Test_GetConfig_ReturnsConfigMap_WhenOnlyConfigMapExists(t *testing.T) {
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
+	config.SkipCertCheck = true
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -93,6 +95,7 @@ func Test_GetConfig_ReturnsSecret_WhenOnlySecretExists(t *testing.T) {
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
+	config.SkipCertCheck = true
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -122,6 +125,7 @@ func Test_KubernetesServiceHost_IsSet(t *testing.T) {
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
+	config.SkipCertCheck = true
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -144,6 +148,7 @@ func Test_ShouldSkipTLSForAuthority(t *testing.T) {
 	k8scs := k8sfake.NewSimpleClientset(configMap)
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.NoError(t, err)
+	config.SkipCertCheck = true
 
 	assert.False(t, config.ShouldSkipTLSForAuthority("some.random.org"))
 	assert.True(t, config.ShouldSkipTLSForAuthority("always.trustworthy.com"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,9 @@ func Test_GetConfig_ReturnsSecret_WhenBothConfigMapAndSecretExist(t *testing.T) 
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
-	config.SkipCertCheck = true
+
+	err = stubTrustedCerts(t, config)
+	assert.NoError(t, err)
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -68,7 +70,9 @@ func Test_GetConfig_ReturnsConfigMap_WhenOnlyConfigMapExists(t *testing.T) {
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
-	config.SkipCertCheck = true
+
+	err = stubTrustedCerts(t, config)
+	assert.NoError(t, err)
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -95,7 +99,9 @@ func Test_GetConfig_ReturnsSecret_WhenOnlySecretExists(t *testing.T) {
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
-	config.SkipCertCheck = true
+
+	err = stubTrustedCerts(t, config)
+	assert.NoError(t, err)
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -125,7 +131,9 @@ func Test_KubernetesServiceHost_IsSet(t *testing.T) {
 
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.Nil(t, err, "unexpected error after running config.GetConfig()", err)
-	config.SkipCertCheck = true
+
+	err = stubTrustedCerts(t, config)
+	assert.NoError(t, err)
 
 	assert.Nil(t, config.Apply(), "unexpected error after running config.Apply()", err)
 
@@ -148,7 +156,6 @@ func Test_ShouldSkipTLSForAuthority(t *testing.T) {
 	k8scs := k8sfake.NewSimpleClientset(configMap)
 	config, err := kcconfig.GetConfig(k8scs)
 	assert.NoError(t, err)
-	config.SkipCertCheck = true
 
 	assert.False(t, config.ShouldSkipTLSForAuthority("some.random.org"))
 	assert.True(t, config.ShouldSkipTLSForAuthority("always.trustworthy.com"))
@@ -161,5 +168,132 @@ func Test_ShouldSkipTLSForAuthority(t *testing.T) {
 	assert.False(t, config.ShouldSkipTLSForAuthority("1fff:0:a88:85a3::ac1f"))
 	assert.True(t, config.ShouldSkipTLSForAuthority("1aaa:0:a88:85a3::ac1f"))
 	assert.True(t, config.ShouldSkipTLSForAuthority("[1aaa:0:a88:85a3::ac1f]:888"))
+}
 
+func Test_TrustedCertsCreateConfig(t *testing.T) {
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kapp-controller-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"caCerts": "cert-42",
+		},
+	}
+	k8scs := k8sfake.NewSimpleClientset(configMap)
+	config, err := kcconfig.GetConfig(k8scs)
+	assert.NoError(t, err)
+
+	backup, certs, close, err := createCertTempFiles(t)
+	assert.NoError(t, err)
+	defer close()
+
+	config.BackupCaBundlePath = backup.Name()
+	config.SystemCaBundlePath = certs.Name()
+
+	assert.NoError(t, config.Apply(), "unexpected error after running config.Apply()")
+
+	contents, err := os.ReadFile(config.SystemCaBundlePath)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(contents), "cert-42")
+}
+
+func Test_TrustedCertsUpdateConfig(t *testing.T) {
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kapp-controller-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"caCerts": "cert-42",
+		},
+	}
+	k8scs := k8sfake.NewSimpleClientset(configMap)
+	config, err := kcconfig.GetConfig(k8scs)
+	assert.NoError(t, err)
+
+	backup, certs, close, err := createCertTempFiles(t)
+	assert.NoError(t, err)
+	defer close()
+
+	config.BackupCaBundlePath = backup.Name()
+	config.SystemCaBundlePath = certs.Name()
+
+	assert.NoError(t, config.Apply(), "unexpected error after running config.Apply()")
+
+	contents, err := os.ReadFile(config.SystemCaBundlePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(contents), "cert-42")
+
+	// update config
+	configMap.Data["caCerts"] = "cert-43"
+
+	k8scs = k8sfake.NewSimpleClientset(configMap)
+	config, err = kcconfig.GetConfig(k8scs)
+	assert.NoError(t, err)
+
+	config.BackupCaBundlePath = backup.Name()
+	config.SystemCaBundlePath = certs.Name()
+
+	assert.NoError(t, config.Apply(), "unexpected error after running config.Apply()")
+
+	contents, err = os.ReadFile(config.SystemCaBundlePath)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(contents), "cert-43")
+}
+
+func Test_TrustedCertsDeleteConfig(t *testing.T) {
+	backup, certs, close, err := createCertTempFiles(t)
+	assert.NoError(t, err)
+	defer close()
+
+	backup.Write([]byte("this-is-the-old-content"))
+
+	// no config found
+	k8scs := k8sfake.NewSimpleClientset()
+	config, err := kcconfig.GetConfig(k8scs)
+	assert.NoError(t, err)
+
+	config.BackupCaBundlePath = backup.Name()
+	config.SystemCaBundlePath = certs.Name()
+
+	assert.NoError(t, config.Apply(), "unexpected error after running config.Apply()")
+
+	contents, err := os.ReadFile(config.SystemCaBundlePath)
+	assert.NoError(t, err)
+
+	// restored to the backup without any additional data
+	assert.Contains(t, string(contents), "this-is-the-old-content")
+}
+
+func stubTrustedCerts(t *testing.T, gc *kcconfig.Config) error {
+	backup, certs, close, err := createCertTempFiles(t)
+	if err != nil {
+		return err
+	}
+	defer close()
+
+	gc.BackupCaBundlePath = backup.Name()
+	gc.SystemCaBundlePath = certs.Name()
+
+	return nil
+}
+
+func createCertTempFiles(t *testing.T) (backup *os.File, certs *os.File, close func(), err error) {
+	backup, err = os.CreateTemp("", "backup.crt")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	certs, err = os.CreateTemp("", "certs.crt")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return backup, certs, func() {
+		backup.Close()
+		certs.Close()
+	}, nil
 }

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -1,0 +1,71 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Reconciler is responsible for reconciling Apps.
+type Reconciler struct {
+	coreClient kubernetes.Interface
+	log        logr.Logger
+}
+
+// NewReconciler constructs new Reconciler.
+func NewReconciler(coreClient kubernetes.Interface, log logr.Logger) *Reconciler {
+	return &Reconciler{coreClient, log}
+}
+
+var _ reconcile.Reconciler = &Reconciler{}
+
+// AttachWatches configures watches needed for reconciler to reconcile Apps.
+func (r *Reconciler) AttachWatches(controller controller.Controller) error {
+	p := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetName() == "kapp-controller-config"
+		},
+	}
+
+	err := controller.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, p)
+	if err != nil {
+		return fmt.Errorf("Watching Configmaps: %s", err)
+	}
+
+	err = controller.Watch(&source.Kind{Type: &v1.Secret{}}, &handler.EnqueueRequestForObject{}, p)
+	if err != nil {
+		return fmt.Errorf("Watching Secrets: %s", err)
+	}
+
+	return nil
+}
+
+// nolint: revive
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues("request", request)
+
+	kcConfig, err := GetConfig(r.coreClient)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("getting kapp-controller config: %s", err)
+	}
+
+	log.Info("Applying new config")
+	err = kcConfig.Apply()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("Applying configuration: %s", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -33,20 +32,13 @@ func NewReconciler(coreClient kubernetes.Interface, log logr.Logger) *Reconciler
 var _ reconcile.Reconciler = &Reconciler{}
 
 // AttachWatches configures watches needed for reconciler to reconcile the kapp-controller Config.
-func (r *Reconciler) AttachWatches(controller controller.Controller) error {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConf := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	namespace, _, err := kubeConf.Namespace()
-	if err != nil {
-		return fmt.Errorf("Getting namespace from kubeconfig: %s", err)
-	}
-
+func (r *Reconciler) AttachWatches(controller controller.Controller, ns string) error {
 	// only reconcile on the KC's config
 	p := predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return o.GetNamespace() == namespace && o.GetName() == kcConfigName
+		return o.GetNamespace() == ns && o.GetName() == kcConfigName
 	})
 
-	err = controller.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, p)
+	err := controller.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, p)
 	if err != nil {
 		return fmt.Errorf("Watching Configmaps: %s", err)
 	}

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -65,13 +65,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	kcConfig, err := GetConfig(r.coreClient)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("getting kapp-controller config: %s", err)
+		log.Error(err, "getting kapp-controller config")
+		return reconcile.Result{}, nil // no re-queue
 	}
 
 	log.Info("Applying new config")
 	err = kcConfig.Apply()
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("Applying configuration: %s", err)
+		log.Error(err, "applying kapp-controller config")
+		return reconcile.Result{}, nil // no re-queue
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-// Reconciler is responsible for reconciling Apps.
+// Reconciler is responsible for reconciling Kapp-controllers config.
 type Reconciler struct {
 	coreClient kubernetes.Interface
 	log        logr.Logger
@@ -31,11 +31,11 @@ func NewReconciler(coreClient kubernetes.Interface, log logr.Logger) *Reconciler
 
 var _ reconcile.Reconciler = &Reconciler{}
 
-// AttachWatches configures watches needed for reconciler to reconcile Apps.
+// AttachWatches configures watches needed for reconciler to reconcile the kapp-controller Config.
 func (r *Reconciler) AttachWatches(controller controller.Controller) error {
 	// only reconcile on the KC's config
 	p := predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return o.GetName() == kcConfigName
+		return o.GetNamespace() == "kapp-controller" && o.GetName() == kcConfigName
 	})
 
 	err := controller.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, p)
@@ -51,7 +51,7 @@ func (r *Reconciler) AttachWatches(controller controller.Controller) error {
 	return nil
 }
 
-// nolint: revive
+// Reconcile gets the current config from the cluster and applies any changes.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := r.log.WithValues("request", request)
 

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -10,8 +10,8 @@ import (
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -33,11 +33,10 @@ var _ reconcile.Reconciler = &Reconciler{}
 
 // AttachWatches configures watches needed for reconciler to reconcile Apps.
 func (r *Reconciler) AttachWatches(controller controller.Controller) error {
-	p := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectOld.GetName() == "kapp-controller-config"
-		},
-	}
+	// only reconcile on the KC's config
+	p := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == kcConfigName
+	})
 
 	err := controller.Watch(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, p)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #179

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

See [this comment](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/179#issuecomment-1078230688) for some concerns and questions before I implemented this feature

- I had a really hard time trying to test this. The reconciler is fairly dumb, so that felt unnecessary. And the config change I wanted an e2e test, but `kubectl exec` was failing from the test suite - always with errors like 

`Running 'kubectl exec -n kapp-controller deployment/kapp-controller -- bash -c ls'...
OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: exec: "bash -c ls": executable file not found in $PATH: unknown
`

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
