### PR TITLE
Fix flakiness of private registry auth test

### DIFF
--- a/test/e2e/assets/registry/registry2.yml
+++ b/test/e2e/assets/registry/registry2.yml
@@ -9,6 +9,8 @@ kind: Service
 metadata:
   namespace: registry
   name: registry-svc
+  annotations:
+    kapp.k14s.io/change-group: server
 spec:
   selector:
     app: self-signed-registry
@@ -21,6 +23,8 @@ kind: Deployment
 metadata:
   name: self-signed-registry
   namespace: registry
+  annotations:
+    kapp.k14s.io/change-group: server
 spec:
   replicas: 1
   selector:
@@ -49,6 +53,11 @@ spec:
           value: /var/lib/tmp/registry
         ports:
         - containerPort: 443
+        startupProbe:
+          httpGet:
+            path: /
+            port: 443
+            scheme: HTTPS
         volumeMounts:
         - mountPath: /etc/ssl
           readOnly: true
@@ -79,3 +88,23 @@ spec:
           name: registry-contents
       - name: registry-sync
         emptyDir: {}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-registry-conn
+  namespace: default
+  annotations:
+    kapp.k14s.io/update-strategy: always-replace
+    kapp.k14s.io/change-rule: upsert after upserting server
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      name: check-registry-conn
+    spec:
+      containers:
+      - name: check
+        image: curlimages/curl
+        args: [-k, --connect-timeout, "1", https://registry-svc.registry]
+      restartPolicy: Never


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
vendir doesn't retry, so we need to make sure that the registry service is up and responsive before we deploy anything to kapp-controller
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Part of #753

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```