### PR TITLE
update example/test for helm fetching to use newer redis version

### DIFF
--- a/examples/redis-helm.yml
+++ b/examples/redis-helm.yml
@@ -8,7 +8,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "12.10.1"
+      version: "16.10.0"
       repository:
         url: https://charts.bitnami.com/bitnami
   template:

--- a/test/e2e/kappcontroller/helm_test.go
+++ b/test/e2e/kappcontroller/helm_test.go
@@ -59,7 +59,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "12.10.1"
+      version: "16.10.0"
       repository:
         url: https://charts.bitnami.com/bitnami
   template:
@@ -173,7 +173,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "12.10.1"
+      version: "16.10.0"
       repository:
         url: https://charts.bitnami.com/bitnami
   - inline:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
seems like redis 12.10.1 is gone from bitnami catalog

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
