### PR TITLE
Add support for positional arguments in package installed status command

### DIFF
--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -159,7 +159,7 @@ func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcor
 	pkgiCmd.AddCommand(pkginst.NewDeleteCmd(pkginst.NewDeleteOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgiCmd.AddCommand(pkginst.NewPauseCmd(pkginst.NewPauseOrKickOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgiCmd.AddCommand(pkginst.NewKickCmd(pkginst.NewPauseOrKickOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
-	pkgiCmd.AddCommand(pkginst.NewStatusCmd(pkginst.NewStatusOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
+	pkgiCmd.AddCommand(pkginst.NewStatusCmd(pkginst.NewStatusOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 
 	pkgaCmd := pkgavail.NewCmd()
 	pkgaCmd.AddCommand(pkgavail.NewListCmd(pkgavail.NewListOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))

--- a/cli/pkg/kctrl/cmd/package/available/get.go
+++ b/cli/pkg/kctrl/cmd/package/available/get.go
@@ -52,7 +52,7 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 				[]string{"package", "available", "get", "-p", "cert-manager.community.tanzu.vmware.com"},
 			},
 			cmdcore.Example{"Get the values schema for a particular version of the package",
-				[]string{"package", "available", "get", "-p", "cert-manager.community.tanzu.vmware.com", "--values-schema"}},
+				[]string{"package", "available", "get", "-p", "cert-manager.community.tanzu.vmware.com/1.0.0", "--values-schema"}},
 		}.Description("-p", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
 		Annotations:  map[string]string{"table": ""},

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -113,6 +113,7 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 			cmdcore.Example{"Install package and ask it to use an existing service account",
 				[]string{"package", "install", "-i", "cert-man", "-p", "cert-manager.community.tanzu.vmware.com", "--version", "1.6.1", "--service-account-name", "existing-sa"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
+		SilenceUsage: true,
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 
@@ -149,6 +150,7 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 			cmdcore.Example{"Update package install with new values file",
 				[]string{"package", "installed", "update", "-i", "cert-man", "--values-file", "values.yml"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
+		SilenceUsage: true,
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -45,7 +45,7 @@ func NewPauseCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobr
 		Use:   "pause",
 		Short: "Pause reconciliation of package install",
 		Args:  cobra.ExactArgs(1),
-		RunE:  func(_ *cobra.Command, _ []string) error { return o.Pause() },
+		RunE:  func(_ *cobra.Command, args []string) error { return o.Pause(args) },
 		Example: cmdcore.Examples{
 			cmdcore.Example{"Pause reconciliation of package install",
 				[]string{"package", "installed", "pause", "-i", "cert-man"},
@@ -70,7 +70,7 @@ func NewKickCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobra
 		Use:   "kick",
 		Short: "Trigger reconciliation of package install",
 		Args:  cobra.ExactArgs(1),
-		RunE:  func(_ *cobra.Command, _ []string) error { return o.Kick() },
+		RunE:  func(_ *cobra.Command, args []string) error { return o.Kick(args) },
 		Example: cmdcore.Examples{
 			cmdcore.Example{"Trigger reconciliation of package install",
 				[]string{"package", "installed", "kick", "-i", "cert-man"},
@@ -96,7 +96,11 @@ func NewKickCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobra
 	return cmd
 }
 
-func (o *PauseOrKickOptions) Pause() error {
+func (o *PauseOrKickOptions) Pause(args []string) error {
+	if o.pkgCmdTreeOpts.PositionalArgs {
+		o.Name = args[0]
+	}
+
 	if len(o.Name) == 0 {
 		return fmt.Errorf("Expected package install name to be non empty")
 	}
@@ -121,7 +125,11 @@ func (o *PauseOrKickOptions) Pause() error {
 	return o.pause(client)
 }
 
-func (o *PauseOrKickOptions) Kick() error {
+func (o *PauseOrKickOptions) Kick(args []string) error {
+	if o.pkgCmdTreeOpts.PositionalArgs {
+		o.Name = args[0]
+	}
+
 	if len(o.Name) == 0 {
 		return fmt.Errorf("Expected package install name to be non empty")
 	}

--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -24,10 +24,12 @@ type StatusOptions struct {
 	Name           string
 
 	IgnoreNotExists bool
+
+	pkgCmdTreeOpts cmdcore.PackageCommandTreeOpts
 }
 
-func NewStatusOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger) *StatusOptions {
-	return &StatusOptions{ui: ui, depsFactory: depsFactory, logger: logger}
+func NewStatusOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger, pkgCmdTreeOpts cmdcore.PackageCommandTreeOpts) *StatusOptions {
+	return &StatusOptions{ui: ui, depsFactory: depsFactory, logger: logger, pkgCmdTreeOpts: pkgCmdTreeOpts}
 }
 
 func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
@@ -36,10 +38,21 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 		Aliases: []string{"s"},
 		Short:   "View status of app created by package install",
 		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Example: cmdcore.Examples{
+			cmdcore.Example{"Check status of package install",
+				[]string{"package", "installed", "status", "-i", "cert-man"},
+			},
+		}.Description("-i", o.pkgCmdTreeOpts),
+		SilenceUsage: true,
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)
-	cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set package installname (required)")
+
+	if !o.pkgCmdTreeOpts.PositionalArgs {
+		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name (required)")
+	} else {
+		cmd.Use = "status INSTALLED_PACKAGE_NAME"
+	}
 
 	return cmd
 }

--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -37,7 +37,7 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 		Use:     "status",
 		Aliases: []string{"s"},
 		Short:   "View status of app created by package install",
-		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		RunE:    func(_ *cobra.Command, args []string) error { return o.Run(args) },
 		Example: cmdcore.Examples{
 			cmdcore.Example{"Check status of package install",
 				[]string{"package", "installed", "status", "-i", "cert-man"},
@@ -57,7 +57,11 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 	return cmd
 }
 
-func (o *StatusOptions) Run() error {
+func (o *StatusOptions) Run(args []string) error {
+	if o.pkgCmdTreeOpts.PositionalArgs {
+		o.Name = args[0]
+	}
+
 	if len(o.Name) == 0 {
 		return fmt.Errorf("Expected package install name to be non empty")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Add support for positional arguments in package installed status command
- Fix package available get example

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #604 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
