### PR TITLE
Add reftrackers for cue ValuesFrom references

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -181,6 +181,13 @@ func (a *App) SecretRefs() map[reftracker.RefKey]struct{} {
 					secrets[refKey] = struct{}{}
 				}
 			}
+		case tpl.Cue != nil && tpl.Cue.ValuesFrom != nil:
+			for _, valsFrom := range tpl.Cue.ValuesFrom {
+				if valsFrom.SecretRef != nil {
+					refKey := reftracker.NewSecretKey(valsFrom.SecretRef.Name, a.app.Namespace)
+					secrets[refKey] = struct{}{}
+				}
+			}
 		default:
 		}
 	}
@@ -226,6 +233,13 @@ func (a *App) ConfigMapRefs() map[reftracker.RefKey]struct{} {
 			}
 		case tpl.HelmTemplate != nil && tpl.HelmTemplate.ValuesFrom != nil:
 			for _, valsFrom := range tpl.HelmTemplate.ValuesFrom {
+				if valsFrom.ConfigMapRef != nil {
+					refKey := reftracker.NewConfigMapKey(valsFrom.ConfigMapRef.Name, a.app.Namespace)
+					configMaps[refKey] = struct{}{}
+				}
+			}
+		case tpl.Cue != nil && tpl.Cue.ValuesFrom != nil:
+			for _, valsFrom := range tpl.Cue.ValuesFrom {
 				if valsFrom.ConfigMapRef != nil {
 					refKey := reftracker.NewConfigMapKey(valsFrom.ConfigMapRef.Name, a.app.Namespace)
 					configMaps[refKey] = struct{}{}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds refTrackers to ConfigMaps and Secrets that are referenced by Cue templating steps

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Fixed a bug where Cue-templated apps would not reconcile when their referenced values changed
```
