### PR TITLE
Add documentation for running kapp-controller in KIND

### DIFF
--- a/examples/local-kind-environment/README.md
+++ b/examples/local-kind-environment/README.md
@@ -1,0 +1,191 @@
+# Setup a local Carvel Kapp Controller in KIND
+
+The purpose of this doc is to walk through the necessary steps to setup Kapp-Controller insidne of [KIND.](https://kind.sigs.k8s.io/docs/user/quick-start/)
+
+This doc also provides examples on creating:
+
+- `packageRepository`
+- `package`
+- `packageInstall`
+
+## Prerequisite's
+
+### KIND
+
+Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+mac: `brew install kind`
+
+### Docker
+
+Install [docker](https://docs.docker.com/get-docker/)
+
+Turn it on.
+
+### jq
+
+Install [jq](https://stedolan.github.io/jq/download/)
+
+mac: `brew install jq`
+
+
+## KIND + docker registry
+
+Setup KIND cluster + docker registry.
+
+Use the setup script:
+
+`./scripts/kind-with-registry.sh`
+
+Ours is slightly updated, but original script can be found [here.](https://raw.githubusercontent.com/kubernetes-sigs/kind/main/site/static/examples/kind-with-registry.sh)
+
+## KAPP Controller
+
+Install the latest release of `kapp-controller`:
+
+```sh
+kubectl apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/latest/download/release.yml
+```
+
+### install RBAC for admin SA account
+
+```
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/develop/examples/rbac/cluster-admin.yml
+```
+
+## Hack the gibson
+
+Update `/etc/hosts` on our local machine to make accessing the local registry easier for all tools.
+
+**NOTE**
+
+We use the registry name `kind-registry.local` as it forces `imgpkg` to use http instead of https. [slack thread](https://kubernetes.slack.com/archives/CH8KCCKA5/p1654541811762389)
+
+
+```sh
+sudo vim /etc/hosts
+
+# ADD
+127.0.0.1 kind-registry.local
+```
+
+** REMEMBER TO DELETE THIS AFTER **
+
+## Build test bundle + push to local docker registry
+
+We use Istio's basic httpbin [example](https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml) for our test service.
+
+```sh
+kbld -f dist/service --imgpkg-lock-output dist/.imgpkg/images.yml
+```
+
+setup latest *and* `0.1.0`
+
+```sh
+for tag in latest 0.1.0 
+do
+  imgpkg push -b kind-registry.local:5000/http-bin:$tag -f dist
+done
+
+```
+
+### check container and tags
+
+List all images in local registry
+
+```sh
+curl -s -X GET kind-registry.local:5000/v2/_catalog | jq .
+
+{
+  "repositories": [
+    "http-bin"
+  ]
+}
+```
+
+check tags for `http-bin` in local registry
+
+```sh
+curl -s -X GET kind-registry.local:5000/v2/http-bin/tags/list | jq .
+
+{
+  "name": "http-bin",
+  "tags": [
+    "0.1.0",
+    "sha256-463b022efdddc68b4bee71012d14be0d0ff22cf0ac53754fbb7400990106b3a1.imgpkg",
+    "latest"
+  ]
+}
+```
+
+## Build package repository and push to docker registry
+
+Build package repository bundle
+
+```sh
+kbld -f ./package-repository/packages --imgpkg-lock-output "./package-repository/.imgpkg/images.yml"
+```
+
+Push package repository to registry
+
+```sh
+for tag in latest 0.1.0
+do
+  imgpkg push -b kind-registry.local:5000/package-repository:$tag -f package-repository
+done
+```
+
+## Install package repository
+
+```sh
+kubectl apply -f package_repository_install.yml
+```
+
+## Install the package
+
+```sh
+kubectl apply -f package_install.yml
+```
+
+## Verify the install(s)
+
+Package Repository
+
+```sh
+❯ kubectl get packagerepository -n kapp-controller-packaging-global
+NAME                            AGE    DESCRIPTION
+mgmt-core-services.twilio.com   125m   Reconcile succeeded
+```
+
+Packages
+
+```sh
+❯ kubectl get packages -n default
+NAME                         PACKAGEMETADATA NAME   VERSION   AGE
+example.com.http-bin.0.1.0   example.com.http-bin   0.1.0     1m6s
+```
+
+PackageInstalls
+
+```sh
+❯ kubectl get packageinstall -n default
+NAME       PACKAGE NAME           PACKAGE VERSION   DESCRIPTION           AGE
+http-bin   example.com.http-bin   0.1.0             Reconcile succeeded   83s
+```
+
+Apps
+
+```sh
+❯ kubectl get apps -n default
+NAME       DESCRIPTION           SINCE-DEPLOY   AGE
+http-bin   Reconcile succeeded   113s           114s
+```
+
+Pods
+
+```sh
+❯ kubectl get pods -n default
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-76778749f4-srfhq   1/1     Running   0          2m9s
+```
+

--- a/examples/local-kind-environment/README.md
+++ b/examples/local-kind-environment/README.md
@@ -1,6 +1,6 @@
 # Setup a local Carvel Kapp Controller in KIND
 
-The purpose of this doc is to walk through the necessary steps to setup Kapp-Controller insidne of [KIND.](https://kind.sigs.k8s.io/docs/user/quick-start/)
+The purpose of this doc is to walk through the necessary steps to setup Kapp-Controller inside of [KIND.](https://kind.sigs.k8s.io/docs/user/quick-start/)
 
 This doc also provides examples on creating:
 
@@ -154,7 +154,7 @@ Package Repository
 ```sh
 ❯ kubectl get packagerepository -n kapp-controller-packaging-global
 NAME                            AGE    DESCRIPTION
-mgmt-core-services.twilio.com   125m   Reconcile succeeded
+package-repository.example.com   125m   Reconcile succeeded
 ```
 
 Packages

--- a/examples/local-kind-environment/dist/.imgpkg/bundle.yml
+++ b/examples/local-kind-environment/dist/.imgpkg/bundle.yml
@@ -1,0 +1,10 @@
+apiVersion: imgpkg.carvel.dev/v1alpha1
+kind: Bundle
+metadata:
+  name: http-bin
+authors:
+  - name: test
+    email: test@example.com
+websites:
+  - url: test.example.com
+

--- a/examples/local-kind-environment/dist/service/http-bin.yml
+++ b/examples/local-kind-environment/dist/service/http-bin.yml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      serviceAccountName: httpbin
+      containers:
+      - image: docker.io/kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 80

--- a/examples/local-kind-environment/package-repository/.imgpkg/images.yml
+++ b/examples/local-kind-environment/package-repository/.imgpkg/images.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: kind-registry.local:5000/http-bin:0.1.0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 0.1.0
+          url: kind-registry.local:5000/http-bin:0.1.0
+  image: kind-registry.local:5000/http-bin@sha256:a299c0f8e265993c28af1eeed6c6da6672483fc71e83124a1d6d89a9a4d75db8
+kind: ImagesLock

--- a/examples/local-kind-environment/package-repository/packages/http-bin/0.1.0.yml
+++ b/examples/local-kind-environment/package-repository/packages/http-bin/0.1.0.yml
@@ -1,0 +1,23 @@
+# See https://carvel.dev/kapp-controller/docs/v0.36.1/packaging/#package
+
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: example.com.http-bin.0.1.0
+  namespace: kapp-controller-packaging-global
+spec:
+  refName: example.com.http-bin
+  version: 0.1.0
+  releaseNotes: "install http-bin example"
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: kind-registry.local:5000/http-bin:0.1.0
+      template:
+        - kbld:
+            paths:
+              - /service
+      deploy:
+        - kapp: {}
+

--- a/examples/local-kind-environment/package-repository/packages/http-bin/metadata.yml
+++ b/examples/local-kind-environment/package-repository/packages/http-bin/metadata.yml
@@ -1,0 +1,18 @@
+# See https://carvel.dev/kapp-controller/docs/v0.36.1/packaging/#package-metadata
+
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: example.com.http-bin
+  namespace: kapp-controller-packaging-global
+spec:
+  displayName: "http-bin example"
+  longDescription: "Negative, I am a meat popsicle"
+  shortDescription: "Lilu Dallas, multi-pass"
+  maintainers:
+    - name: test
+  categories:
+    - "test"
+    - "http-bin"
+  supportDescription: "Please hold while your call is connected."
+

--- a/examples/local-kind-environment/package_install.yml
+++ b/examples/local-kind-environment/package_install.yml
@@ -1,0 +1,12 @@
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: http-bin
+  namespace: default
+spec:
+  serviceAccountName: cluster-admin-sa
+  packageRef:
+    refName: example.com.http-bin
+    versionSelection:
+      constraints: 0.1.0
+

--- a/examples/local-kind-environment/package_repository_install.yml
+++ b/examples/local-kind-environment/package_repository_install.yml
@@ -1,0 +1,11 @@
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: package-repository.example.com
+  # Adds it to global namespace (as defined by kapp-controller)
+  # which makes packages available in all namespaces
+  namespace: kapp-controller-packaging-global
+spec:
+  fetch:
+    imgpkgBundle:
+      image: kind-registry.local:5000/package-repository:0.1.0

--- a/examples/local-kind-environment/scripts/kind-with-registry.sh
+++ b/examples/local-kind-environment/scripts/kind-with-registry.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -o errexit
+
+# create registry container unless it already exists
+reg_name='kind-registry.local'
+reg_port='5000'
+if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:5000"]
+EOF
+
+# connect the registry to the cluster network if not already connected
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  docker network connect "kind" "${reg_name}"
+fi
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds documentation to `/examples` on how to run kapp-controller in a local [KIND](https://kind.sigs.k8s.io/docs/user/quick-start/) 

#### Which issue(s) this PR fixes:
No issue, just adding more docs for local dev
Fixes #N/A 

#### Does this PR introduce a user-facing change?
NONE

```release-note
Adds user documentation for running kapp-controller locally in KIND
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
