### PR TITLE
pkgr benchmark test

### DIFF
--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
 
 # see https://github.com/benchmark-action/github-action-benchmark
 jobs:
@@ -54,3 +63,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
+      - name: store benchmark into github pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'go'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub pages branch automatically
+          auto-push: true

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -1,0 +1,41 @@
+name: benchmarks
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+# see https://github.com/benchmark-action/github-action-benchmark
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+      # Run benchmark with `go test -bench` and stores the output to a file
+      - name: Run benchmark
+        run: go test ./test/bench/... -bench. | tee output.txt
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.txt came from
+          tool: 'go'
+          # Where the output from the benchmark tool is stored
+          output-file-path: output.txt
+          # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Enable alert commit comment
+          comment-on-alert: true

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -50,6 +50,7 @@ jobs:
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
+        if: github.ref == 'refs/heads/develop'
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 # see https://github.com/benchmark-action/github-action-benchmark
@@ -15,10 +13,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v1 # default version of go is 1.10
+        with:
+          go-version: "1.17.6"
+      - name: Install Carvel Tools
+        run: ./hack/install-deps.sh
       # Run benchmark with `go test -bench` and stores the output to a file
-      - name: Run benchmark
-        run: go test ./test/bench/... -bench. | tee output.txt
+      - name: Setup k8s and Run benchmark
+        run: |
+          set -e -x
+          mkdir /tmp/bin
+          export PATH=/tmp/bin:$PATH
+          curl -sLo /tmp/bin/minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
+          chmod +x /tmp/bin/minikube
+          minikube start --driver=docker
+          eval $(minikube docker-env --shell=bash)
+
+          ./hack/deploy-test.sh
+
+          go test ./test/bench/... -bench=. | tee output.txt
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@v1

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -48,7 +48,7 @@ jobs:
           output-file-path: output.txt
           # Where the previous data file is stored
           external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
+          alert-threshold: '125%'
           fail-on-alert: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -50,7 +50,7 @@ jobs:
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@3d3bca03e83647895ef4f911fa57de3c7a391aaf
-        # if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/develop'
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'
@@ -67,7 +67,7 @@ jobs:
       # I don't fully understand but the two storage options are mutually exclusive if they're in the same block
       - name: Store Result into Github Pages
         uses: benchmark-action/github-action-benchmark@3d3bca03e83647895ef4f911fa57de3c7a391aaf
-        # if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/develop'
         with:
           tool: 'go'
           output-file-path: output.txt

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -64,5 +64,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
+      # I don't fully understand but the two storage options are mutually exclusive if they're in the same block
+      - name: Store Result into Github Pages
+        uses: benchmark-action/github-action-benchmark@v1
+        if: github.ref == 'refs/heads/develop'
+        with:
+          tool: 'go'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -63,8 +63,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
-      - name: store benchmark into github pages
+      - name: Store benchmark into github pages
         uses: benchmark-action/github-action-benchmark@v1
+        if: github.ref == 'refs/heads/develop'
         with:
           tool: 'go'
           output-file-path: output.txt

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 # see https://github.com/benchmark-action/github-action-benchmark

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -63,12 +63,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
-      - name: Store benchmark into github pages
-        uses: benchmark-action/github-action-benchmark@v1
-        if: github.ref == 'refs/heads/develop'
-        with:
-          tool: 'go'
-          output-file-path: output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true

--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -49,8 +49,8 @@ jobs:
           key: ${{ runner.os }}-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        if: github.ref == 'refs/heads/develop'
+        uses: benchmark-action/github-action-benchmark@3d3bca03e83647895ef4f911fa57de3c7a391aaf
+        # if: github.ref == 'refs/heads/develop'
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'
@@ -66,8 +66,8 @@ jobs:
           comment-on-alert: true
       # I don't fully understand but the two storage options are mutually exclusive if they're in the same block
       - name: Store Result into Github Pages
-        uses: benchmark-action/github-action-benchmark@v1
-        if: github.ref == 'refs/heads/develop'
+        uses: benchmark-action/github-action-benchmark@3d3bca03e83647895ef4f911fa57de3c7a391aaf
+        # if: github.ref == 'refs/heads/develop'
         with:
           tool: 'go'
           output-file-path: output.txt

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -88,6 +88,15 @@ The `hack/test-e2e.sh` script (also run by `test-all`) will tee its output
 to both your stdout and the (gitignored) file `tmp/e2eoutput.txt` so that you
 can more easily grep/search/parse the output.
 
