### PR TITLE
PackageInstall: check if semver constraints are nil 

### DIFF
--- a/pkg/packageinstall/packageinstall.go
+++ b/pkg/packageinstall/packageinstall.go
@@ -207,6 +207,9 @@ func (pi *PackageInstallCR) referencedPkgVersion() (datapkgingv1alpha1.Package, 
 	}
 
 	semverConfig := pi.model.Spec.PackageRef.VersionSelection
+	if semverConfig == nil {
+		return datapkgingv1alpha1.Package{}, fmt.Errorf("Expected non-empty version selection")
+	}
 
 	pkgList, err := pi.pkgclient.DataV1alpha1().Packages(pi.model.Namespace).List(
 		context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
so we error instead of panic

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

fixes #740 

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes # https://github.com/vmware-tanzu/carvel-kapp-controller/issues/740

#### Does this PR introduce a user-facing change?
Before this change:

1. copy example PKGI given in #740 into a file `borken.yml` 
2. run  `kapp deploy -a test -f borken.yml`

Observed behavior: kapp keeps polling for status, and there is a segfault in the kapp-controller logs. 

After this change: 
```
➜  ~ kapp deploy -a borken -f tmp-pkgi.yaml                                                                                                                                                                                                          [15/06/22|10:00AM]
Target cluster 'https://192.168.64.8:8443' (nodes: minikube)

Changes

Namespace  Name  Kind            Age  Op  Op st.  Wait to    Rs    Ri
default    test  PackageInstall  41m  -   -       reconcile  fail  Reconcile failed:  (message: unable
                                                                   to find valid semver version
                                                                   selection in PackageInstall test)

Op:      0 create, 0 delete, 0 update, 1 noop, 0 exists
Wait to: 1 reconcile, 0 delete, 0 noop

Continue? [yN]: y

10:35:47AM: ---- applying 1 changes [0/1 done] ----
10:35:47AM: noop packageinstall/test (packaging.carvel.dev/v1alpha1) namespace: default
10:35:47AM: ---- waiting on 1 changes [0/1 done] ----
10:35:47AM: fail: reconcile packageinstall/test (packaging.carvel.dev/v1alpha1) namespace: default
10:35:47AM:  ^ Reconcile failed:  (message: unable to find valid semver version selection in PackageInstall test)

kapp: Error: waiting on reconcile packageinstall/test (packaging.carvel.dev/v1alpha1) namespace: default:
  Finished unsuccessfully (Reconcile failed:  (message: unable to find valid semver version selection in PackageInstall test))
  ```


#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
