### PR TITLE
Fix flaky Test_PackageInstall_UsesExistingAppWithSameName test

### DIFF
--- a/test/e2e/kappcontroller/packageinstall_test.go
+++ b/test/e2e/kappcontroller/packageinstall_test.go
@@ -448,6 +448,7 @@ spec:
 
 	logger.Section("Create App CR", func() {
 		kubectl.RunWithOpts([]string{"apply", "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
+		kubectl.Run([]string{"wait", "--for=condition=ReconcileSucceeded", "app/" + name, "--timeout", "1m"})
 	})
 
 	logger.Section("Create PackageInstall with same name as App CR", func() {


### PR DESCRIPTION
Cross one off from #753 

`Test_PackageInstall_UsesExistingAppWithSameName` would flake because the app reconciler is adding finalizers to the app at the same time the PKGI reconciler wants to update the app.

If the PKGI reconciler sees the app before the app reconciler finishes, there's a race for who updates it first. If the PKGI reconciler loses that race, it gets angry and puts a failure status message on the PKGI, and that fails the `kapp deploy`, which fails the test.

By just waiting for the app to get ReconcileSucceeded, we can guarantee that the app reconciler has finished and avoid the race. Ran it 100 times and it didn't flake.