### PR TITLE
Add arm64 builds

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Run release script
         run: |
           set -e -x
+          minikube start --driver=docker --wait=all
+          docker buildx create minikube --use --driver=kubernetes --bootstrap
           ./hack/build-release.sh
           cd cli
           ./hack/build-binaries.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN go run ./hack/dependencies.go install -d out --arch ${TARGETARCH} --os ${TAR
 # kapp-controller
 COPY . .
 # helpful ldflags reference: https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
-RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOSARCH=${TARGETARCH} go build -mod=vendor -ldflags="-X 'main.Version=$KCTRL_VER'" -trimpath -o out/kapp-controller ./cmd/controller
-RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOSARCH=${TARGETARCH} go build -mod=vendor -ldflags="-X 'main.Version=$KCTRL_VER'" -trimpath -o out/kapp-controller-sidecarexec ./cmd/sidecarexec
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOSARCH=${TARGETARCH} go build -mod=vendor -ldflags="-X 'main.Version=$KCTRL_VER'" -trimpath -o out/kapp-controller ./cmd/controller
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOSARCH=${TARGETARCH} go build -mod=vendor -ldflags="-X 'main.Version=$KCTRL_VER'" -trimpath -o out/kapp-controller-sidecarexec ./cmd/sidecarexec
 
 # --- run image ---
 FROM photon:4.0

--- a/config-release/values.yml
+++ b/config-release/values.yml
@@ -3,3 +3,4 @@
 push_images: true
 image_cache: false
 image_repo: ghcr.io/vmware-tanzu/carvel-kapp-controller
+platform: "linux/amd64,linux/arm64"

--- a/config/build.yml
+++ b/config/build.yml
@@ -5,14 +5,17 @@ kind: Sources
 sources:
 - image: kapp-controller
   path: .
-  #@ if/end not data.values.image_cache:
   docker:
-    build:
-      #! Always rebuild image
+    buildx:
       pull: true
-      noCache: true
+      noCache: #@ not data.values.image_cache
       #! pass kapp_controller_version into Dockerfile.
-      rawOptions: #@ ["--build-arg", "KCTRL_VER="+data.values.kapp_controller_version]
+      rawOptions:
+      - #@ "--build-arg=KCTRL_VER="+data.values.kapp_controller_version
+      #@ if/end data.values.push_secret != "":
+      - #@ "--registry-secret="+data.values.push_secret
+      #@ if/end data.values.platform != "":
+      - #@ "--platform="+data.values.platform
 
 #@ if/end data.values.push_images:
 ---

--- a/config/build.yml
+++ b/config/build.yml
@@ -12,8 +12,6 @@ sources:
       #! pass kapp_controller_version into Dockerfile.
       rawOptions:
       - #@ "--build-arg=KCTRL_VER="+data.values.kapp_controller_version
-      #@ if/end data.values.push_secret != "":
-      - #@ "--registry-secret="+data.values.push_secret
       #@ if/end data.values.platform != "":
       - #@ "--platform="+data.values.platform
 

--- a/config/values.yml
+++ b/config/values.yml
@@ -12,7 +12,6 @@ dangerous_enable_pprof: false
 push_images: false
 image_cache: true
 image_repo: docker.io/k14stest/kapp-controller-test
-push_secret: ""
 platform: ""
 
 api_port: 10350

--- a/config/values.yml
+++ b/config/values.yml
@@ -12,6 +12,8 @@ dangerous_enable_pprof: false
 push_images: false
 image_cache: true
 image_repo: docker.io/k14stest/kapp-controller-test
+push_secret: ""
+platform: ""
 
 api_port: 10350
 kapp_controller_version: "develop"

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -7,7 +7,7 @@ mkdir -p tmp/
 # makes the get_kappctrl_ver function available (scrapes version from git tag)
 source $(dirname "$0")/version-util.sh
 
-ytt -f config/ -f config-release -v kapp_controller_version="$(get_kappctrl_ver)" | kbld -f- > ./tmp/release.yml
+ytt -f config/ -f config-release -v kapp_controller_version="$(get_kappctrl_ver)" --data-values-env=KCTRL | kbld -f- > ./tmp/release.yml
 
 shasum -a 256 ./tmp/release*.yml | tee ./tmp/checksums.txt
 

--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -3,6 +3,7 @@
       amd64: c370fab22081b17b780d4ec37fb664edb58fe6f28d635ad4beccbac7997586f9
     linux:
       amd64: 65dbc4f3a4a2ed84296dd1b323e8e7bd77e488fa7540d12dd36cf7fb2fc77c03
+      arm64: 3eaa8fcb3526a2a305a4845196bbffe7e1b0f3ea57fcd90daad94c855139df86
   dev: true
   name: ytt
   repo: vmware-tanzu/carvel-ytt
@@ -13,6 +14,7 @@
       amd64: 5fd3afbe09a66fc9e91252c57448045eeeab1ee3f6d305da6f9885186b744e67
     linux:
       amd64: 67c86ece94a3747b2e011a5b72044b69f2594ca807621b1e1e4c805f6abcaeef
+      arm64: 658725c5dab5349dd4cb826ff9278749f093ed2275aadf51dc994265e6599b2c
   dev: true
   name: kbld
   repo: vmware-tanzu/carvel-kbld
@@ -23,6 +25,7 @@
       amd64: 51e209f903b17c9e330151c41c6d507bfabccfdaa56dd8fdaa1c0f39ed2240e9
     linux:
       amd64: dec5040d90478fdf0af3c1548d46f9ded642f156245bba83fe99171c8461e4f7
+      arm64: e2047147c4bc00d8fcf9a5f01bdefc9fdf0aa5de9582357f03e54d4cd9fc0d75
   dev: true
   name: kapp
   repo: vmware-tanzu/carvel-kapp
@@ -33,6 +36,7 @@
       amd64: b8462c9b2b9c060e1a81c206ea9810937bf7357ae2ee150f94ec8635dff1d612
     linux:
       amd64: c7190adcb8445480e4e457c899aecdf7ca98606c625493b904c0eb2ab721ce19
+      arm64: 415120c4ede6ff1456feae6b980319998c0a3fc2128bbac1946ba98ce4d07aaf
   dev: true
   name: imgpkg
   repo: vmware-tanzu/carvel-imgpkg
@@ -43,6 +47,7 @@
       amd64: c26547097d67f21e129a25557d9d36c7c0e109afe130adff63d3c83ce9459ecc
     linux:
       amd64: 1aa12d070f2e91fcb0f4d138704c5061075b0821e6f943f5a39676d7a4709142
+      arm64: 015977ae54d85bf2366d7affb0d582fecf79737f0eb80fa8a66de9f66e877b61
   dev: true
   name: vendir
   repo: vmware-tanzu/carvel-vendir
@@ -51,6 +56,7 @@
 - checksums:
     linux:
       amd64: 1484ffb0c7a608d8069470f48b88d729e88c41a1b6602f145231e8ea7b43b50a
+      arm64: 5c0aa709c5aaeedd190907d70f9012052c1eea7dff94bffe941b879a33873947
   dev: false
   name: helm
   repo: helm/helm
@@ -60,6 +66,7 @@
 - checksums:
     linux:
       amd64: 53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb
+      arm64: 4945313ed0dfddba52a12ab460d750c91ead725d734039493da0285ad6c5f032
   dev: false
   name: sops
   repo: mozilla/sops
@@ -68,6 +75,7 @@
 - checksums:
     linux:
       amd64: 6414f71ce947fbbea1314f6e9786c5d48436ebc76c3fd6167bf018e432b3b669
+      arm64: 6c82aa1d406e5a401ec3bb344cd406626478be74d5ae628f192d907cd78af981
   dev: false
   name: age
   repo: FiloSottile/age
@@ -77,6 +85,7 @@
 - checksums:
     linux:
       amd64: 5e7ecb614b5926acfc36eb1258800391ab7c6e6e026fa7cacbfe92006bac895c
+      arm64: a8c3f4140d18c324cc69f5de4df0566e529e1636cff340095a42475799bf3fed
   dev: false
   name: cue
   repo: cue-lang/cue


### PR DESCRIPTION
#### What this PR does / why we need it:
- Switch to using [docker buildx](https://docs.docker.com/buildx/working-with-buildx) for building through kbld for multi-arch support
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #573

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Adds support for arm64 in the kapp-controller image
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
