### PR TITLE
Add `--values` to `kctrl package installed update`

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -722,11 +722,10 @@ func (o *CreateOrUpdateOptions) updateDataValuesSecret(client kubernetes.Interfa
 	if err != nil {
 		return fmt.Errorf("Reading data values file '%s': %s", o.valuesFile, err.Error())
 	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: o.NamespaceFlags.Name}, Data: dataValues,
-	}
 
-	_, err = client.CoreV1().Secrets(o.NamespaceFlags.Name).Update(context.Background(), secret, metav1.UpdateOptions{})
+	updatedSecret := createdSecret.DeepCopy()
+	updatedSecret.Data = dataValues
+	_, err = client.CoreV1().Secrets(o.NamespaceFlags.Name).Update(context.Background(), updatedSecret, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("Updating Secret resource: %s", err.Error())
 	}

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -732,9 +732,8 @@ func (o *CreateOrUpdateOptions) updateDataValuesSecret(client kubernetes.Interfa
 		return fmt.Errorf("Reading data values file '%s': %s", o.valuesFile, err.Error())
 	}
 
-	updatedSecret := createdSecret.DeepCopy()
-	updatedSecret.Data = dataValues
-	_, err = client.CoreV1().Secrets(o.NamespaceFlags.Name).Update(context.Background(), updatedSecret, metav1.UpdateOptions{})
+	createdSecret.Data = dataValues
+	_, err = client.CoreV1().Secrets(o.NamespaceFlags.Name).Update(context.Background(), createdSecret, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("Updating Secret resource: %s", err.Error())
 	}

--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -68,8 +68,6 @@ spec:
 
 	yaml := packageMetadata + "\n" + packageCR1 + "\n" + packageCR2
 
-	//TODO: Add test with data values. Let --values-file
-
 	cleanUp := func() {
 		// TODO: Check for error while uninstalling in cleanup?
 		kappCtrl.Run([]string{"package", "installed", "delete", "--package-install", pkgiName})

--- a/cli/test/e2e/pkgi_values_test.go
+++ b/cli/test/e2e/pkgi_values_test.go
@@ -1,0 +1,120 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageInstallValues(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	appName := "test-package-name"
+	pkgiName := "testpkgi"
+	packageMetadataName := "test-pkg.carvel.dev"
+	packageVersion := "1.0.0"
+
+	packageMetadata := fmt.Sprintf(`---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: %s
+spec:
+  displayName: "Carvel Test Package"
+  shortDescription: "Carvel package for testing installation"`, packageMetadataName)
+
+	packageCR := `---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: test-pkg.carvel.dev.1.0.0
+spec:
+  refName: test-pkg.carvel.dev
+  version: 1.0.0
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: k8slt/kctrl-example-pkg:v1.0.0
+      template:
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - "-"
+          - ".imgpkg/images.yml"
+      deploy:
+      - kapp: {}`
+
+	valuesFile := `
+---
+foo: bar
+`
+
+	yaml := packageMetadata + "\n" + packageCR
+
+	cleanUp := func() {
+		// TODO: Check for error while uninstalling in cleanup?
+		kappCtrl.Run([]string{"package", "installed", "delete", "--package-install", pkgiName})
+		kapp.Run([]string{"delete", "-a", appName})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("Adding test package", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-a", appName, "-f", "-"}, RunOpts{
+			StdinReader: strings.NewReader(yaml), AllowError: true,
+		})
+		require.NoError(t, err)
+	})
+
+	logger.Section("Installing test package with values config", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "create", "--package-install", pkgiName, "-p", packageMetadataName,
+			"--version", packageVersion, "--values-file", "-"}, RunOpts{StdinReader: strings.NewReader(valuesFile)})
+		require.NoError(t, err)
+
+		// Check for owned value secret
+		secretName := fmt.Sprintf("%s-%s-values", pkgiName, env.Namespace)
+		out, err := kubectl.RunWithOpts([]string{"get", "secret", secretName, "-o", "yaml"}, RunOpts{})
+		require.NoError(t, err)
+		require.Contains(t, out, pkgiName+"-"+"kctrl-test")
+
+		// Check for reference to values secret
+		out, err = kubectl.RunWithOpts([]string{"get", "pkgi", pkgiName, "-o", "yaml"}, RunOpts{})
+		require.NoError(t, err)
+		require.Contains(t, out, secretName)
+	})
+
+	logger.Section("Dropping consumed values file", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--drop-values-file"}, RunOpts{})
+		require.NoError(t, err)
+
+		// Check for owned value secret
+		secretName := fmt.Sprintf("%s-%s-values", pkgiName, env.Namespace)
+		_, err = kubectl.RunWithOpts([]string{"get", "secret", secretName, "-o", "yaml"}, RunOpts{AllowError: true})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "NotFound")
+
+		// Check for reference to values secret
+		out, err := kubectl.RunWithOpts([]string{"get", "pkgi", pkgiName, "-o", "yaml"}, RunOpts{})
+		require.NoError(t, err)
+		require.NotContains(t, out, secretName)
+	})
+
+	// Check for successful deletion post dropping values file. kctrl should not try to delete secret
+	logger.Section("package install delete", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "delete", "--package-install", pkgiName}, RunOpts{})
+		require.NoError(t, err)
+	})
+}

--- a/cli/test/e2e/pkgi_values_test.go
+++ b/cli/test/e2e/pkgi_values_test.go
@@ -111,7 +111,7 @@ foo: bar
 	})
 
 	logger.Section("Dropping consumed values file", func() {
-		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--drop-values-file"}, RunOpts{})
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--with-values=false"}, RunOpts{})
 		require.NoError(t, err)
 
 		// Check for owned value secret

--- a/cli/test/e2e/pkgi_values_test.go
+++ b/cli/test/e2e/pkgi_values_test.go
@@ -96,6 +96,20 @@ foo: bar
 		require.Contains(t, out, secretName)
 	})
 
+	// TODO: Add check for ensuring that we wait for reconciliation when secrets are updated
+	// When https://github.com/vmware-tanzu/carvel-kapp-controller/issues/670 is resolved
+
+	logger.Section("Updating values config for test package", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--values-file", "-"}, RunOpts{StdinReader: strings.NewReader(valuesFile)})
+		require.NoError(t, err)
+
+		// Check that ownership annotations are intact
+		secretName := fmt.Sprintf("%s-%s-values", pkgiName, env.Namespace)
+		out, err := kubectl.RunWithOpts([]string{"get", "secret", secretName, "-o", "yaml"}, RunOpts{})
+		require.NoError(t, err)
+		require.Contains(t, out, pkgiName+"-"+"kctrl-test")
+	})
+
 	logger.Section("Dropping consumed values file", func() {
 		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--drop-values-file"}, RunOpts{})
 		require.NoError(t, err)

--- a/cli/test/e2e/pkgi_values_test.go
+++ b/cli/test/e2e/pkgi_values_test.go
@@ -111,7 +111,7 @@ foo: bar
 	})
 
 	logger.Section("Dropping consumed values file", func() {
-		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--with-values=false"}, RunOpts{})
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName, "--values=false"}, RunOpts{})
 		require.NoError(t, err)
 
 		// Check for owned value secret


### PR DESCRIPTION
#### What this PR does / why we need it:
This flag allows users to drop values secrets being consumed by a package and remove it's references in a package installation while updating it. 
PR also fixes value secret updates clobbering ownership annotations.

#### Which issue(s) this PR fixes:
Fixes #675 

#### Does this PR introduce a user-facing change?
```release-note
`--values` can be used to drop values secret being consumed by package install, when no value is provided via `--values-file`
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change
