### PR TITLE
Add tailing behaviour to package repo and add a package repo kick command

### DIFF
--- a/cli/pkg/kctrl/cmd/app/app_tailer.go
+++ b/cli/pkg/kctrl/cmd/app/app_tailer.go
@@ -8,14 +8,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cppforlife/color"
 	"github.com/cppforlife/go-cli-ui/ui"
 	uitable "github.com/cppforlife/go-cli-ui/ui/table"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
 	kcexternalversions "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -29,10 +27,9 @@ type AppTailer struct {
 	statusUI cmdcore.StatusLoggingUI
 	client   kcclient.Interface
 
-	stopperChan       chan struct{}
-	erroredWhileWatch bool
-	failureMessage    string
-	opts              AppTailerOpts
+	stopperChan chan struct{}
+	watchError  error
+	opts        AppTailerOpts
 
 	lastSeenDeployStdout string
 }
@@ -48,78 +45,19 @@ func NewAppTailer(namespace string, name string, ui ui.UI, client kcclient.Inter
 }
 
 func (o *AppTailer) printTillCurrent(status kcv1alpha1.AppStatus) error {
-	if o.isDeleting(status) {
+	if IsDeleting(status) {
 		return nil
 	}
 
-	o.printUpdate(kcv1alpha1.AppStatus{}, status)
-
-	if o.erroredWhileWatch {
-		return fmt.Errorf("Reconciling app: %s", o.failureMessage)
+	completed, err := NewAppStatusDiff(kcv1alpha1.AppStatus{}, status, o.statusUI).PrintUpdate()
+	if err != nil {
+		return fmt.Errorf("Reconciling app: %s", err)
 	}
+	if completed {
+		o.stopWatch()
+	}
+
 	return nil
-}
-
-func (o *AppTailer) printUpdate(oldStatus kcv1alpha1.AppStatus, status kcv1alpha1.AppStatus) {
-	if status.Fetch != nil {
-		if oldStatus.Fetch == nil || (!oldStatus.Fetch.StartedAt.Equal(&status.Fetch.StartedAt) && status.Fetch.UpdatedAt.Unix() <= status.Fetch.StartedAt.Unix()) {
-			o.statusUI.PrintLogLine("Fetch started", "", false, status.Fetch.StartedAt.Time)
-		}
-		if oldStatus.Fetch == nil || !oldStatus.Fetch.UpdatedAt.Equal(&status.Fetch.UpdatedAt) {
-			if status.Fetch.ExitCode != 0 && status.Fetch.UpdatedAt.Unix() >= status.Fetch.StartedAt.Unix() {
-				msg := "Fetch failed"
-				o.statusUI.PrintLogLine(msg, status.Fetch.Stderr, true, status.Fetch.UpdatedAt.Time)
-				o.failureMessage = msg
-				o.stopWatch(true)
-				return
-			}
-			o.statusUI.PrintLogLine("Fetching", status.Fetch.Stdout, false, status.Fetch.UpdatedAt.Time)
-			o.statusUI.PrintLogLine("Fetch succeeded", "", false, status.Fetch.UpdatedAt.Time)
-		}
-	}
-	if status.Template != nil {
-		if oldStatus.Template == nil || !oldStatus.Template.UpdatedAt.Equal(&status.Template.UpdatedAt) {
-			if status.Template.ExitCode != 0 {
-				msg := "Template failed"
-				o.statusUI.PrintLogLine(msg, status.Template.Stderr, true, status.Template.UpdatedAt.Time)
-				o.failureMessage = msg
-				o.stopWatch(true)
-				return
-			}
-			o.statusUI.PrintLogLine("Template succeeded", "", false, status.Template.UpdatedAt.Time)
-		}
-	}
-	if status.Deploy != nil {
-		isDeleting := o.isDeleting(status)
-		ongoingOp := "Deploy"
-		if isDeleting {
-			ongoingOp = "Delete"
-		}
-		if oldStatus.Deploy == nil || !oldStatus.Deploy.StartedAt.Equal(&status.Deploy.StartedAt) {
-			msg := fmt.Sprintf("%s started", ongoingOp)
-			o.statusUI.PrintLogLine(msg, "", false, status.Deploy.StartedAt.Time)
-		}
-		if oldStatus.Deploy == nil || !oldStatus.Deploy.UpdatedAt.Equal(&status.Deploy.UpdatedAt) {
-			if status.Deploy.ExitCode != 0 && status.Deploy.Finished {
-				msg := fmt.Sprintf("Deploy failed")
-				o.statusUI.PrintLogLine(msg, status.Deploy.Stderr, true, status.Deploy.UpdatedAt.Time)
-				o.failureMessage = msg
-				o.stopWatch(true)
-				return
-			}
-			o.printDeployStdout(status.Deploy.Stdout, status.Deploy.UpdatedAt.Time, isDeleting)
-		}
-	}
-
-	if o.hasReconciled(status) {
-		o.statusUI.PrintLogLine("Deploy succeeded", "", false, status.Deploy.UpdatedAt.Time)
-		o.stopWatch(false)
-	}
-	failed, errMsg := o.hasFailed(status)
-	if failed {
-		o.statusUI.PrintLogLine(errMsg, "", true, time.Now())
-		o.stopWatch(true)
-	}
 }
 
 func (o *AppTailer) printInfo(app kcv1alpha1.App) {
@@ -156,36 +94,6 @@ func (o *AppTailer) metricString(status kcv1alpha1.AppStatus) string {
 	}
 }
 
-func (o *AppTailer) hasReconciled(status kcv1alpha1.AppStatus) bool {
-	for _, condition := range status.Conditions {
-		if condition.Type == kcv1alpha1.ReconcileSucceeded && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func (o *AppTailer) hasFailed(status kcv1alpha1.AppStatus) (bool, string) {
-	for _, condition := range status.Conditions {
-		if condition.Type == kcv1alpha1.ReconcileFailed && condition.Status == corev1.ConditionTrue {
-			return true, color.RedString(fmt.Sprintf("%s: %s", kcv1alpha1.ReconcileFailed, status.UsefulErrorMessage))
-		}
-		if condition.Type == kcv1alpha1.DeleteFailed && condition.Status == corev1.ConditionTrue {
-			return true, color.RedString(fmt.Sprintf("%s: %s", kcv1alpha1.DeleteFailed, status.UsefulErrorMessage))
-		}
-	}
-	return false, ""
-}
-
-func (o *AppTailer) isDeleting(status kcv1alpha1.AppStatus) bool {
-	for _, condition := range status.Conditions {
-		if condition.Type == kcv1alpha1.Deleting && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
 func (o *AppTailer) TailAppStatus() error {
 	o.stopperChan = make(chan struct{})
 	app, err := o.client.KappctrlV1alpha1().Apps(o.Namespace).Get(context.Background(), o.Name, metav1.GetOptions{})
@@ -205,7 +113,7 @@ func (o *AppTailer) TailAppStatus() error {
 			return err
 		}
 
-		if o.hasReconciled(app.Status) {
+		if HasReconciled(app.Status) {
 			return nil
 		}
 	}
@@ -225,14 +133,13 @@ func (o *AppTailer) TailAppStatus() error {
 	}
 
 	<-o.stopperChan
-	if o.erroredWhileWatch {
-		return fmt.Errorf("Reconciling app: %s", o.failureMessage)
+	if o.watchError != nil {
+		return fmt.Errorf("Reconciling app: %s", o.watchError)
 	}
 	return nil
 }
 
-func (o *AppTailer) stopWatch(failing bool) {
-	o.erroredWhileWatch = failing
+func (o *AppTailer) stopWatch() {
 	close(o.stopperChan)
 }
 
@@ -245,12 +152,17 @@ func (o *AppTailer) udpateEventHandler(oldObj interface{}, newObj interface{}) {
 		return
 	}
 
-	o.printUpdate(oldApp.Status, newApp.Status)
+	// o.printUpdate(oldApp.Status, newApp.Status)
+	stopWatch, err := NewAppStatusDiff(oldApp.Status, newApp.Status, o.statusUI).PrintUpdate()
+	o.watchError = err
+	if stopWatch {
+		o.stopWatch()
+	}
 }
 
 func (o *AppTailer) deleteEventHandler(oldObj interface{}) {
 	o.statusUI.PrintLogLine(fmt.Sprintf("App '%s' in namespace '%s' deleted", o.Name, o.Namespace), "", false, time.Now())
-	o.stopWatch(false)
+	o.stopWatch()
 }
 
 func (o *AppTailer) printDeployStdout(stdout string, timestamp time.Time, isDeleting bool) {
@@ -267,4 +179,93 @@ func (o *AppTailer) printDeployStdout(stdout string, timestamp time.Time, isDele
 	o.statusUI.PrintMessageBlockDiff(o.lastSeenDeployStdout, stdout, timestamp)
 
 	o.lastSeenDeployStdout = stdout
+}
+
+type AppStatusDiff struct {
+	old kcv1alpha1.AppStatus
+	new kcv1alpha1.AppStatus
+
+	statusUI cmdcore.StatusLoggingUI
+
+	lastSeenDeployStdout string
+}
+
+func NewAppStatusDiff(old kcv1alpha1.AppStatus, new kcv1alpha1.AppStatus, statusUI cmdcore.StatusLoggingUI) *AppStatusDiff {
+	return &AppStatusDiff{old: old, new: new, statusUI: statusUI}
+}
+
+func (d *AppStatusDiff) PrintUpdate() (bool, error) {
+	if d.new.Fetch != nil {
+		if d.old.Fetch == nil || (!d.old.Fetch.StartedAt.Equal(&d.new.Fetch.StartedAt) && d.new.Fetch.UpdatedAt.Unix() <= d.new.Fetch.StartedAt.Unix()) {
+			d.statusUI.PrintLogLine("Fetch started", "", false, d.new.Fetch.StartedAt.Time)
+		}
+		if d.old.Fetch == nil || !d.old.Fetch.UpdatedAt.Equal(&d.new.Fetch.UpdatedAt) {
+			if d.new.Fetch.ExitCode != 0 && d.new.Fetch.UpdatedAt.Unix() >= d.new.Fetch.StartedAt.Unix() {
+				msg := "Fetch failed"
+				errLog := d.new.Fetch.Stderr + "\n" + d.new.Fetch.Error
+				d.statusUI.PrintLogLine(msg, errLog, true, d.new.Fetch.UpdatedAt.Time)
+				return true, fmt.Errorf(msg)
+			}
+			d.statusUI.PrintLogLine("Fetching", d.new.Fetch.Stdout, false, d.new.Fetch.UpdatedAt.Time)
+			d.statusUI.PrintLogLine("Fetch succeeded", "", false, d.new.Fetch.UpdatedAt.Time)
+		}
+	}
+	if d.new.Template != nil {
+		if d.old.Template == nil || !d.old.Template.UpdatedAt.Equal(&d.new.Template.UpdatedAt) {
+			if d.new.Template.ExitCode != 0 {
+				msg := "Template failed"
+				errLog := d.new.Template.Stderr + "\n" + d.new.Template.Error
+				d.statusUI.PrintLogLine(msg, errLog, true, d.new.Template.UpdatedAt.Time)
+				return true, fmt.Errorf(msg)
+			}
+			d.statusUI.PrintLogLine("Template succeeded", "", false, d.new.Template.UpdatedAt.Time)
+		}
+	}
+	if d.new.Deploy != nil {
+		isDeleting := IsDeleting(d.new)
+		ongoingOp := "Deploy"
+		if isDeleting {
+			ongoingOp = "Delete"
+		}
+		if d.old.Deploy == nil || !d.old.Deploy.StartedAt.Equal(&d.new.Deploy.StartedAt) {
+			msg := fmt.Sprintf("%s started", ongoingOp)
+			d.statusUI.PrintLogLine(msg, "", false, d.new.Deploy.StartedAt.Time)
+		}
+		if d.old.Deploy == nil || !d.old.Deploy.UpdatedAt.Equal(&d.new.Deploy.UpdatedAt) {
+			if d.new.Deploy.ExitCode != 0 && d.new.Deploy.Finished {
+				msg := fmt.Sprintf("%s failed", ongoingOp)
+				errLog := d.new.Deploy.Stderr + "\n" + d.new.Deploy.Error
+				d.statusUI.PrintLogLine(msg, errLog, true, d.new.Deploy.UpdatedAt.Time)
+				return true, fmt.Errorf(msg)
+			}
+			d.printDeployStdout(d.new.Deploy.Stdout, d.new.Deploy.UpdatedAt.Time, isDeleting)
+		}
+	}
+
+	if HasReconciled(d.new) {
+		d.statusUI.PrintLogLine("Deploy succeeded", "", false, d.new.Deploy.UpdatedAt.Time)
+		return true, nil
+	}
+	failed, errMsg := HasFailed(d.new)
+	if failed {
+		d.statusUI.PrintLogLine(errMsg, "", true, time.Now())
+		return true, fmt.Errorf(errMsg)
+	}
+	return false, nil
+}
+
+func (d *AppStatusDiff) printDeployStdout(stdout string, timestamp time.Time, isDeleting bool) {
+	if d.lastSeenDeployStdout == "" {
+		d.lastSeenDeployStdout = stdout
+		msg := "Deploying"
+		if isDeleting {
+			msg = "Deleting"
+		}
+		d.statusUI.PrintLogLine(msg, stdout, false, timestamp)
+		return
+	}
+
+	d.statusUI.PrintMessageBlockDiff(d.lastSeenDeployStdout, stdout, timestamp)
+
+	d.lastSeenDeployStdout = stdout
 }

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -165,6 +165,7 @@ func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcor
 	pkgrepoCmd.AddCommand(pkgrepo.NewDeleteCmd(pkgrepo.NewDeleteOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgrepo.NewAddCmd(pkgrepo.NewAddOrUpdateOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgrepo.NewUpdateCmd(pkgrepo.NewAddOrUpdateOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
+	pkgrepoCmd.AddCommand(pkgrepo.NewKickCmd(pkgrepo.NewKickOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 
 	pkgiCmd := pkginst.NewCmd()
 	pkgiCmd.AddCommand(pkginst.NewListCmd(pkginst.NewListOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -13,16 +13,13 @@ import (
 	cmdapp "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/logger"
-	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type DeleteOptions struct {
 	ui          ui.UI
+	statusUI    cmdcore.StatusLoggingUI
 	depsFactory cmdcore.DepsFactory
 	logger      logger.Logger
 
@@ -35,7 +32,7 @@ type DeleteOptions struct {
 }
 
 func NewDeleteOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger, pkgCmdTreeOpts cmdcore.PackageCommandTreeOpts) *DeleteOptions {
-	return &DeleteOptions{ui: ui, depsFactory: depsFactory, logger: logger, pkgCmdTreeOpts: pkgCmdTreeOpts}
+	return &DeleteOptions{ui: ui, statusUI: cmdcore.NewStatusLoggingUI(ui), depsFactory: depsFactory, logger: logger, pkgCmdTreeOpts: pkgCmdTreeOpts}
 }
 
 func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
@@ -103,37 +100,13 @@ func (o *DeleteOptions) Run(args []string) error {
 }
 
 func (o *DeleteOptions) waitForDeletion(client versioned.Interface) error {
-	o.ui.PrintLinef("Waiting for deletion to be completed...")
-	msgsUI := cmdcore.NewDedupingMessagesUI(cmdcore.NewPlainMessagesUI(o.ui))
-	description := getPackageRepositoryDescription(o.Name, o.NamespaceFlags.Name)
+	o.statusUI.PrintMessagef("Waiting for package repository reconciliation for '%s'", o.Name)
+	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client)
 
-	if err := wait.Poll(o.WaitFlags.CheckInterval, o.WaitFlags.Timeout, func() (done bool, err error) {
-		pkgr, err := client.PackagingV1alpha1().PackageRepositories(
-			o.NamespaceFlags.Name).Get(context.Background(), o.Name, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				msgsUI.NotifySection("%s: DeletionSucceeded", description)
-				return true, nil
-			}
-			return false, err
-		}
-
-		status := pkgr.Status.GenericStatus
-
-		// Should wait for generation to be observed before checking
-		// the reconciliation status so that we know we are checking the new spec
-		if pkgr.Generation == pkgr.Status.ObservedGeneration {
-			for _, condition := range pkgr.Status.Conditions {
-				msgsUI.NotifySection("%s: %s", description, condition.Type)
-
-				if condition.Type == v1alpha1.DeleteFailed && condition.Status == corev1.ConditionTrue {
-					return false, fmt.Errorf("%s: Deleting: %s. %s", description, status.UsefulErrorMessage, status.FriendlyDescription)
-				}
-			}
-		}
-		return false, nil
-	}); err != nil {
-		return fmt.Errorf("%s: Deleting: %s", description, err)
+	err := repoWatcher.TailRepoStatus()
+	if err != nil {
+		return err
 	}
+
 	return nil
 }

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -1,0 +1,148 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/spf13/cobra"
+	cmdapp "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
+	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/logger"
+	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type KickOptions struct {
+	ui          ui.UI
+	statusUI    cmdcore.StatusLoggingUI
+	depsFactory cmdcore.DepsFactory
+	logger      logger.Logger
+
+	WaitFlags cmdcore.WaitFlags
+
+	NamespaceFlags cmdcore.NamespaceFlags
+	Name           string
+}
+
+func NewKickOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger) *KickOptions {
+	return &KickOptions{ui: ui, statusUI: cmdcore.NewStatusLoggingUI(ui), depsFactory: depsFactory, logger: logger}
+}
+
+func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "kick",
+		Short:       "Trigger reconciliation for repository",
+		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: ""},
+	}
+
+	o.NamespaceFlags.Set(cmd, flagsFactory)
+	cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set repository name (required)")
+	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
+		AllowDisableWait: true,
+		DefaultInterval:  1 * time.Second,
+		DefaultTimeout:   5 * time.Minute,
+	})
+
+	return cmd
+}
+
+func (o *KickOptions) Run() error {
+	if len(o.Name) == 0 {
+		return fmt.Errorf("Expected repository name to be non empty")
+	}
+
+	client, err := o.depsFactory.KappCtrlClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.PackagingV1alpha1().PackageRepositories(o.NamespaceFlags.Name).Get(context.Background(), o.Name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("Repository '%s' does not exist in namespace '%s'", o.Name, o.NamespaceFlags.Name)
+		}
+		return err
+	}
+
+	o.ui.BeginLinef("Triggering reconciliation for package repository '%s' in namespace '%s'", o.Name, o.NamespaceFlags.Name)
+	err = o.ui.AskForConfirmation()
+	if err != nil {
+		return err
+	}
+
+	err = o.triggerReconciliation(client)
+	if err != nil {
+		return err
+	}
+
+	if o.WaitFlags.Enabled {
+		err = o.waitForReconciliation(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *KickOptions) triggerReconciliation(client kcclient.Interface) error {
+	pausePatch := []map[string]interface{}{
+		{
+			"op":    "add",
+			"path":  "/spec/paused",
+			"value": true,
+		},
+	}
+
+	patchJSON, err := json.Marshal(pausePatch)
+	if err != nil {
+		return err
+	}
+
+	o.statusUI.PrintMessagef("Triggering reconciliation for package repository '%s' in namespace '%s'", o.Name, o.NamespaceFlags.Name)
+
+	_, err = client.PackagingV1alpha1().PackageRepositories(o.NamespaceFlags.Name).Patch(context.Background(), o.Name, types.JSONPatchType, patchJSON, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	unpausePatch := []map[string]interface{}{
+		{
+			"op":   "remove",
+			"path": "/spec/paused",
+		},
+	}
+
+	patchJSON, err = json.Marshal(unpausePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.PackagingV1alpha1().PackageRepositories(o.NamespaceFlags.Name).Patch(context.Background(), o.Name, types.JSONPatchType, patchJSON, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *KickOptions) waitForReconciliation(client kcclient.Interface) error {
+	o.statusUI.PrintMessagef("Waiting for package repository reconciliation for '%s'", o.Name)
+	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client)
+
+	err := repoWatcher.TailRepoStatus()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/pkg/kctrl/cmd/package/repository/repo_tailer.go
+++ b/cli/pkg/kctrl/cmd/package/repository/repo_tailer.go
@@ -1,0 +1,125 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cppforlife/go-cli-ui/ui"
+	cmdapp "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
+	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	kcpkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
+	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
+	kcexternalversions "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type RepoTailer struct {
+	Namespace string
+	Name      string
+
+	ui       ui.UI
+	statusUI cmdcore.StatusLoggingUI
+	client   kcclient.Interface
+
+	stopperChan chan struct{}
+	watchError  error
+
+	lastSeenDeployStdout string
+}
+
+func NewRepoTailer(namespace string, name string, ui ui.UI, client kcclient.Interface) *RepoTailer {
+	return &RepoTailer{Namespace: namespace, Name: name, ui: ui, statusUI: cmdcore.NewStatusLoggingUI(ui), client: client}
+}
+
+func (o *RepoTailer) TailRepoStatus() error {
+	o.stopperChan = make(chan struct{})
+	_, err := o.client.PackagingV1alpha1().PackageRepositories(o.Namespace).Get(context.Background(), o.Name, metav1.GetOptions{})
+	if err != nil {
+		if !(errors.IsNotFound(err)) {
+			return err
+		}
+	}
+
+	informerFactory := kcexternalversions.NewFilteredSharedInformerFactory(o.client, 30*time.Minute, o.Namespace, func(opts *metav1.ListOptions) {
+		opts.FieldSelector = fmt.Sprintf("metadata.name=%s", o.Name)
+	})
+	informer := informerFactory.Packaging().V1alpha1().PackageRepositories().Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: o.udpateEventHandler,
+		DeleteFunc: o.deleteEventHandler,
+	})
+
+	go informer.Run(o.stopperChan)
+	if !cache.WaitForCacheSync(o.stopperChan, informer.HasSynced) {
+		return fmt.Errorf("Timed out waiting for caches to sync")
+	}
+
+	<-o.stopperChan
+	if o.watchError != nil {
+		return fmt.Errorf("Reconciling repository: %s", o.watchError)
+	}
+	return nil
+}
+
+func (o *RepoTailer) stopWatch() {
+	close(o.stopperChan)
+}
+
+func (o *RepoTailer) printTillCurrent(status kcv1alpha1.AppStatus) error {
+	if cmdapp.IsDeleting(status) {
+		return nil
+	}
+
+	completed, err := cmdapp.NewAppStatusDiff(kcv1alpha1.AppStatus{}, status, o.statusUI).PrintUpdate()
+	if err != nil {
+		return fmt.Errorf("Reconciling package repository: %s", err)
+	}
+	if completed {
+		o.stopWatch()
+	}
+
+	return nil
+}
+
+func (o *RepoTailer) udpateEventHandler(oldObj interface{}, newObj interface{}) {
+	newRepo, _ := newObj.(*kcpkgv1alpha1.PackageRepository)
+	oldRepo, _ := oldObj.(*kcpkgv1alpha1.PackageRepository)
+
+	if newRepo.Generation != newRepo.Status.ObservedGeneration {
+		o.statusUI.PrintLogLine(fmt.Sprintf("Waiting for generation %d to be observed", newRepo.Generation), "", false, time.Now())
+		return
+	}
+
+	mappedOldStatus := o.appStatusFromPkgrStatus(oldRepo.Status)
+	mappedNewStatus := o.appStatusFromPkgrStatus(newRepo.Status)
+
+	// o.printUpdate(oldApp.Status, newApp.Status)
+	stopWatch, err := cmdapp.NewAppStatusDiff(mappedOldStatus, mappedNewStatus, o.statusUI).PrintUpdate()
+	o.watchError = err
+	if stopWatch {
+		o.stopWatch()
+	}
+}
+
+func (o *RepoTailer) deleteEventHandler(oldObj interface{}) {
+	o.statusUI.PrintLogLine(fmt.Sprintf("Package repository '%s' in namespace '%s' deleted", o.Name, o.Namespace), "", false, time.Now())
+	o.stopWatch()
+}
+
+func (o *RepoTailer) appStatusFromPkgrStatus(status kcpkgv1alpha1.PackageRepositoryStatus) kcv1alpha1.AppStatus {
+	return kcv1alpha1.AppStatus{
+		Fetch:    status.Fetch,
+		Template: status.Template,
+		Deploy:   status.Deploy,
+		GenericStatus: kcv1alpha1.GenericStatus{
+			Conditions: status.Conditions,
+		},
+	}
+}

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -64,6 +64,13 @@ func TestPackageRepository(t *testing.T) {
 		kubectl.Run([]string{"get", "pkg/pkg.test.carvel.dev.2.0.0"})
 	})
 
+	logger.Section("kicking a repository", func() {
+		out := kappCtrl.Run([]string{"package", "repository", "kick", "-r", pkgrName})
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+	})
+
 	logger.Section("listing repositories with one repository being present", func() {
 		out, _ := kappCtrl.RunWithOpts([]string{"package", "repository", "list", "--json"}, RunOpts{})
 

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -53,7 +53,11 @@ func TestPackageRepository(t *testing.T) {
 	})
 
 	logger.Section("adding a repository", func() {
-		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL})
+		out := kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL})
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+
 		kubectl.Run([]string{"get", kind, pkgrName})
 		kubectl.Run([]string{"get", "pkgm/pkg.test.carvel.dev"})
 		kubectl.Run([]string{"get", "pkg/pkg.test.carvel.dev.1.0.0"})
@@ -103,9 +107,12 @@ func TestPackageRepository(t *testing.T) {
 
 		kubectl.Run([]string{"get", kind, pkgrName})
 
-		kappCtrl.Run([]string{"package", "repository", "update", "-r", pkgrName, "--url", pkgrURL})
+		out := kappCtrl.Run([]string{"package", "repository", "update", "-r", pkgrName, "--url", pkgrURL})
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
 
-		out := kappCtrl.Run([]string{"package", "repository", "get", "-r", pkgrName, "--json"})
+		out = kappCtrl.Run([]string{"package", "repository", "get", "-r", pkgrName, "--json"})
 
 		output := uitest.JSONUIFromBytes(t, []byte(out))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR adds the tailing behaviour seen in package installs to package repos as well.
A kick command to trigger reconciliation for a package repository is added as well.

It also makes a a lot of logic in the app package reusable.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #671 
Fixes #763 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
- Adds progress tailing behaviour to package repo commands
- Adds `package repo kick` command which lets users trigger reconciliation for package repositories
```

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
