### PR TITLE
Fix trivy scan

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -71,7 +71,7 @@ jobs:
           ./hack/build.sh
 
           # docker image
-          docker build -t docker.io/carvel/kapp-controller:${{ github.sha }} .
+          docker buildx build -t docker.io/carvel/kapp-controller:${{ github.sha }} .
       - name: Install Trivy
         run: |
           brew install aquasecurity/trivy/trivy
@@ -92,7 +92,7 @@ jobs:
           # kapp-controller binary - output in sarif and json
           trivy rootfs --ignore-unfixed --format sarif --output trivy-results.sarif "controller"
           trivy rootfs --ignore-unfixed --format json --output trivy-results.json "controller"
-      
+
           # kapp-controller docker image - output in sarif and json
           trivy image --ignore-unfixed --format sarif --output trivy-results-image.sarif "docker.io/carvel/kapp-controller:${{ github.sha }}"
           trivy image --ignore-unfixed --format json --output trivy-results-image.json "docker.io/carvel/kapp-controller:${{ github.sha }}"
@@ -104,10 +104,10 @@ jobs:
         id: cve-summary
         run: |
           set -eo pipefail
-        
+
           summary_binary=$(jq '.Results[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' trivy-results.json | tr -d \\ | tr -d '"')
           summary_image=$(jq '.Results[] | select(.Vulnerabilities) | .Vulnerabilities | group_by(.Severity) | map({Severity: .[0].Severity, Count: length}) | tostring' trivy-results-image.json | tr -d \\ | tr -d '"')
-          
+
           summary=$( echo -e "Binary Image Summary:\n$summary_binary\nDocker Image Summary:\n$summary_image")
           if [[ -n $summary_binary || -n $summary_image ]]
           then


### PR DESCRIPTION
The trivy scan is doing a `docker build`, which fails now due to the use of variables like `BUILDPLATFORM` that are only present in a buildx context. 

https://github.com/vmware-tanzu/carvel-kapp-controller/runs/6853399271?check_suite_focus=true