### PR TITLE
Build / download deps in golang image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
#### What this PR does / why we need it:
Switches our build step to use [library/golang](https://hub.docker.com/_/golang) instead of Photon.
 
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #644

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```