+#### Benchmark Testing
+
+Benchmark tests are run via github action. They can also be run locally via go
+toolchain `go test ./test/bench/... -bench=.`
+
+Benchmarks run on develop branch are
+graphed in [github
+pages](https://vmware-tanzu.github.io/carvel-kapp-controller/dev/bench/index.html).
+
 ### Profiling
 1.) Enable profiling by editing config/values.yaml and setting `dangerous_enable_pprof`
 to true

--- a/test/bench/pkgr_test.go
+++ b/test/bench/pkgr_test.go
@@ -1,0 +1,101 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package bench
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Benchmark_pkgr_with_500_packages(b *testing.B) {
+	runWithPkgsAndVersions(b, 100, 5)
+}
+
+func Benchmark_pkgr_with_100_packages(b *testing.B) {
+	runWithPkgsAndVersions(b, 50, 2)
+}
+
+func Benchmark_pkgr_with_50_packages(b *testing.B) {
+	runWithPkgsAndVersions(b, 50, 1)
+}
+
+func runWithPkgsAndVersions(b *testing.B, numPackages int, numVersionsPerPackage int) {
+	pkgrFileName := writePkgr(b, numPackages, numVersionsPerPackage)
+	defer os.Remove(pkgrFileName)
+
+	cleanup := func() {
+		cmd := exec.Command("kapp", "delete", "-a", appName(pkgrFileName), "-y")
+		cmd.Run()
+	}
+	cleanup()
+	defer cleanup()
+
+	for n := 0; n < b.N; n++ {
+		deployAndDeletePkgr(b, pkgrFileName)
+	}
+}
+
+// given a file name like "repo-500.yaml" returns "repo-500"
+func appName(fileName string) string {
+	return fileName[:len(fileName)-5]
+}
+
+func deployAndDeletePkgr(b *testing.B, pkgrFileName string) {
+	cmd := exec.Command("kapp", "deploy", "-f", pkgrFileName, "-a", appName(pkgrFileName), "-y")
+	output, err := cmd.Output()
+	require.NoError(b, err, string(output))
+
+	cmd = exec.Command("kapp", "delete", "-a", appName(pkgrFileName), "-y")
+	output, err = cmd.Output()
+	require.NoError(b, err, string(output))
+}
+
+func writePkgr(b *testing.B, numPackages int, numVersions int) string {
+	totalPackages := numPackages * numVersions
+
+	preamble := fmt.Sprintf(`
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: minimal-repo-%d.tanzu.carvel.dev
+  namespace: kapp-controller-packaging-global
+  annotations:
+    kapp.k14s.io/disable-original: ""
+spec:
+  fetch:
+    inline:
+      paths:
+`, totalPackages)
+
+	pkgStr := `
+        packages/pkg.test.carvel.dev/pkg%[1]d.test.carvel.dev.0.%[2]d.0.yml: |
+          ---
+          apiVersion: data.packaging.carvel.dev/v1alpha1
+          kind: Package
+          metadata:
+            name: pkg%[1]d.test.carvel.dev.0.%[2]d.0
+          spec:
+            refName: pkg%[1]d.test.carvel.dev
+            version: 0.%[2]d.0
+            template:
+              spec: {}
+`
+	fname := fmt.Sprintf("pkgr-%d.yaml", totalPackages)
+	f, err := os.Create(fname)
+	require.NoError(b, err)
+	defer f.Close()
+
+	f.WriteString(preamble)
+	for i := 0; i < numPackages; i++ {
+		for j := 0; j < numVersions; j++ {
+			_, err := f.WriteString(fmt.Sprintf(pkgStr, i, j))
+			require.NoError(b, err)
+		}
+	}
+	return fname
+}


### PR DESCRIPTION

#### What this PR does / why we need it:

- introduces benchmarking test suite
- introduces [benchmark action ](https://github.com/vmware-tanzu/carvel-kapp-controller/runs/6056404533?check_suite_focus=true) 
  - to run on changes to develop branch or manual trigger.
  - action has the ability to alert if we increase the benchmarked metrics by X (200% by default)

*open questions* : 
- the github action has the ability to write a[ timeseries graph of the metrics to github pages](https://github.com/benchmark-action/github-action-benchmark#charts-on-github-pages-1) which imo is the best reason for using it,  but are we cool with enabling github pages and letting it do its thing?
- the benchmarks default failure is if a single run drifts by 200% -- imo we should tighten that to more like 150% or even 130% but it might take a couple failures to learn how much variability we get naturally - any opinions?

#### Which issue(s) this PR fixes:

This is related to the "layering" tract of work - I thought it'd be cool to introduce a benchmark suite and then we can see the impact of other work on the benchmarks as they get merged.
