### PR TITLE
execute pkg repo fetching in the sidecar

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -130,6 +130,8 @@ func Run(opts Options, runLog logr.Logger) error {
 		return fmt.Errorf("Starting RPC client: %s", err)
 	}
 
+	sidecarCmdExec := sidecarClient.CmdExec()
+
 	{ // add controller for config
 		reconciler := kcconfig.NewReconciler(
 			coreClient, kcConfig, sidecarClient.OSConfig(), runLog.WithName("config"))
@@ -169,7 +171,7 @@ func Run(opts Options, runLog logr.Logger) error {
 			AppClient:  kcClient,
 			KcConfig:   kcConfig,
 			AppMetrics: appMetrics,
-			CmdRunner:  sidecarClient.CmdExec(),
+			CmdRunner:  sidecarCmdExec,
 		}
 		reconciler := app.NewReconciler(kcClient, runLog.WithName("app"),
 			appFactory, refTracker, updateStatusTracker)
@@ -213,7 +215,7 @@ func Run(opts Options, runLog logr.Logger) error {
 	}
 
 	{ // add controller for pkgrepositories
-		appFactory := pkgrepository.AppFactory{coreClient, kcClient, kcConfig}
+		appFactory := pkgrepository.AppFactory{coreClient, kcClient, kcConfig, sidecarCmdExec}
 
 		reconciler := pkgrepository.NewReconciler(kcClient, coreClient,
 			runLog.WithName("pkgr"), appFactory, refTracker, updateStatusTracker)

--- a/pkg/pkgrepository/app_factory.go
+++ b/pkg/pkgrepository/app_factory.go
@@ -21,13 +21,13 @@ type AppFactory struct {
 	CoreClient kubernetes.Interface
 	AppClient  kcclient.Interface
 	KcConfig   *config.Config
+	CmdRunner  exec.CmdRunner
 }
 
 // NewCRDPackageRepo constructs "hidden" App to reconcile PackageRepository.
 func (f *AppFactory) NewCRDPackageRepo(app *kcv1alpha1.App, pkgr *pkgv1alpha1.PackageRepository, log logr.Logger) *CRDApp {
-	cmdRunner := exec.PlainCmdRunner{}
-	fetchFactory := fetch.NewFactory(f.CoreClient, fetch.VendirOpts{SkipTLSConfig: f.KcConfig}, cmdRunner)
-	templateFactory := template.NewFactory(f.CoreClient, fetchFactory, false, cmdRunner)
-	deployFactory := deploy.NewFactory(f.CoreClient, nil, cmdRunner, log)
+	fetchFactory := fetch.NewFactory(f.CoreClient, fetch.VendirOpts{SkipTLSConfig: f.KcConfig}, f.CmdRunner)
+	templateFactory := template.NewFactory(f.CoreClient, fetchFactory, false, f.CmdRunner)
+	deployFactory := deploy.NewFactory(f.CoreClient, nil, f.CmdRunner, log)
 	return NewCRDApp(app, pkgr, log, f.AppClient, fetchFactory, templateFactory, deployFactory)
 }

--- a/pkg/pkgrepository/app_fetch.go
+++ b/pkg/pkgrepository/app_fetch.go
@@ -6,14 +6,11 @@ package pkgrepository
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path"
 	"strconv"
 	"time"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
-
-	goexec "os/exec"
 )
 
 func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
@@ -42,7 +39,8 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 		return "", result
 	}
 
-	result = a.runVendir(conf, dstPath)
+	result = vendir.Run(conf, dstPath)
+
 	// retry if error occurs before reporting failure.
 	// This is mainly done to support private registry
 	// authentication for images/bundles since placeholder
@@ -63,7 +61,7 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 				// no secrets/configmaps have changed, no point in retrying
 				continue
 			}
-			result = a.runVendir(newConf, dstPath)
+			result = vendir.Run(newConf, dstPath)
 			if result.Error == nil {
 				break
 			}
@@ -79,23 +77,4 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 	}
 
 	return dstPath, result
-}
-
-func (a *App) runVendir(conf []byte, workingDir string) exec.CmdRunResult {
-	var stdoutBs, stderrBs bytes.Buffer
-	cmd := goexec.Command("vendir", "sync", "-f", "-", "--lock-file", os.DevNull)
-	cmd.Dir = workingDir
-	cmd.Stdin = bytes.NewReader(conf)
-	cmd.Stdout = &stdoutBs
-	cmd.Stderr = &stderrBs
-
-	err := cmd.Run()
-
-	result := exec.CmdRunResult{
-		Stdout: stdoutBs.String(),
-		Stderr: stderrBs.String(),
-	}
-	result.AttachErrorf("Fetching resources: %s", err)
-
-	return result
 }

--- a/test/e2e/assets/https-server/server.yml
+++ b/test/e2e/assets/https-server/server.yml
@@ -111,6 +111,26 @@ data:
       name: http-server-returned-cm
     data:
       content: http-server-returned-content
+binaryData:
+  # Includes single file: packages/package.yml
+  #   ---
+  #   apiVersion: data.packaging.carvel.dev/v1alpha1
+  #   kind: Package
+  #   metadata:
+  #     name: package-behind-ca-cert.carvel.dev.1.0.0
+  #   spec:
+  #     refName: package-behind-ca-cert.carvel.dev
+  #     version: 1.0.0
+  #     template:
+  #       spec:
+  #         fetch:
+  #         - http:
+  #             url: unused
+  #         template:
+  #         - ytt: {}
+  #         deploy:
+  #         - kapp: {}
+  packages.tar: "H4sIAHczxmIAA+2SS2rEMAyGZ51T6AL22KmTQg5RuupetZVJyGOM4wRC6d0bx5M+oAylDJRCvo0sS/+PjGVRN3ii4Wjjgc9de7gxQohcKQjxPs/WKNKYr2QiA6nSXKo7makUhFSZzA4gbj3Id4yDR7eMYprrfUtbWV6px6fAe/wnMMYStPUTuaE+9wUY9MjjLtT9iWt0E7Xc0HScJLa2Qpk0dW8KeIz7knTkMYiKBKDHjgq4bBJ7pmrpZBqZJuc/WXHJBRfJYEkHlaPy4WfCpXnaBo0eAJ4626Kn4ASweQZK8rraEgaV93bLAqNrCxj7cSBzuf1qFTSz9wW8vF5yQ7Y9zx/VBq1dy3/9iTs7Ozu/4A1GdDfIAAgAAA=="
 
 # TODO should we make vendir's http retry within App CR, to avoid
 # transient failure when Service=>Deployment networking is not ready?


### PR DESCRIPTION
#### What this PR does / why we need it:

- if pkg repo fetching is not executed within the sidecar, os level configuration for proxying and ca certs will not be applied to pkg repos

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
