### PR TITLE
Add bash completion command

### DIFF
--- a/cli/pkg/kctrl/cmd/completion.go
+++ b/cli/pkg/kctrl/cmd/completion.go
@@ -32,7 +32,7 @@ func NewCmdCompletion() *cobra.Command {
   source <(kctrl completion zsh)
 
   # zsh on osx / oh-my-zsh
-  kctrl completion zsh > "${fpath[1]}/kctrl"
+  kctrl completion zsh > "${fpath[1]}/_kctrl"
 
   # fish:
   kctrl completion fish | source

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -85,6 +85,8 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 
 	ConfigureGlobalFlags(o, cmd, flagsFactory, pkgOpts.PositionalArgs)
 
+	cmd.AddCommand(NewCmdCompletion())
+
 	return cmd
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add bash completion to kctrl

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #586 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
kctrl now provides auto completion capabilities for bash, zsh and fish.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
