### PR TITLE
Ensure that pkgi status tail is picked up after kicking it

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -148,6 +148,11 @@ func (o *PauseOrKickOptions) Kick() error {
 		return err
 	}
 
+	err = o.waitForAppPause(client)
+	if err != nil {
+		return err
+	}
+
 	err = o.unpause(client)
 	if err != nil {
 		return err
@@ -161,6 +166,7 @@ func (o *PauseOrKickOptions) Kick() error {
 }
 
 func (o *PauseOrKickOptions) pause(client kcclient.Interface) error {
+	o.statusUI.PrintMessagef("Pausing reconciliation for package installation '%s' in namespace '%s'", o.Name, o.NamespaceFlags.Name)
 	pausePatch := []map[string]interface{}{
 		{
 			"op":    "add",
@@ -183,6 +189,7 @@ func (o *PauseOrKickOptions) pause(client kcclient.Interface) error {
 }
 
 func (o *PauseOrKickOptions) unpause(client kcclient.Interface) error {
+	o.statusUI.PrintMessagef("Starting reconciliation for package install '%s' in namespace '%s'", o.Name, o.NamespaceFlags.Name)
 	unpausePatch := []map[string]interface{}{
 		{
 			"op":   "remove",
@@ -200,6 +207,25 @@ func (o *PauseOrKickOptions) unpause(client kcclient.Interface) error {
 		return err
 	}
 
+	return nil
+}
+
+func (o *PauseOrKickOptions) waitForAppPause(client kcclient.Interface) error {
+	if err := wait.Poll(o.WaitFlags.CheckInterval, o.WaitFlags.Timeout, func() (done bool, err error) {
+		appResource, err := client.KappctrlV1alpha1().Apps(o.NamespaceFlags.Name).Get(context.Background(), o.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if appResource.Generation != appResource.Status.ObservedGeneration {
+			return false, nil
+		}
+		if appResource.Status.FriendlyDescription == "Canceled/paused" {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("Waiting for app '%s' in namespace '%s' to be paused: %s", o.Name, o.NamespaceFlags.Name, err)
+	}
 	return nil
 }
 

--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -203,16 +203,15 @@ spec:
 
 	logger.Section("package installed kick", func() {
 
-		_, err := kappCtrl.RunWithOpts([]string{
+		out, err := kappCtrl.RunWithOpts([]string{
 			"package", "installed", "kick",
 			"--package-install", pkgiName,
 		}, RunOpts{})
 		require.NoError(t, err)
 
-		out, err := kubectl.RunWithOpts([]string{"get", "app", pkgiName}, RunOpts{})
-		require.NoError(t, err)
-
-		require.Contains(t, out, "Reconcile succeeded")
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "App reconciled")
 	})
 
 	logger.Section("package install delete", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
It ensures that the status tail is picked up by `kctrl` while kicking a package installation.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #661 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Fixes: Package installation status tail not picked up when reconciliation is triggered
```

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
