### PR TITLE
`kctrl`:  ytt overlay flags

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -34,7 +34,7 @@ import (
 const (
 	valuesFileKey        = "values.yaml"
 	yttOverlayPrefix     = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
-	yttOverlayAnnotation = yttOverlayPrefix + ".kctrl-overlay-secret"
+	yttOverlayAnnotation = yttOverlayPrefix + ".kctrl-ytt-overlays"
 )
 
 type CreateOrUpdateOptions struct {

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -396,7 +396,8 @@ func (o CreateOrUpdateOptions) update(client kubernetes.Interface, kcClient kccl
 		if err != nil {
 			return err
 		}
-		if overlaysSecret != nil {
+		_, found := updatedPkgInstall.Annotations[yttOverlayAnnotation]
+		if !found && overlaysSecret != nil {
 			updatedPkgInstall.Annotations[yttOverlayAnnotation] = overlaysSecret.Name
 			changed = true
 		}

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -34,7 +34,7 @@ import (
 const (
 	valuesFileKey        = "values.yaml"
 	yttOverlayPrefix     = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
-	yttOverlayAnnotation = yttOverlayPrefix + ".kctrl.carvel.dev"
+	yttOverlayAnnotation = yttOverlayPrefix + ".kctrl-overlay-secret"
 )
 
 type CreateOrUpdateOptions struct {

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	valuesFileKey        = "values.yaml"
-	yttOverlayAnnotation = "ext.packaging.carvel.dev/ytt-paths-from-secret-name.kctrl"
+	yttOverlayAnnotation = "ext.packaging.carvel.dev/ytt-paths-from-secret-name.kctrl.carvel.dev"
 )
 
 type CreateOrUpdateOptions struct {
@@ -1018,7 +1018,6 @@ func (o *CreateOrUpdateOptions) showVersions(client pkgclient.Interface) error {
 
 const (
 	yttOverlayPrefix = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
-	yttOverlaySuffix = "kctrl.carvel.dev"
 )
 
 func (o *CreateOrUpdateOptions) createOrUpdateYttOverlaySecrets(pkgi *kcpkgv1alpha1.PackageInstall, client kubernetes.Interface) (*corev1.Secret, error) {

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -355,7 +355,7 @@ func (o CreateOrUpdateOptions) update(client kubernetes.Interface, kcClient kccl
 	// Or when existing ytt overlay has to be updated
 	reconciliationPaused := false
 	if (o.valuesFile != "" && len(pkgInstall.Spec.Values) > 0) ||
-		(len(o.YttOverlayFlags.yttOverlayFiles) > 0 && o.hasYttOverlays(pkgInstall)) {
+		(len(o.YttOverlayFlags.yttOverlayFiles) > 0 && hasYttOverlays(pkgInstall)) {
 		updatedPkgInstall, err = o.pauseReconciliation(kcClient)
 		if err != nil {
 			return err
@@ -1063,15 +1063,6 @@ func (o *CreateOrUpdateOptions) createOrUpdateYttOverlaySecrets(pkgi *kcpkgv1alp
 	return createdOrUpdatedSecret, nil
 }
 
-func (o *CreateOrUpdateOptions) hasYttOverlays(pkgi *kcpkgv1alpha1.PackageInstall) bool {
-	for annotation := range pkgi.Annotations {
-		if strings.HasPrefix(annotation, yttOverlayPrefix) {
-			return true
-		}
-	}
-	return false
-}
-
 func (o *CreateOrUpdateOptions) dropYttOverlaySecrets(pkgi *kcpkgv1alpha1.PackageInstall, client kubernetes.Interface) error {
 	o.statusUI.PrintMessage("Dropping overlay secrets")
 	overlaySecretName, hasOverlay := pkgi.Annotations[yttOverlayAnnotation]
@@ -1112,4 +1103,13 @@ func getPackageInstallDescription(name string, namespace string) string {
 		description += " cluster"
 	}
 	return description
+}
+
+func hasYttOverlays(pkgi *kcpkgv1alpha1.PackageInstall) bool {
+	for annotation := range pkgi.Annotations {
+		if strings.HasPrefix(annotation, yttOverlayPrefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -33,7 +33,8 @@ import (
 
 const (
 	valuesFileKey        = "values.yaml"
-	yttOverlayAnnotation = "ext.packaging.carvel.dev/ytt-paths-from-secret-name.kctrl.carvel.dev"
+	yttOverlayPrefix     = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
+	yttOverlayAnnotation = yttOverlayPrefix + ".kctrl.carvel.dev"
 )
 
 type CreateOrUpdateOptions struct {
@@ -305,7 +306,7 @@ func (o *CreateOrUpdateOptions) RunUpdate(args []string) error {
 
 	if len(o.version) == 0 && len(o.valuesFile) == 0 && o.values &&
 		o.YttOverlayFlags.yttOverlays && len(o.YttOverlayFlags.yttOverlayFiles) == 0 {
-		return fmt.Errorf("Expected either package version ,values file or overlays to update the package")
+		return fmt.Errorf("Expected either package version, values file or overlays to update the package")
 	}
 
 	err := o.SecureNamespaceFlags.CheckForDisallowedSharedNamespaces(o.NamespaceFlags.Name)
@@ -403,7 +404,7 @@ func (o CreateOrUpdateOptions) update(client kubernetes.Interface, kcClient kccl
 		}
 	}
 
-	if !o.YttOverlayFlags.yttOverlays {
+	if !o.YttOverlayFlags.yttOverlays && hasYttOverlays(updatedPkgInstall) {
 		err = o.dropYttOverlaySecrets(updatedPkgInstall, client)
 		if err != nil {
 			return err
@@ -1022,10 +1023,6 @@ func (o *CreateOrUpdateOptions) showVersions(client pkgclient.Interface) error {
 
 	return nil
 }
-
-const (
-	yttOverlayPrefix = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
-)
 
 func (o *CreateOrUpdateOptions) createOrUpdateYttOverlaySecrets(pkgi *kcpkgv1alpha1.PackageInstall, client kubernetes.Interface) (*corev1.Secret, error) {
 	o.statusUI.PrintMessage("Creating overlay secrets")

--- a/cli/pkg/kctrl/cmd/package/installed/delete.go
+++ b/cli/pkg/kctrl/cmd/package/installed/delete.go
@@ -271,8 +271,8 @@ func (o *DeleteOptions) cleanUpIfInstallNotFound(dynamicClient dynamic.Interface
 	//Delete ytt overlays secret created by kctrl if any
 	err = o.deleteIfExistsAndOwned(
 		schema.GroupVersionResource{
-			Group:    rbacv1.SchemeGroupVersion.Group,
-			Version:  rbacv1.SchemeGroupVersion.Version,
+			Group:    corev1.SchemeGroupVersion.Group,
+			Version:  corev1.SchemeGroupVersion.Version,
 			Resource: KindSecret.Resource(),
 		}, fmt.Sprintf("%s-%s-overlays", o.Name, o.NamespaceFlags.Name), o.NamespaceFlags.Name, dynamicClient)
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/package/installed/get.go
+++ b/cli/pkg/kctrl/cmd/package/installed/get.go
@@ -231,7 +231,7 @@ func (o *GetOptions) overlayList(pkgi kcpkgv1alpha1.PackageInstall) []string {
 }
 
 // Returns pkgi status string and a bool indicating if it is a failure
-// TODO: Add Paused/Cancelled statuses at a warn level
+// TODO: Add Paused/Canceled statuses at a warn level
 func packageInstallStatus(pkgi *kcpkgv1alpha1.PackageInstall) (string, bool) {
 	if pkgi.Spec.Canceled {
 		return "Canceled", true

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
@@ -11,6 +11,6 @@ type YttOverlayFlags struct {
 }
 
 func (s *YttOverlayFlags) Set(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay", nil, "A file or folder with ytt overlays to be applied to package install")
+	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay-file", nil, "A file or folder with ytt overlays to be applied to package install")
 	cmd.Flags().BoolVar(&s.yttOverlays, "ytt-overlays", true, "Add or keep ytt overlays")
 }

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
@@ -11,6 +11,6 @@ type YttOverlayFlags struct {
 }
 
 func (s *YttOverlayFlags) Set(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay-file", nil, "A file or folder with ytt overlays to be applied to package install")
+	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay-file", nil, "Path to ytt overlay file (can also be a directory)")
 	cmd.Flags().BoolVar(&s.yttOverlays, "ytt-overlays", true, "Add or keep ytt overlays")
 }

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
@@ -11,6 +11,6 @@ type YttOverlayFlags struct {
 }
 
 func (s *YttOverlayFlags) Set(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay", nil, "")
+	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay", nil, "A file or folder with ytt overlays to be applied to package install")
 	cmd.Flags().BoolVar(&s.yttOverlays, "ytt-overlays", true, "Add or keep ytt overlays")
 }

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
@@ -1,0 +1,16 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installed
+
+import "github.com/spf13/cobra"
+
+type YttOverlayFlags struct {
+	yttOverlays     bool
+	yttOverlayFiles []string
+}
+
+func (s *YttOverlayFlags) Set(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&s.yttOverlayFiles, "ytt-overlay", nil, "")
+	cmd.Flags().BoolVar(&s.yttOverlays, "ytt-overlays", true, "Add or keep ytt overlays")
+}

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
@@ -40,6 +40,16 @@ func (o *YttOverlays) OverlaysSecret() (*corev1.Secret, error) {
 
 	filePathsMap := map[string][]byte{}
 	for i, file := range o.files {
+		// Omit stdin input
+		if file == "-" {
+			bytes, err := cmdcore.NewInputFile(file).Bytes()
+			if err != nil {
+				return nil, fmt.Errorf("Reading file: %s", err.Error())
+			}
+			filePathsMap[fmt.Sprintf("%04d-stdin.yaml", i)] = bytes
+			continue
+		}
+
 		fileInfo, err := os.Stat(file)
 		if err != nil {
 			return nil, fmt.Errorf("Checking file '%s'", file)
@@ -53,7 +63,7 @@ func (o *YttOverlays) OverlaysSecret() (*corev1.Secret, error) {
 				ext := filepath.Ext(path)
 				for _, allowedExt := range fileResourcesAllowedExts {
 					if allowedExt == ext {
-						bytes, err := cmdcore.NewLocalFileSource(path).Bytes()
+						bytes, err := cmdcore.NewInputFile(path).Bytes()
 						if err != nil {
 							return fmt.Errorf("Reading file: %s", err.Error())
 						}
@@ -77,7 +87,7 @@ func (o *YttOverlays) OverlaysSecret() (*corev1.Secret, error) {
 			for _, allowedExt := range fileResourcesAllowedExts {
 				ext := filepath.Ext(file)
 				if allowedExt == ext {
-					bytes, err := cmdcore.NewLocalFileSource(file).Bytes()
+					bytes, err := cmdcore.NewInputFile(file).Bytes()
 					if err != nil {
 						return nil, fmt.Errorf("Reading file: %s", err.Error())
 					}

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +57,15 @@ func (o *YttOverlays) OverlaysSecret() (*corev1.Secret, error) {
 						if err != nil {
 							return fmt.Errorf("Reading file: %s", err.Error())
 						}
-						filePathsMap[fmt.Sprintf("%04d-%s", i, path)] = bytes
+						key := fmt.Sprintf("%04d-%s", i, path)
+						key = strings.ReplaceAll(key, "/", "_")
+
+						// Handle windows file paths
+						key = strings.ReplaceAll(key, ":\\", "_")
+						key = strings.ReplaceAll(key, "\\", "_")
+						key = strings.ReplaceAll(key, "$", ".")
+
+						filePathsMap[key] = bytes
 					}
 				}
 				return nil
@@ -72,7 +81,7 @@ func (o *YttOverlays) OverlaysSecret() (*corev1.Secret, error) {
 					if err != nil {
 						return nil, fmt.Errorf("Reading file: %s", err.Error())
 					}
-					filePathsMap[fmt.Sprintf("%04d-%s", i, file)] = bytes
+					filePathsMap[fmt.Sprintf("%04d-%s", i, filepath.Base(file))] = bytes
 				}
 			}
 		}

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
@@ -1,0 +1,83 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installed
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	fileResourcesAllowedExts = []string{".yaml", ".yml"}
+)
+
+type YttOverlays struct {
+	packageInstall string
+	namespace      string
+	files          []string
+}
+
+func NewYttOverlays(files []string, packageInstall string, namespace string) *YttOverlays {
+	return &YttOverlays{files: files, packageInstall: packageInstall, namespace: namespace}
+}
+
+func (o *YttOverlays) OverlaysSecret() (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s-overlays", o.packageInstall, o.namespace),
+			Annotations: map[string]string{
+				KctrlPkgAnnotation: NewCreatedResourceAnnotations(o.packageInstall, o.namespace).PackageAnnValue(),
+			},
+		},
+	}
+
+	filePathsMap := map[string][]byte{}
+	for i, file := range o.files {
+		fileInfo, err := os.Stat(file)
+		if err != nil {
+			return nil, fmt.Errorf("Checking file '%s'", file)
+		}
+
+		if fileInfo.IsDir() {
+			err := filepath.Walk(file, func(path string, fi os.FileInfo, err error) error {
+				if err != nil || fi.IsDir() {
+					return err
+				}
+				ext := filepath.Ext(path)
+				for _, allowedExt := range fileResourcesAllowedExts {
+					if allowedExt == ext {
+						bytes, err := cmdcore.NewLocalFileSource(path).Bytes()
+						if err != nil {
+							return fmt.Errorf("Reading file: %s", err.Error())
+						}
+						filePathsMap[fmt.Sprintf("%04d-%s", i, path)] = bytes
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, fmt.Errorf("Listing files '%s'", file)
+			}
+		} else {
+			for _, allowedExt := range fileResourcesAllowedExts {
+				ext := filepath.Ext(file)
+				if allowedExt == ext {
+					bytes, err := cmdcore.NewLocalFileSource(file).Bytes()
+					if err != nil {
+						return nil, fmt.Errorf("Reading file: %s", err.Error())
+					}
+					filePathsMap[fmt.Sprintf("%04d-%s", i, file)] = bytes
+				}
+			}
+		}
+	}
+	secret.Data = filePathsMap
+
+	return secret, nil
+}

--- a/cli/test/e2e/ytt_overlays_test.go
+++ b/cli/test/e2e/ytt_overlays_test.go
@@ -113,7 +113,7 @@ metadata:
 		require.Contains(t, out, "Deploy succeeded")
 
 		out = kubectl.Run([]string{"get", "deployment", deploymentName, "-o", "yaml"})
-		require.Contains(t, out, "foo")
+		require.Contains(t, out, "test: foo")
 	})
 
 	logger.Section("get package install", func() {

--- a/cli/test/e2e/ytt_overlays_test.go
+++ b/cli/test/e2e/ytt_overlays_test.go
@@ -1,0 +1,179 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	uitest "github.com/cppforlife/go-cli-ui/ui/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYttOverlays(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+	kubectl := Kubectl{t, env.Namespace, logger}
+
+	packageName := "test-pkg.carvel.dev"
+	packageVersion := "1.0.0"
+	appName := "test-package"
+	pkgiName := "overlay-test"
+	deploymentName := "simple-app"
+
+	yaml := `---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: test-pkg.carvel.dev
+spec:
+  displayName: "Carvel Test Package"
+  shortDescription: "Carvel package for testing installation"
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: test-pkg.carvel.dev.1.0.0
+spec:
+  refName: test-pkg.carvel.dev
+  version: 1.0.0
+  valuesSchema:
+    openAPIv3:
+      properties:
+        app_port:
+          default: 80
+          description: App port
+          type: integer
+        app_name:
+          description: App Name
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: k8slt/kctrl-example-pkg:v1.0.0
+      template:
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - "-"
+          - ".imgpkg/images.yml"
+      deploy:
+      - kapp: {}`
+
+	overlay1 := `
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment"})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    test: foo
+`
+	overlay2 := `
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment"})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    test: bar
+`
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", appName})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("add test package", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-a", appName, "-f", "-"}, RunOpts{
+			StdinReader: strings.NewReader(yaml),
+		})
+		require.NoError(t, err)
+	})
+
+	logger.Section("install with ytt overlays", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"package", "install", "-i", pkgiName, "--package", packageName, "--version", packageVersion, "--ytt-overlay-file", "-"}, RunOpts{
+			StdinReader: strings.NewReader(overlay1),
+		})
+		require.NoError(t, err)
+		//Ensure that progress is tailed
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+
+		out = kubectl.Run([]string{"get", "deployment", deploymentName, "-o", "yaml"})
+		require.Contains(t, out, "foo")
+	})
+
+	logger.Section("get package install", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "get", "--package-install", pkgiName, "--json"}, RunOpts{})
+		require.NoError(t, err)
+
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{{
+			"conditions":      "- type: ReconcileSucceeded\n  status: \"True\"\n  reason: \"\"\n  message: \"\"",
+			"namespace":       env.Namespace,
+			"name":            pkgiName,
+			"overlay_secrets": fmt.Sprintf("- %s-%s-overlays", pkgiName, env.Namespace),
+			"package_name":    "test-pkg.carvel.dev",
+			"package_version": "1.0.0",
+			"status":          "Reconcile succeeded",
+		}}
+
+		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
+	})
+
+	logger.Section("update ytt overlay", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "update", "-i", pkgiName, "--ytt-overlay-file", "-"}, RunOpts{
+			StdinReader: strings.NewReader(overlay2),
+		})
+		require.NoError(t, err)
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+
+		out = kubectl.Run([]string{"get", "deployment", deploymentName, "-o", "yaml"})
+		require.Contains(t, out, "test: bar")
+	})
+
+	logger.Section("drop ytt overlays", func() {
+		out := kappCtrl.Run([]string{"package", "installed", "update", "-i", pkgiName, "--ytt-overlays=false"})
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+
+		out = kubectl.Run([]string{"get", "deployment", deploymentName, "-o", "yaml"})
+		require.NotContains(t, out, "test: foo")
+		require.NotContains(t, out, "test: bar")
+	})
+
+	logger.Section("get package install", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "get", "--package-install", pkgiName, "--json"}, RunOpts{})
+		require.NoError(t, err)
+
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{{
+			"conditions":      "- type: ReconcileSucceeded\n  status: \"True\"\n  reason: \"\"\n  message: \"\"",
+			"namespace":       env.Namespace,
+			"name":            pkgiName,
+			"package_name":    "test-pkg.carvel.dev",
+			"package_version": "1.0.0",
+			"status":          "Reconcile succeeded",
+		}}
+
+		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add flags which allow overlaying of package content while creating package installs.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #674 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Introduce ytt overlay flags
- `--ytt-overlays` (boolean) decides whether or not ytt overlays are added/kept.
- `--ytt-overlay-file` files can be used to supply ytt overlay file paths or paths to directories wioth ytt overlays.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR vmware-tanzu/carvel#558
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
