### PR TITLE
Fix for spurious errors from the v2 golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,15 +18,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v3
         with:
-          go-version: "1.17.6"
+          go-version: "1.17"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.41.1
+          version: v1.45.2
           args: -v


### PR DESCRIPTION
Fixes failures like in https://github.com/vmware-tanzu/carvel-kapp-controller/runs/5851714201

ytt had the same problem, fixed in https://github.com/vmware-tanzu/carvel-ytt/commit/4a72c9bc0a7468dc88c17ff413722eb7a6770f5a