### PR TITLE
kctrl: Remove `install` option in package installed update command

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -257,6 +257,14 @@ func (o *CreateOrUpdateOptions) RunUpdate(args []string) error {
 		o.Name = args[0]
 	}
 
+	if len(o.Name) == 0 {
+		return fmt.Errorf("Expected package install to be non-empty")
+	}
+
+	if len(o.version) == 0 && len(o.valuesFile) == 0 {
+		return fmt.Errorf("Expected either package version or values file to update the package")
+	}
+
 	client, err := o.depsFactory.CoreClient()
 	if err != nil {
 		return err

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -162,7 +162,6 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 	cmd.Flags().StringVarP(&o.packageName, "package", "p", "", "Name of package install to be updated")
 	cmd.Flags().StringVar(&o.version, "version", "", "Set package version")
 	cmd.Flags().StringVar(&o.valuesFile, "values-file", "", "The path to the configuration values file, optional")
-	cmd.Flags().BoolVarP(&o.install, "install", "", false, "Install package if the installed package does not exist, optional")
 
 	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
 		AllowDisableWait: true,
@@ -275,20 +274,7 @@ func (o *CreateOrUpdateOptions) RunUpdate(args []string) error {
 		context.Background(), o.Name, metav1.GetOptions{},
 	)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		if !o.install {
-			return fmt.Errorf("Package not installed")
-		}
-		o.statusUI.PrintMessagef("Installing package '%s'", o.Name)
-
-		err = o.create(client, kcClient)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 
 	err = o.update(client, kcClient, pkgInstall)

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -74,7 +74,6 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 		DefaultTimeout:   5 * time.Minute,
 	})
 
-	// For `add` command create option will always be true
 	o.CreateRepository = true
 
 	return cmd
@@ -102,8 +101,6 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 	}
 
 	cmd.Flags().StringVarP(&o.URL, "url", "", "", "OCI registry url for package repository bundle (required)")
-
-	cmd.Flags().BoolVar(&o.CreateRepository, "create", false, "Creates the package repository if it does not exist, optional")
 
 	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
 		AllowDisableWait: true,

--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
 	"github.com/stretchr/testify/require"
@@ -190,6 +191,9 @@ spec:
 			"--package-install", pkgiName,
 		}, RunOpts{})
 		require.NoError(t, err)
+
+		// Sleep for 1 second as it takes time for the underlying app cr to be paused
+		time.Sleep(1 * time.Second)
 
 		out, err := kubectl.RunWithOpts([]string{"get", "app", pkgiName}, RunOpts{})
 		require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Remove `install` option in package installed update command as package installed create can be used to install or update a package)
- Remove `create` option for package repository update as package repository add can be used to create or update a repository.
- Update error messages to be more helpful.

#### Which issue(s) this PR fixes:
<!--
Fixes #678 , #679, #682
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
`package installed update` doesn't support `--install` option. `package installed create` can still be used for installing as well as updating existing package installs.
`package repository update` doesn't support `--create` option. `package repository create` can still be used for adding or updating existing package repositories.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
