### PR TITLE
Add release-published workflow

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,31 @@
+name: Checks after any release is published
+on:
+  release:
+    types: ['published']
+
+jobs:
+  validate-github-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vmware-tanzu/carvel-setup-action@v1
+        with:
+          only: kctrl
+          kctrl: ${{ github.event.release.tag_name }}
+      - run: |
+          kctrl version
+          version=`kctrl version`
+          tag="${{ github.event.release.tag_name }}"
+          tool_version="$(echo $version | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')"
+          if [[ "v${tool_version}" == "${tag}" ]];
+          then
+            echo "Version match with $tag"
+            exit 0
+          else
+            echo "Versions do not match v$tool_version != $tag"
+            exit 1
+          fi
+      - run: |
+          curl -X POST https://api.github.com/repos/vmware-tanzu/carvel-release-scripts/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.carvel_bot_access_token }} \
+          --data '{"event_type": "kctrl_released", "client_payload": { "tagName": "${{ github.event.release.tag_name }}", "repo": "${{ github.repository }}", "toolName": "kctrl" }}'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add release-published workflow which triggers bumping kctrl version in carvel-release-scripts.
Identical to the release-published workflows present in other tools.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
With the carvel-setup-action now supporting kctrl, this is the final piece that would be required to bump kctrl version in homebrew and install script whenever a release is published.

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
