### PR TITLE
Remove resources from the "all" category

### DIFF
--- a/config/crds.yml
+++ b/config/crds.yml
@@ -593,7 +593,6 @@ spec:
   group: kappctrl.k14s.io
   names:
     categories:
-    - all
     - carvel
     kind: App
     listKind: AppList
@@ -1177,7 +1176,6 @@ spec:
   group: packaging.carvel.dev
   names:
     categories:
-    - all
     - carvel
     kind: PackageInstall
     listKind: PackageInstallList
@@ -1337,7 +1335,6 @@ spec:
   group: packaging.carvel.dev
   names:
     categories:
-    - all
     - carvel
     kind: PackageRepository
     listKind: PackageRepositoryList

--- a/pkg/apis/kappctrl/v1alpha1/types.go
+++ b/pkg/apis/kappctrl/v1alpha1/types.go
@@ -10,7 +10,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={all,carvel}
+// +kubebuilder:resource:categories={carvel}
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 // +kubebuilder:printcolumn:name=Since-Deploy,JSONPath=.status.deploy.startedAt,description=Last time app started being deployed. Does not mean anything was changed.,type=date
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date

--- a/pkg/apis/packaging/v1alpha1/package_install.go
+++ b/pkg/apis/packaging/v1alpha1/package_install.go
@@ -12,7 +12,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=pkgi,categories={all,carvel}
+// +kubebuilder:resource:shortName=pkgi,categories={carvel}
 // +kubebuilder:printcolumn:name=Package name,JSONPath=.spec.packageRef.refName,description=PackageMetadata name,type=string
 // +kubebuilder:printcolumn:name=Package version,JSONPath=.status.version,description=PackageMetadata version,type=string
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string

--- a/pkg/apis/packaging/v1alpha1/package_repository.go
+++ b/pkg/apis/packaging/v1alpha1/package_repository.go
@@ -11,7 +11,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=pkgr,categories={all,carvel}
+// +kubebuilder:resource:shortName=pkgr,categories={carvel}
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 // A package repository is a collection of packages and their metadata.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Remove resources from the "all" category

This causes noise from kubectl when users do not have rbac permissions to
view these resources

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #605

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Resources will no longer show up as part of the "all" category (kubectl get all)
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
