### PR TITLE
Use the built-in minikube

### DIFF
--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -31,10 +31,6 @@ jobs:
       - name: Setup k8s and Run benchmark
         run: |
           set -e -x
-          mkdir /tmp/bin
-          export PATH=/tmp/bin:$PATH
-          curl -sLo /tmp/bin/minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
-          chmod +x /tmp/bin/minikube
           minikube start --driver=docker
           eval $(minikube docker-env --shell=bash)
 

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -38,8 +38,6 @@ jobs:
 
         ./hack/verify-no-dirty-files.sh
 
-        curl -sLo /tmp/bin/minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
-        chmod +x /tmp/bin/minikube
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)
 

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -41,8 +41,6 @@ jobs:
 
         ./hack/verify-no-dirty-files.sh
 
-        curl -sLo /tmp/bin/minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
-        chmod +x /tmp/bin/minikube
         minikube start --driver=docker
         eval $(minikube docker-env --shell=bash)
 

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -92,7 +92,7 @@ jobs:
           # kapp-controller binary - output in sarif and json
           trivy rootfs --ignore-unfixed --format sarif --output trivy-results.sarif "controller"
           trivy rootfs --ignore-unfixed --format json --output trivy-results.json "controller"
-      
+
           # kapp-controller docker image - output in sarif and json
           trivy image --ignore-unfixed --format sarif --output trivy-results-image.sarif "docker.io/carvel/kapp-controller:${{ github.sha }}"
           trivy image --ignore-unfixed --format json --output trivy-results-image.json "docker.io/carvel/kapp-controller:${{ github.sha }}"
@@ -104,10 +104,10 @@ jobs:
         id: cve-summary
         run: |
           set -eo pipefail
-        
+
           summary_binary=$(jq '.Results[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' trivy-results.json | tr -d \\ | tr -d '"')
           summary_image=$(jq '.Results[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' trivy-results-image.json | tr -d \\ | tr -d '"')
-          
+
           summary=$( echo -e "Binary Image Summary:\n$summary_binary\nDocker Image Summary:\n$summary_image")
           if [[ -n $summary_binary || -n $summary_image ]]
           then

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -29,11 +29,6 @@ jobs:
         run: |
           set -e -x
 
-          mkdir /tmp/bin
-          export PATH=/tmp/bin:$PATH
-
-          curl -sLo /tmp/bin/minikube https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
-          chmod +x /tmp/bin/minikube
           minikube start --driver=docker
           eval $(minikube docker-env --shell=bash)
 


### PR DESCRIPTION
Just a tiny cleanup to use the built-in minikube from the [ubuntu-latest runner](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#tools) rather than redownloading it.