### PR TITLE
support certificate reloading even when /etc is on a different mount from /tmp

### DIFF
--- a/pkg/sidecarexec/os_config.go
+++ b/pkg/sidecarexec/os_config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -52,7 +53,10 @@ func (r OSConfig) ApplyCACerts(chain string, unusedResult *int) error {
 	}
 	defer origCopyFile.Close()
 
-	tmpFile, err := os.CreateTemp(os.TempDir(), "tmp-ca-bundle-")
+	// Place tmp file into dst directory as Rename call below
+	// cannot succeed if tmp file is on a different mount
+	// (no guarantee that /tmp and /etc are on same fs).
+	tmpFile, err := os.CreateTemp(filepath.Dir(r.CACertsLoc.Path), "tmp-ca-bundle-")
 	if err != nil {
 		return fmt.Errorf("Creating tmp certs file: %s", err)
 	}

--- a/test/e2e/assets/https-server/server.yml
+++ b/test/e2e/assets/https-server/server.yml
@@ -9,6 +9,8 @@ kind: Service
 metadata:
   namespace: https-server
   name: https-svc
+  annotations:
+    kapp.k14s.io/change-group: server
 spec:
   selector:
     app: self-signed-https-server
@@ -21,6 +23,8 @@ kind: Deployment
 metadata:
   name: self-signed-https-server
   namespace: https-server
+  annotations:
+    kapp.k14s.io/change-group: server
 spec:
   replicas: 1
   selector:
@@ -107,3 +111,30 @@ data:
       name: http-server-returned-cm
     data:
       content: http-server-returned-content
+
+# TODO should we make vendir's http retry within App CR, to avoid
+# transient failure when Service=>Deployment networking is not ready?
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-nginx-conn
+  namespace: default
+  annotations:
+    kapp.k14s.io/update-strategy: always-replace
+    kapp.k14s.io/change-rule: upsert after upserting server
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: check-nginx-conn
+    spec:
+      containers:
+      - name: check
+        image: busybox
+        command:
+        - /bin/sh
+        - "-c"
+        - |
+          wget --tries=10 --no-check-certificate https://https-svc.https-server.svc.cluster.local/deployment.yml
+      restartPolicy: Never


### PR DESCRIPTION
#### What this PR does / why we need it:

manually tested by applying /etc mount similar to what TCE does.

it does expect that `chmod g+w /kapp-etc/pki/tls/certs/` is used for the directory, not file (at the end of https://github.com/vmware-tanzu/community-edition/blob/ffcf732e5522546d10a919560327e4d8cbd70c7c/addons/packages/kapp-controller/0.38.1/bundle/config/values.star#L17).

#### Which issue(s) this PR fixes:
n/a

#### Does this PR introduce a user-facing change?
no

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
