### PR TITLE
Disallow use of shared namespaces for package installs

### DIFF
--- a/cli/pkg/kctrl/cmd/core/namespace_flags.go
+++ b/cli/pkg/kctrl/cmd/core/namespace_flags.go
@@ -13,14 +13,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var sharedNamespaces = []string{
-	"default",
-	"kube-public",
-}
-
 type NamespaceFlags struct {
-	Name                    string
-	AllowedSharedNamespaces bool
+	Name string
 }
 
 func (s *NamespaceFlags) Set(cmd *cobra.Command, flagsFactory FlagsFactory) {
@@ -32,7 +26,6 @@ func (s *NamespaceFlags) SetWithPackageCommandTreeOpts(cmd *cobra.Command, flags
 	namespaceEnvVariableKey := fmt.Sprintf("%s_NAMESPACE", strings.ToUpper(opts.BinaryName))
 	name := flagsFactory.NewNamespaceNameFlag(&s.Name, namespaceEnvVariableKey)
 	cmd.Flags().VarP(name, "namespace", "n", fmt.Sprintf("Specified namespace ($%s or default from kubeconfig)", namespaceEnvVariableKey))
-	cmd.Flags().BoolVar(&s.AllowedSharedNamespaces, "dangerous-allow-use-of-shared-namespace", false, "Allow use of shared namespaces (default: false)")
 }
 
 type NamespaceNameFlag struct {
@@ -64,20 +57,6 @@ func (s *NamespaceNameFlag) Resolve() error {
 
 	*s.value = value
 
-	return nil
-}
-
-func (s *NamespaceFlags) CheckForDisallowedSharedNamespaces() error {
-	if s.AllowedSharedNamespaces {
-		return nil
-	}
-	for _, ns := range sharedNamespaces {
-		if s.Name == ns {
-			return fmt.Errorf(`Creating sensitive resources in a shared namespace (%s)
-			(hint: Specify a namespace using the '-n' flag or use kubeconfig to change default namespace 'kubectl config set-context --current --namespace=private-namespace'.
-			Or use '--dangerous-allow-allow-use-of-shared-namespace=%s' to allow use of shared namespace)`, s.Name, s.Name)
-		}
-	}
 	return nil
 }
 

--- a/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
+++ b/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
@@ -1,0 +1,37 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var sharedNamespaces = []string{
+	"default",
+	"kube-public",
+}
+
+type SecureNamespaceFlags struct {
+	AllowedSharedNamespaces bool
+}
+
+func (s *SecureNamespaceFlags) Set(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&s.AllowedSharedNamespaces, "dangerous-allow-use-of-shared-namespace", false, "Allow use of shared namespaces")
+}
+
+func (s *SecureNamespaceFlags) CheckForDisallowedSharedNamespaces(namespace string) error {
+	if s.AllowedSharedNamespaces {
+		return nil
+	}
+	for _, ns := range sharedNamespaces {
+		if namespace == ns {
+			return fmt.Errorf("Creating sensitive resources in a shared namespace (%s)"+
+				"(hint: Specify a namespace using the '-n' flag or use kubeconfig to change default namespace 'kubectl config set-context --current --namespace=private-namespace'."+
+				"Or use '--dangerous-allow-allow-use-of-shared-namespace=%s' to allow use of shared namespace)", namespace, namespace)
+		}
+	}
+	return nil
+}

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -198,6 +198,11 @@ func (o *CreateOrUpdateOptions) RunCreate(args []string) error {
 		return fmt.Errorf("Expected package name to be non empty")
 	}
 
+	err := o.NamespaceFlags.CheckForDisallowedSharedNamespaces()
+	if err != nil {
+		return err
+	}
+
 	if len(o.version) == 0 {
 		pkgClient, err := o.depsFactory.PackageClient()
 		if err != nil {
@@ -279,6 +284,11 @@ func (o *CreateOrUpdateOptions) RunUpdate(args []string) error {
 
 	if len(o.version) == 0 && len(o.valuesFile) == 0 && o.values {
 		return fmt.Errorf("Expected either package version or values file to update the package")
+	}
+
+	err := o.NamespaceFlags.CheckForDisallowedSharedNamespaces()
+	if err != nil {
+		return err
 	}
 
 	client, err := o.depsFactory.CoreClient()

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -50,9 +50,10 @@ type CreateOrUpdateOptions struct {
 
 	install bool
 
-	Name               string
-	NamespaceFlags     cmdcore.NamespaceFlags
-	createdAnnotations *CreatedResourceAnnotations
+	Name                 string
+	NamespaceFlags       cmdcore.NamespaceFlags
+	SecureNamespaceFlags cmdcore.SecureNamespaceFlags
+	createdAnnotations   *CreatedResourceAnnotations
 
 	pkgCmdTreeOpts cmdcore.PackageCommandTreeOpts
 }
@@ -80,6 +81,7 @@ func NewCreateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name (required)")
@@ -122,6 +124,7 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name (required)")
@@ -163,6 +166,7 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name")
@@ -198,7 +202,7 @@ func (o *CreateOrUpdateOptions) RunCreate(args []string) error {
 		return fmt.Errorf("Expected package name to be non empty")
 	}
 
-	err := o.NamespaceFlags.CheckForDisallowedSharedNamespaces()
+	err := o.SecureNamespaceFlags.CheckForDisallowedSharedNamespaces(o.NamespaceFlags.Name)
 	if err != nil {
 		return err
 	}
@@ -286,7 +290,7 @@ func (o *CreateOrUpdateOptions) RunUpdate(args []string) error {
 		return fmt.Errorf("Expected either package version or values file to update the package")
 	}
 
-	err := o.NamespaceFlags.CheckForDisallowedSharedNamespaces()
+	err := o.SecureNamespaceFlags.CheckForDisallowedSharedNamespaces(o.NamespaceFlags.Name)
 	if err != nil {
 		return err
 	}

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -16,8 +16,7 @@ import (
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/logger"
 	kappctrl "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
-	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
-	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
+	kcpkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
 	versions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -127,6 +126,11 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 		return fmt.Errorf("Expected package repository url to be non-empty")
 	}
 
+	err := o.NamespaceFlags.CheckForDisallowedSharedNamespaces()
+	if err != nil {
+		return err
+	}
+
 	client, err := o.depsFactory.KappCtrlClient()
 	if err != nil {
 		return err
@@ -180,23 +184,23 @@ func (o *AddOrUpdateOptions) add(client kcclient.Interface) error {
 	return err
 }
 
-func (o *AddOrUpdateOptions) newPackageRepository() (*v1alpha1.PackageRepository, error) {
-	pkgr := &v1alpha1.PackageRepository{
+func (o *AddOrUpdateOptions) newPackageRepository() (*kcpkg.PackageRepository, error) {
+	pkgr := &kcpkg.PackageRepository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      o.Name,
 			Namespace: o.NamespaceFlags.Name,
 		},
-		Spec: kappipkg.PackageRepositorySpec{},
+		Spec: kcpkg.PackageRepositorySpec{},
 	}
 
 	return o.updateExistingPackageRepository(pkgr)
 }
 
-func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *v1alpha1.PackageRepository) (*v1alpha1.PackageRepository, error) {
+func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *kcpkg.PackageRepository) (*kcpkg.PackageRepository, error) {
 
 	pkgr = pkgr.DeepCopy()
 
-	pkgr.Spec.Fetch = &kappipkg.PackageRepositoryFetch{
+	pkgr.Spec.Fetch = &kcpkg.PackageRepositoryFetch{
 		ImgpkgBundle: &kappctrl.AppFetchImgpkgBundle{Image: o.URL},
 	}
 

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -30,9 +30,10 @@ type AddOrUpdateOptions struct {
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
-	NamespaceFlags cmdcore.NamespaceFlags
-	Name           string
-	URL            string
+	NamespaceFlags       cmdcore.NamespaceFlags
+	SecureNamespaceFlags cmdcore.SecureNamespaceFlags
+	Name                 string
+	URL                  string
 
 	CreateRepository bool
 
@@ -59,6 +60,7 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set package repository name (required)")
@@ -94,6 +96,7 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set package repository name (required)")
@@ -126,7 +129,7 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 		return fmt.Errorf("Expected package repository url to be non-empty")
 	}
 
-	err := o.NamespaceFlags.CheckForDisallowedSharedNamespaces()
+	err := o.SecureNamespaceFlags.CheckForDisallowedSharedNamespaces(o.NamespaceFlags.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Disallows use of shared namespaces for package installations by default, to avoid storing sensitive configuration and RBAC resources in them. Adds a dangerous flag to override this behaviour.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #672 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
- Disallow use of shared namespaces (`default`, `kube-public`) by default
    - `--dangerous-allow-use-of-shared-namespace` can be used to override this default behaviour
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:
To be added
```docs

```
