### PR TITLE
Revert "Bump actions/checkout from 2 to 3"

### DIFF
--- a/.github/workflows/dependency-updater.yml
+++ b/.github/workflows/dependency-updater.yml
@@ -13,7 +13,7 @@ jobs:
         tool: ['ytt', 'kapp', 'kbld', 'imgpkg', 'vendir']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Get Current Release Version

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "1.17"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
       - name: golangci-lint

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: misspell
         uses: reviewdog/action-misspell@3347037502cd60235723196fe0084fd1c11ff33a # v1.1.0
         with:

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1
 
       - name: Install Carvel Tools
         uses: vmware-tanzu/carvel-setup-action@v1

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: "1.17.6"
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v1
     - name: Install Carvel Tools
       run: ./hack/install-deps.sh
     - name: Run Tests

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: "1.17"
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v1
     - name: Install Carvel Tools
       uses: vmware-tanzu/carvel-setup-action@v1
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -58,7 +58,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Set up Go 1.x

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: "1.17.6"
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1
       - name: Install Carvel Tools
         run: ./hack/install-deps.sh
       - name: Run Upgrade Test


### PR DESCRIPTION
Reverts vmware-tanzu/carvel-kapp-controller#613

It's breaking our test-gh workflow