### PR TITLE
Fix test-gh checkout action

### DIFF
--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: "1.17.6"
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
     - name: Install Carvel Tools
       run: ./hack/install-deps.sh
     - name: Run Tests


### PR DESCRIPTION
Didn't realize that our tests require git tags, the update to v3 of this action seems to not fetch tags by default