### PR TITLE
Use UID of ServiceAccount for token cache

### DIFF
--- a/pkg/satoken/token_manager.go
+++ b/pkg/satoken/token_manager.go
@@ -33,6 +33,9 @@ func NewManager(c clientset.Interface, log logr.Logger) *Manager {
 		getToken: func(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
 			return c.CoreV1().ServiceAccounts(namespace).CreateToken(context.TODO(), name, tr, metav1.CreateOptions{})
 		},
+		reviewToken: func(tr *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error) {
+			return c.AuthenticationV1().TokenReviews().Create(context.TODO(), tr, metav1.CreateOptions{})
+		},
 		cache: make(map[string]*authenticationv1.TokenRequest),
 		clock: clock.RealClock{},
 		log:   log,
@@ -49,8 +52,9 @@ type Manager struct {
 	cache      map[string]*authenticationv1.TokenRequest
 
 	// mocked for testing
-	getToken func(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
-	clock    clock.Clock
+	getToken    func(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
+	reviewToken func(tr *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error)
+	clock       clock.Clock
 
 	log logr.Logger
 }
@@ -118,6 +122,16 @@ func (m *Manager) expired(t *authenticationv1.TokenRequest) bool {
 
 // requiresRefresh returns true if the token is older half of it's maxTTL
 func (m *Manager) requiresRefresh(tr *authenticationv1.TokenRequest) bool {
+	review, err := m.reviewToken(&authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{
+			Token: tr.Status.Token,
+		},
+	})
+	if err != nil || !review.Status.Authenticated {
+		m.log.Info("ReviewToken request failed or not authenticated - refresh required", "reviewTokenRequest", review)
+		return true
+	}
+
 	if tr.Spec.ExpirationSeconds == nil {
 		cpy := tr.DeepCopy()
 		cpy.Status.Token = ""

--- a/pkg/satoken/token_manager_test.go
+++ b/pkg/satoken/token_manager_test.go
@@ -20,9 +20,10 @@ import (
 
 func TestTokenCachingAndExpiration(t *testing.T) {
 	type suite struct {
-		clock *testingclock.FakeClock
-		tg    *fakeTokenGetter
-		mgr   *Manager
+		clock    *testingclock.FakeClock
+		tg       *fakeTokenGetter
+		reviewer *fakeTokenReviewer
+		mgr      *Manager
 	}
 
 	type testCase struct {
@@ -92,8 +93,19 @@ func TestTokenCachingAndExpiration(t *testing.T) {
 						},
 					},
 				},
+				reviewer: &fakeTokenReviewer{
+					review: &authenticationv1.TokenReview{
+						Spec: authenticationv1.TokenReviewSpec{
+							Token: "foo",
+						},
+						Status: authenticationv1.TokenReviewStatus{
+							Authenticated: true,
+						},
+					},
+				},
 			}
 			s.mgr.getToken = s.tg.getToken
+			s.mgr.reviewToken = s.reviewer.reviewToken
 			s.mgr.clock = s.clock
 
 			_, err := s.mgr.GetServiceAccountToken("a", "b", getTokenRequest())
@@ -114,6 +126,7 @@ func TestRequiresRefresh(t *testing.T) {
 
 	type testCase struct {
 		now, exp      time.Time
+		authenticated bool
 		expectRefresh bool
 	}
 
@@ -121,21 +134,31 @@ func TestRequiresRefresh(t *testing.T) {
 		{
 			now:           start.Add(1 * time.Minute),
 			exp:           start.Add(maxTTL),
+			authenticated: true,
 			expectRefresh: false,
 		},
 		{
 			now:           start.Add(59 * time.Minute),
 			exp:           start.Add(maxTTL),
+			authenticated: true,
 			expectRefresh: false,
 		},
 		{
 			now:           start.Add(61 * time.Minute),
 			exp:           start.Add(maxTTL),
+			authenticated: true,
 			expectRefresh: true,
 		},
 		{
 			now:           start.Add(3 * time.Hour),
 			exp:           start.Add(maxTTL),
+			authenticated: false,
+			expectRefresh: true,
+		},
+		{
+			now:           start.Add(1 * time.Minute),
+			exp:           start.Add(maxTTL),
+			authenticated: false,
 			expectRefresh: true,
 		},
 	}
@@ -153,8 +176,19 @@ func TestRequiresRefresh(t *testing.T) {
 					ExpirationTimestamp: metav1.Time{Time: c.exp},
 				},
 			}
+			reviewer := &fakeTokenReviewer{
+				review: &authenticationv1.TokenReview{
+					Spec: authenticationv1.TokenReviewSpec{
+						Token: "foo",
+					},
+					Status: authenticationv1.TokenReviewStatus{
+						Authenticated: c.authenticated,
+					},
+				},
+			}
 
 			mgr := NewManager(nil, log)
+			mgr.reviewToken = reviewer.reviewToken
 			mgr.clock = clock
 
 			rr := mgr.requiresRefresh(tr)
@@ -211,6 +245,17 @@ type fakeTokenGetter struct {
 func (ftg *fakeTokenGetter) getToken(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
 	ftg.count++
 	return ftg.tr, ftg.err
+}
+
+type fakeTokenReviewer struct {
+	count  int
+	review *authenticationv1.TokenReview
+	err    error
+}
+
+func (ftr *fakeTokenReviewer) reviewToken(tr *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error) {
+	ftr.count++
+	return ftr.review, ftr.err
 }
 
 func getTokenRequest() *authenticationv1.TokenRequest {

--- a/pkg/satoken/token_manager_test.go
+++ b/pkg/satoken/token_manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testingclock "k8s.io/utils/clock/testing"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,7 +40,7 @@ func TestTokenCachingAndExpiration(t *testing.T) {
 			f: func(t *testing.T, s *suite) {
 				s.clock.SetTime(s.clock.Now())
 
-				_, err := s.mgr.GetServiceAccountToken("a", "b", getTokenRequest())
+				_, err := s.mgr.GetServiceAccountToken(&v1.ServiceAccount{}, getTokenRequest())
 
 				assert.NoErrorf(t, err, "unexpected error getting token")
 				assert.Equal(t, s.tg.count, 1, "expected refresh to not be called, call count was %d", s.tg.count)
@@ -51,7 +52,7 @@ func TestTokenCachingAndExpiration(t *testing.T) {
 			f: func(t *testing.T, s *suite) {
 				s.clock.SetTime(s.clock.Now().Add(time.Hour + time.Minute))
 
-				_, err := s.mgr.GetServiceAccountToken("a", "b", getTokenRequest())
+				_, err := s.mgr.GetServiceAccountToken(&v1.ServiceAccount{}, getTokenRequest())
 
 				assert.NoErrorf(t, err, "unexpected error getting token")
 				assert.Equal(t, s.tg.count, 2, "expected token to be refreshed, call count was %d", s.tg.count)
@@ -66,7 +67,7 @@ func TestTokenCachingAndExpiration(t *testing.T) {
 					err: fmt.Errorf("err"),
 				}
 				s.mgr.getToken = tg.getToken
-				tr, err := s.mgr.GetServiceAccountToken("a", "b", getTokenRequest())
+				tr, err := s.mgr.GetServiceAccountToken(&v1.ServiceAccount{}, getTokenRequest())
 
 				assert.NoErrorf(t, err, "unexpected error getting token")
 				assert.Equal(t, tr.Status.Token, "foo", "unexpected token")
@@ -108,11 +109,11 @@ func TestTokenCachingAndExpiration(t *testing.T) {
 			s.mgr.reviewToken = s.reviewer.reviewToken
 			s.mgr.clock = s.clock
 
-			_, err := s.mgr.GetServiceAccountToken("a", "b", getTokenRequest())
+			_, err := s.mgr.GetServiceAccountToken(&v1.ServiceAccount{}, getTokenRequest())
 			assert.NoErrorf(t, err, "unexpected error getting token")
 			assert.Equal(t, s.tg.count, 1, "unexpected client call, call count was %d", s.tg.count)
 
-			_, err = s.mgr.GetServiceAccountToken("a", "b", getTokenRequest())
+			_, err = s.mgr.GetServiceAccountToken(&v1.ServiceAccount{}, getTokenRequest())
 			assert.NoErrorf(t, err, "unexpected error getting token")
 			assert.Equal(t, s.tg.count, 1, "expected token to be served from cache, call count was %d", s.tg.count)
 


### PR DESCRIPTION
- Handles the case where a SA is created, deleted and recreated

Signed-off-by: Neil Hickey <nhickey@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #701

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
