### PR TITLE
avoid having separate binary just for sidecarexec

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 /config-release
 /Dockerfile
 /tmp
+/controller
+/cli
+/.git

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ var Version = "develop"
 
 func main() {
 	ctrlOpts := Options{}
+	var sidecarexec bool
 
 	flag.IntVar(&ctrlOpts.Concurrency, "concurrency", 10, "Max concurrent reconciles")
 	flag.StringVar(&ctrlOpts.Namespace, "namespace", "", "Namespace to watch")
@@ -26,7 +27,13 @@ func main() {
 	flag.BoolVar(&ctrlOpts.EnablePprof, "dangerous-enable-pprof", false, "If set to true, enable pprof on "+PprofListenAddr)
 	flag.DurationVar(&ctrlOpts.APIRequestTimeout, "api-request-timeout", time.Duration(0), "HTTP timeout for Kubernetes API requests")
 	flag.BoolVar(&ctrlOpts.APIPriorityAndFairness, "enable-api-priority-and-fairness", true, "Enable/disable APIPriorityAndFairness feature gate for apiserver. Recommended to disable for <= k8s 1.19.")
+	flag.BoolVar(&sidecarexec, "sidecarexec", false, "Run sidecarexec")
 	flag.Parse()
+
+	if sidecarexec {
+		sidecarexecMain()
+		return
+	}
 
 	log := zap.New(zap.UseDevMode(false)).WithName("kc")
 	logf.SetLogger(log)

--- a/cmd/controller/sidecarexec.go
+++ b/cmd/controller/sidecarexec.go
@@ -13,10 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// Version is set via ldflags at build-time from the most recent git tag; see hack/build.sh
-var Version = "develop"
-
-func main() {
+func sidecarexecMain() {
 	mainLog := zap.New(zap.UseDevMode(false)).WithName("kc-sidecarexec")
 	mainLog.Info("start sidecarexec", "version", Version)
 

--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -60,7 +60,7 @@ spec:
             - all
       - name: kapp-controller-sidecarexec
         image: kapp-controller
-        command: ["/kapp-controller-sidecarexec"]
+        args: ["--sidecarexec"]
         resources:
           requests:
             cpu: 120m

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,9 +10,8 @@ go mod tidy
 go fmt ./cmd/... ./pkg/...
 
 go build -trimpath -mod=vendor -o controller ./cmd/controller/...
-go build -trimpath -mod=vendor -o controller-sidecarexec ./cmd/sidecarexec/main.go
 
-ls -la ./controller ./controller-sidecarexec
+ls -la ./controller
 
 ./hack/gen-crds.sh
 ytt -f config/ >/dev/null


### PR DESCRIPTION
#### What this PR does / why we need it:

- speeds up hack/deploy.sh
- reduces production kapp-controller image size by 39MB

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
 no

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
