### PR TITLE
apiserver: custom QPS and Burst to allow high throughput of packages

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -100,7 +100,15 @@ func Run(opts Options, runLog logr.Logger) error {
 		return fmt.Errorf("Expected to find %s env var", kappctrlAPIPORTEnvKey)
 	}
 
-	server, err := apiserver.NewAPIServer(restConfig, coreClient, kcClient, apiserver.NewAPIServerOpts{
+	// to facilitate creation of many packages at once from a larger PKGR
+	pkgRestConfig := config.GetConfigOrDie()
+	pkgRestConfig.QPS = 100
+	pkgRestConfig.Burst = 100
+	pkgKcClient, err := kcclient.NewForConfig(pkgRestConfig)
+	if err != nil {
+		return fmt.Errorf("Building pkg kappctrl client: %s", err)
+	}
+	server, err := apiserver.NewAPIServer(pkgRestConfig, coreClient, pkgKcClient, apiserver.NewAPIServerOpts{
 		GlobalNamespace:              opts.PackagingGloablNS,
 		BindPort:                     bindPort,
 		EnableAPIPriorityAndFairness: opts.APIPriorityAndFairness,

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -102,8 +102,8 @@ func Run(opts Options, runLog logr.Logger) error {
 
 	// to facilitate creation of many packages at once from a larger PKGR
 	pkgRestConfig := config.GetConfigOrDie()
-	pkgRestConfig.QPS = 100
-	pkgRestConfig.Burst = 100
+	pkgRestConfig.QPS = 60
+	pkgRestConfig.Burst = 90
 	pkgKcClient, err := kcclient.NewForConfig(pkgRestConfig)
 	if err != nil {
 		return fmt.Errorf("Building pkg kappctrl client: %s", err)

--- a/test/bench/pkgr_test.go
+++ b/test/bench/pkgr_test.go
@@ -17,8 +17,8 @@ import (
 // we'll assert against these thresholds below; maps represent "for x packages, what's the max allowed seconds to deploy or delete"?
 // thresholds set by observing runs locally, rounding, multiplying by 1.25, and rounding:
 var (
-	deploySecondsForPackageCount = map[int]float64{50: 7, 100: 11, 500: 39}
-	deleteSecondsForPackageCount = map[int]float64{50: 13, 100: 20, 500: 81}
+	deploySecondsForPackageCount = map[int]float64{50: 5, 100: 7, 500: 22.5}
+	deleteSecondsForPackageCount = map[int]float64{50: 7, 100: 8, 500: 25}
 )
 
 func Benchmark_pkgr_with_500_packages(b *testing.B) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

Benchmarks on current develop (sidescroll to see all metrics):
```
Benchmark_pkgr_with_500_packages-2   	       1	94443823631 ns/op	        63.52 DeleteSeconds	        30.88 DeploySeconds
Benchmark_pkgr_with_100_packages-2   	       1	23855612927 ns/op	        15.56 DeleteSeconds	         8.249 DeploySeconds
Benchmark_pkgr_with_50_packages-2    	       1	14642181389 ns/op	         9.423 DeleteSeconds	         5.172 DeploySeconds
```

configuring high QPS and Burst only for packages gives us:
Benchmark run on this branch:
```
Benchmark_pkgr_with_500_packages-2   	       1	36399893748 ns/op	        18.88 DeleteSeconds	        17.48 DeploySeconds
Benchmark_pkgr_with_100_packages-2   	       1	9438283825 ns/op	         5.262 DeleteSeconds	         4.143 DeploySeconds
Benchmark_pkgr_with_50_packages-2    	       1	6437118537 ns/op	         4.277 DeleteSeconds	         2.126 DeploySeconds
```

Note that we also previously tested this change on GKE.  Ran with slightly different PKGR sizes, but similar results:

kapp controller 34 on GKE:

- pkgr w. 200 packages:  15 DeploySeconds   34 DeleteSeconds
- pkgr w. 1000 packages: 65 DeploySeconds.  132 DeleteSeconds

kc 0.34 plus these changes, on GKE: 

- pkgr w. 200 packages:  10 DeploySeconds   15 DeleteSeconds
- pkgr w. 1000 packages: 38 DeploySeconds.  43 DeleteSeconds

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
PackageRepositories, especially those with hundreds of packages, now reconcile faster
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
