### PR TITLE
Enhance tty experience

### DIFF
--- a/cli/pkg/kctrl/cmd/app/delete.go
+++ b/cli/pkg/kctrl/cmd/app/delete.go
@@ -19,6 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	TTYByDefaultKey = "cli.carvel.dev/tty-by-default"
+)
+
 type DeleteOptions struct {
 	ui          ui.UI
 	statusUI    cmdcore.StatusLoggingUI
@@ -39,9 +43,10 @@ func NewDeleteOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.L
 
 func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Delete app",
-		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Use:         "delete",
+		Short:       "Delete app",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/kick.go
+++ b/cli/pkg/kctrl/cmd/app/kick.go
@@ -37,9 +37,10 @@ func NewKickOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Log
 
 func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kick",
-		Short: "Trigger reconciliation for app",
-		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Use:         "kick",
+		Short:       "Trigger reconciliation for app",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/pause.go
+++ b/cli/pkg/kctrl/cmd/app/pause.go
@@ -33,10 +33,11 @@ func NewPauseOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Lo
 
 func NewPauseCmd(o *PauseOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "pause",
-		Aliases: []string{"p"},
-		Short:   "Pause reconciliation for app",
-		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Use:         "pause",
+		Aliases:     []string{"p"},
+		Short:       "Pause reconciliation for app",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/status.go
+++ b/cli/pkg/kctrl/cmd/app/status.go
@@ -29,10 +29,11 @@ func NewStatusOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.L
 
 func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "status",
-		Aliases: []string{"s"},
-		Short:   "View status of app",
-		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Use:         "status",
+		Aliases:     []string{"s"},
+		Short:       "View status of app",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -73,9 +73,9 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 
 	pkgOpts := cmdcore.PackageCommandTreeOpts{BinaryName: "kctrl", PositionalArgs: false, Color: true, JSON: true}
 
-	SetGlobalFlags(o, cmd, flagsFactory, pkgOpts)
+	setGlobalFlags(o, cmd, flagsFactory, pkgOpts)
 
-	ConfigurePathResolvers(o, cmd, flagsFactory)
+	configurePathResolvers(o, cmd, flagsFactory)
 
 	cmd.AddCommand(NewVersionCmd(NewVersionOptions(o.ui, o.depsFactory), flagsFactory))
 
@@ -94,28 +94,28 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 
 	cmd.AddCommand(appCmd)
 
-	ConfigureGlobalFlags(o, cmd, flagsFactory, pkgOpts.PositionalArgs)
+	configureGlobalFlags(o, cmd, flagsFactory, pkgOpts.PositionalArgs)
 
 	cmd.AddCommand(NewCmdCompletion())
 
-	ConfigureTTY(o, cmd)
+	configureTTY(o, cmd)
 	return cmd
 }
 
-func SetGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, opts cmdcore.PackageCommandTreeOpts) {
+func setGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, opts cmdcore.PackageCommandTreeOpts) {
 	o.UIFlags.Set(cmd, flagsFactory, opts)
 	o.LoggerFlags.Set(cmd, flagsFactory)
 	o.KubeAPIFlags.Set(cmd, flagsFactory)
 	o.KubeconfigFlags.Set(cmd, flagsFactory, opts)
 }
 
-func ConfigurePathResolvers(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
+func configurePathResolvers(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory) {
 	o.configFactory.ConfigurePathResolver(o.KubeconfigFlags.Path.Value)
 	o.configFactory.ConfigureContextResolver(o.KubeconfigFlags.Context.Value)
 	o.configFactory.ConfigureYAMLResolver(o.KubeconfigFlags.YAML.Value)
 }
 
-func ConfigureGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, positionalNameArg bool) {
+func configureGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, positionalNameArg bool) {
 	finishDebugLog := func(cmd *cobra.Command) {
 		origRunE := cmd.RunE
 		if origRunE != nil {
@@ -144,7 +144,7 @@ func ConfigureGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdc
 	}
 }
 
-func ConfigureTTY(o *KctrlOptions, cmd *cobra.Command) {
+func configureTTY(o *KctrlOptions, cmd *cobra.Command) {
 	configureTTYFlag := func(cmd *cobra.Command) {
 		var forceTTY bool
 
@@ -187,10 +187,10 @@ func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcor
 }
 
 func AttachGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, opts cmdcore.PackageCommandTreeOpts) {
-	SetGlobalFlags(o, cmd, flagsFactory, opts)
-	ConfigurePathResolvers(o, cmd, flagsFactory)
-	ConfigureGlobalFlags(o, cmd, flagsFactory, opts.PositionalArgs)
-	ConfigureTTY(o, cmd)
+	setGlobalFlags(o, cmd, flagsFactory, opts)
+	configurePathResolvers(o, cmd, flagsFactory)
+	configureGlobalFlags(o, cmd, flagsFactory, opts.PositionalArgs)
+	configureTTY(o, cmd)
 }
 
 func AttachKctrlPackageCommandTree(cmd *cobra.Command, confUI *ui.ConfUI, opts cmdcore.PackageCommandTreeOpts) {

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -77,6 +77,7 @@ func NewCreateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 				[]string{"package", "installed", "create", "-i", "cert-man", "-p", "cert-manager.community.tanzu.vmware.com", "--version", "1.6.1", "--service-account-name", "existing-sa"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 
@@ -118,6 +119,7 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 				[]string{"package", "install", "-i", "cert-man", "-p", "cert-manager.community.tanzu.vmware.com", "--version", "1.6.1", "--service-account-name", "existing-sa"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 
@@ -158,6 +160,7 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 				[]string{"package", "installed", "update", "-i", "cert-man", "--values", "false"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 

--- a/cli/pkg/kctrl/cmd/package/installed/delete.go
+++ b/cli/pkg/kctrl/cmd/package/installed/delete.go
@@ -58,6 +58,7 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 				[]string{"package", "installed", "delete", "-i", "cert-man"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -52,6 +52,7 @@ func NewPauseCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobr
 			},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)
@@ -77,6 +78,7 @@ func NewKickCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobra
 			},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -44,6 +44,7 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 			},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
+	cmdapp "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/logger"
 	kappctrl "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
@@ -54,6 +55,7 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 				[]string{"package", "repository", "add", "-r", "tce", "--url", "projects.registry.vmware.com/tce/main:0.9.1"}},
 		}.Description("-r", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/spf13/cobra"
+	cmdapp "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/logger"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
@@ -47,6 +48,7 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 				[]string{"package", "repository", "delete", "-r", "tce"}},
 		}.Description("-r", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
+		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)

--- a/cli/pkg/kctrl/cmd/ui_flags.go
+++ b/cli/pkg/kctrl/cmd/ui_flags.go
@@ -19,8 +19,6 @@ type UIFlags struct {
 }
 
 func (f *UIFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, opts cmdcore.PackageCommandTreeOpts) {
-	// Default tty to true: https://github.com/vmware-tanzu/carvel-kapp/issues/28
-	cmd.PersistentFlags().BoolVar(&f.TTY, "tty", true, "Force TTY-like output")
 	if opts.Color {
 		cmd.PersistentFlags().BoolVar(&f.Color, "color", true, "Set color output")
 	}
@@ -32,8 +30,6 @@ func (f *UIFlags) Set(cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, opt
 }
 
 func (f *UIFlags) ConfigureUI(ui *ui.ConfUI) {
-	ui.EnableTTY(f.TTY)
-
 	if f.Color {
 		ui.EnableColor()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Set tty flag as an alternate/other flag instead of global flag.
- Set default value of tty to true for add/update, delete, pause, kick and status commands. For rest of the commands, default value should be false.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #717 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
