### PR TITLE
Add sidecarexec sandboxing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,8 @@ RUN chmod g+w /etc/pki/tls/certs
 # Copy the ca-bundle so we have an original
 RUN cp /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt.orig
 
-COPY --from=deps /workspace/out/* ./
+COPY --from=deps /workspace/out/* /usr/bin/
 
 # Run as kapp-controller by default, will be overridden to a random uid on OpenShift
 USER 1000
-ENV PATH="/:${PATH}"
-ENTRYPOINT ["/kapp-controller"]
+ENTRYPOINT ["/usr/bin/kapp-controller"]

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/sidecarexec"
 	"k8s.io/klog/v2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -18,7 +20,7 @@ var Version = "develop"
 
 func main() {
 	ctrlOpts := Options{}
-	var sidecarexec bool
+	var isSidecarexec, isSidecarexecWrap bool
 
 	flag.IntVar(&ctrlOpts.Concurrency, "concurrency", 10, "Max concurrent reconciles")
 	flag.StringVar(&ctrlOpts.Namespace, "namespace", "", "Namespace to watch")
@@ -27,11 +29,21 @@ func main() {
 	flag.BoolVar(&ctrlOpts.EnablePprof, "dangerous-enable-pprof", false, "If set to true, enable pprof on "+PprofListenAddr)
 	flag.DurationVar(&ctrlOpts.APIRequestTimeout, "api-request-timeout", time.Duration(0), "HTTP timeout for Kubernetes API requests")
 	flag.BoolVar(&ctrlOpts.APIPriorityAndFairness, "enable-api-priority-and-fairness", true, "Enable/disable APIPriorityAndFairness feature gate for apiserver. Recommended to disable for <= k8s 1.19.")
-	flag.BoolVar(&sidecarexec, "sidecarexec", false, "Run sidecarexec")
+	flag.BoolVar(&isSidecarexec, "sidecarexec", false, "Run sidecarexec")
+	flag.BoolVar(&isSidecarexecWrap, "sidecarexecwrap", false, "Run sidecarexecwrap")
 	flag.Parse()
 
-	if sidecarexec {
+	if isSidecarexec {
 		sidecarexecMain()
+		return
+	}
+	if isSidecarexecWrap {
+		err := sidecarexec.SandboxWrap{}.ExecuteCmd(flag.Args())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "sidecarexecwrap: Error: %s\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 		return
 	}
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,7 +20,7 @@ var Version = "develop"
 
 func main() {
 	ctrlOpts := Options{}
-	var isSidecarexec, isSidecarexecWrap bool
+	var isSidecarexec, isSidecarexecDebug, isSidecarexecWrap bool
 
 	flag.IntVar(&ctrlOpts.Concurrency, "concurrency", 10, "Max concurrent reconciles")
 	flag.StringVar(&ctrlOpts.Namespace, "namespace", "", "Namespace to watch")
@@ -30,11 +30,12 @@ func main() {
 	flag.DurationVar(&ctrlOpts.APIRequestTimeout, "api-request-timeout", time.Duration(0), "HTTP timeout for Kubernetes API requests")
 	flag.BoolVar(&ctrlOpts.APIPriorityAndFairness, "enable-api-priority-and-fairness", true, "Enable/disable APIPriorityAndFairness feature gate for apiserver. Recommended to disable for <= k8s 1.19.")
 	flag.BoolVar(&isSidecarexec, "sidecarexec", false, "Run sidecarexec")
+	flag.BoolVar(&isSidecarexecDebug, "sidecarexecdebug", false, "Run sidecarexecdebug")
 	flag.BoolVar(&isSidecarexecWrap, "sidecarexecwrap", false, "Run sidecarexecwrap")
 	flag.Parse()
 
-	if isSidecarexec {
-		sidecarexecMain()
+	if isSidecarexec || isSidecarexecDebug {
+		sidecarexecMain(isSidecarexecDebug, flag.Args())
 		return
 	}
 	if isSidecarexecWrap {

--- a/cmd/controller/sidecarexec.go
+++ b/cmd/controller/sidecarexec.go
@@ -4,6 +4,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	goexec "os/exec"
 	"syscall"
 	"time"
 
@@ -13,16 +16,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func sidecarexecMain() {
-	mainLog := zap.New(zap.UseDevMode(false)).WithName("kc-sidecarexec")
-	mainLog.Info("start sidecarexec", "version", Version)
-
-	go reapZombies(mainLog)
-
+func sidecarexecMain(debug bool, debugArgs []string) {
 	localCmdRunner := exec.NewPlainCmdRunner()
 	sandboxCmdRunner := sidecarexec.NewSandboxCmdRunner(localCmdRunner, sidecarexec.SandboxCmdRunnerOpts{
 		RequiresPosix: map[string]bool{
 			"vendir": true,
+			"bash":   true, // for debugging
 		},
 		RequiresNetwork: map[string]bool{
 			"vendir": true,
@@ -30,7 +29,27 @@ func sidecarexecMain() {
 		},
 	})
 
-	opts := sidecarexec.ServerOpts{
+	if debug {
+		cmd := goexec.Command("bash")
+		if len(debugArgs) > 0 {
+			cmd = goexec.Command(debugArgs[0], debugArgs[1:]...)
+		}
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := sandboxCmdRunner.Run(cmd, exec.RunOpts{})
+		if err != nil {
+			fmt.Printf("Exit error: %s\n", err)
+		}
+		return
+	}
+
+	mainLog := zap.New(zap.UseDevMode(false)).WithName("kc-sidecarexec")
+	mainLog.Info("start sidecarexec", "version", Version)
+
+	go reapZombies(mainLog)
+
+	serverOpts := sidecarexec.ServerOpts{
 		AllowedCmdNames: []string{
 			// Fetch (calls impgkg and others internally)
 			"vendir",
@@ -38,8 +57,7 @@ func sidecarexecMain() {
 			"ytt", "kbld", "sops", "helm", "cue",
 		},
 	}
-
-	server := sidecarexec.NewServer(sandboxCmdRunner, opts, mainLog)
+	server := sidecarexec.NewServer(sandboxCmdRunner, serverOpts, mainLog)
 
 	err := server.Serve()
 	if err != nil {

--- a/cmd/controller/sidecarexec.go
+++ b/cmd/controller/sidecarexec.go
@@ -20,6 +20,16 @@ func sidecarexecMain() {
 	go reapZombies(mainLog)
 
 	localCmdRunner := exec.NewPlainCmdRunner()
+	sandboxCmdRunner := sidecarexec.NewSandboxCmdRunner(localCmdRunner, sidecarexec.SandboxCmdRunnerOpts{
+		RequiresPosix: map[string]bool{
+			"vendir": true,
+		},
+		RequiresNetwork: map[string]bool{
+			"vendir": true,
+			"kbld":   true,
+		},
+	})
+
 	opts := sidecarexec.ServerOpts{
 		AllowedCmdNames: []string{
 			// Fetch (calls impgkg and others internally)
@@ -29,7 +39,7 @@ func sidecarexecMain() {
 		},
 	}
 
-	server := sidecarexec.NewServer(localCmdRunner, opts, mainLog)
+	server := sidecarexec.NewServer(sandboxCmdRunner, opts, mainLog)
 
 	err := server.Serve()
 	if err != nil {

--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -15,6 +15,10 @@ spec:
   revisionHistoryLimit: 0
   template:
     metadata:
+      annotations:
+        #! Necessary at least on GKE (which includes a default apparmor policy)
+        #! which seems to prevent execution of mount syscall even within a user namespace
+        container.apparmor.security.beta.kubernetes.io/kapp-controller-sidecarexec: unconfined
       labels:
         app: kapp-controller
     spec:
@@ -66,6 +70,8 @@ spec:
             cpu: 120m
             memory: 100Mi
         env:
+        - name: KAPPCTRL_SIDECAREXEC_LIMIT_DIR
+          value: /etc/kappctrl-mem-tmp
         - name: KAPPCTRL_SIDECAREXEC_SOCK
           value: /etc/kappctrl-mem-tmp/sidecarexec.sock
         volumeMounts:

--- a/pkg/deploy/kapp.go
+++ b/pkg/deploy/kapp.go
@@ -59,7 +59,7 @@ func (a *Kapp) Deploy(tplOutput string, startedApplyingFunc func(),
 
 	resultBuf, doneTrackingOutputCh := a.trackCmdOutput(cmd, startedApplyingFunc, changedFunc)
 
-	err = a.cmdRunner.RunWithCancel(cmd, a.cancelCh)
+	err = a.cmdRunner.RunWithCancel(cmd, a.cancelCh, exec.RunOpts{})
 	close(doneTrackingOutputCh)
 
 	result := resultBuf.Copy()
@@ -82,7 +82,7 @@ func (a *Kapp) Delete(startedApplyingFunc func(), changedFunc func(exec.CmdRunRe
 
 	resultBuf, doneTrackingOutputCh := a.trackCmdOutput(cmd, startedApplyingFunc, changedFunc)
 
-	err = a.cmdRunner.RunWithCancel(cmd, a.cancelCh)
+	err = a.cmdRunner.RunWithCancel(cmd, a.cancelCh, exec.RunOpts{})
 	close(doneTrackingOutputCh)
 
 	result := resultBuf.Copy()
@@ -113,7 +113,7 @@ func (a *Kapp) Inspect() exec.CmdRunResult {
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 
-	err = a.cmdRunner.RunWithCancel(cmd, a.cancelCh)
+	err = a.cmdRunner.RunWithCancel(cmd, a.cancelCh, exec.RunOpts{})
 
 	result := exec.CmdRunResult{
 		Stdout: stdoutBs.String(),

--- a/pkg/exec/cmd_runner.go
+++ b/pkg/exec/cmd_runner.go
@@ -13,8 +13,15 @@ import (
 // of this interface so that they can be intercepted and potentially
 // modified in kctrl when running kapp-controller locally.
 type CmdRunner interface {
-	Run(*exec.Cmd) error
-	RunWithCancel(cmd *exec.Cmd, cancelCh chan struct{}) error
+	Run(*exec.Cmd, RunOpts) error
+	RunWithCancel(cmd *exec.Cmd, cancelCh chan struct{}, opts RunOpts) error
+}
+
+// RunOpts specifies additional options for running commands.
+type RunOpts struct {
+	// VisiblePaths indicates which paths
+	// should be visible to the command when executed.
+	VisiblePaths []string
 }
 
 // PlainCmdRunner implements CmdRunner interface by simply running exec.Cmd.
@@ -28,13 +35,13 @@ func NewPlainCmdRunner() PlainCmdRunner {
 }
 
 // Run executes exec.Cmd.
-func (PlainCmdRunner) Run(cmd *exec.Cmd) error {
+func (PlainCmdRunner) Run(cmd *exec.Cmd, opts RunOpts) error {
 	return cmd.Run()
 }
 
 // RunWithCancel executes exec.Cmd.
 // Kills execution immediately if value is read from cancelCh.
-func (PlainCmdRunner) RunWithCancel(cmd *exec.Cmd, cancelCh chan struct{}) error {
+func (PlainCmdRunner) RunWithCancel(cmd *exec.Cmd, cancelCh chan struct{}, opts RunOpts) error {
 	select {
 	case <-cancelCh:
 		return fmt.Errorf("Already canceled")

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -400,7 +400,7 @@ func (v *Vendir) Run(conf []byte, workingDir string) exec.CmdRunResult {
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 
-	err := v.cmdRunner.Run(cmd)
+	err := v.cmdRunner.Run(cmd, exec.RunOpts{VisiblePaths: []string{workingDir}})
 
 	result := exec.CmdRunResult{
 		Stdout: stdoutBs.String(),

--- a/pkg/sidecarexec/cmd_exec.go
+++ b/pkg/sidecarexec/cmd_exec.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"fmt"
 	goexec "os/exec"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
 )
 
@@ -34,6 +36,7 @@ type CmdOutput struct {
 type CmdExec struct {
 	cmdRunner       exec.CmdRunner
 	allowedCmdNames map[string]struct{}
+	log             logr.Logger
 }
 
 // Run executes a command (out of a set of allowed ones).
@@ -41,6 +44,10 @@ func (r CmdExec) Run(input CmdInput, output *CmdOutput) error {
 	if _, found := r.allowedCmdNames[input.Command]; !found {
 		return fmt.Errorf("Command '%s' is not allowed", input.Command)
 	}
+
+	t1 := time.Now()
+	r.log.Info("Start command", "cmd", input.Command)
+	defer func() { r.log.Info("Finish command", "cmd", input.Command, "dur", time.Now().Sub(t1).String()) }()
 
 	cmd := goexec.Command(input.Command, input.Args...)
 

--- a/pkg/sidecarexec/cmd_exec.go
+++ b/pkg/sidecarexec/cmd_exec.go
@@ -18,6 +18,8 @@ type CmdInput struct {
 	Stdin   []byte
 	Env     []string
 	Dir     string
+
+	VisiblePaths []string
 }
 
 // CmdOutput describes an command execution result.
@@ -30,7 +32,7 @@ type CmdOutput struct {
 
 // CmdExec provides RPC interface for command execution.
 type CmdExec struct {
-	local           exec.CmdRunner
+	cmdRunner       exec.CmdRunner
 	allowedCmdNames map[string]struct{}
 }
 
@@ -56,7 +58,7 @@ func (r CmdExec) Run(input CmdInput, output *CmdOutput) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := r.local.Run(cmd)
+	err := r.cmdRunner.Run(cmd, exec.RunOpts{VisiblePaths: input.VisiblePaths})
 	if err != nil {
 		output.Error = err.Error()
 		output.ExitCode = -1

--- a/pkg/sidecarexec/cmd_exec_client.go
+++ b/pkg/sidecarexec/cmd_exec_client.go
@@ -31,13 +31,13 @@ func (e runError) ExitCode() int { return e.exitCode }
 func (e runError) Error() string { return e.message }
 
 // Run makes a CmdExec.Run RPC call. kapp command run locally though.
-func (r CmdExecClient) Run(cmd *goexec.Cmd) error {
+func (r CmdExecClient) Run(cmd *goexec.Cmd, opts exec.RunOpts) error {
 	// TODO is there better way to "undo" path resolution done by exec.Command
 	cmdName := filepath.Base(cmd.Path)
 	args := cmd.Args[1:]
 
 	if cmdName == "kapp" {
-		return r.local.Run(cmd)
+		return r.local.Run(cmd, opts)
 	}
 
 	input := CmdInput{
@@ -45,6 +45,8 @@ func (r CmdExecClient) Run(cmd *goexec.Cmd) error {
 		Args:    args,
 		Env:     cmd.Env,
 		Dir:     cmd.Dir,
+
+		VisiblePaths: opts.VisiblePaths,
 	}
 
 	if cmd.Stdin != nil {
@@ -76,11 +78,11 @@ func (r CmdExecClient) Run(cmd *goexec.Cmd) error {
 }
 
 // RunWithCancel is not supported except for kapp which runs locally.
-func (r CmdExecClient) RunWithCancel(cmd *goexec.Cmd, cancelCh chan struct{}) error {
+func (r CmdExecClient) RunWithCancel(cmd *goexec.Cmd, cancelCh chan struct{}, opts exec.RunOpts) error {
 	cmdName := filepath.Base(cmd.Path)
 
 	if cmdName == "kapp" {
-		return r.local.RunWithCancel(cmd, cancelCh)
+		return r.local.RunWithCancel(cmd, cancelCh, opts)
 	}
 
 	panic("Internal inconsistency: RunWithCancel not supported")

--- a/pkg/sidecarexec/sandbox_cmd_runner.go
+++ b/pkg/sidecarexec/sandbox_cmd_runner.go
@@ -1,0 +1,31 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sidecarexec
+
+import (
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
+)
+
+// SandboxCmdRunner implements CmdRunner interface by running command
+// in a new process/mount namespace.
+type SandboxCmdRunner struct {
+	local exec.CmdRunner
+	opts  SandboxCmdRunnerOpts
+}
+
+// SandboxCmdRunnerOpts specifies sandboxing options.
+type SandboxCmdRunnerOpts struct {
+	// RequiresPosix indicates which commands should run in an environment
+	// with an extended file system (e.g. include /lib, /lib64, /usr/*, ...).
+	RequiresPosix map[string]bool
+	// RequiresNetwork indicates which commands need network access.
+	RequiresNetwork map[string]bool
+}
+
+var _ exec.CmdRunner = SandboxCmdRunner{}
+
+// NewSandboxCmdRunner returns a new SandboxCmdRunner.
+func NewSandboxCmdRunner(local exec.CmdRunner, opts SandboxCmdRunnerOpts) SandboxCmdRunner {
+	return SandboxCmdRunner{local, opts}
+}

--- a/pkg/sidecarexec/sandbox_cmd_runner_darwin.go
+++ b/pkg/sidecarexec/sandbox_cmd_runner_darwin.go
@@ -1,0 +1,24 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sidecarexec
+
+import (
+	goexec "os/exec"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
+)
+
+func (SandboxCmdRunner) Run(cmd *goexec.Cmd, opts exec.RunOpts) error {
+	panic("Not implemented on this OS")
+}
+
+func (SandboxCmdRunner) RunWithCancel(cmd *goexec.Cmd, cancelCh chan struct{}, opts exec.RunOpts) error {
+	panic("Not implemented on this OS")
+}
+
+type SandboxWrap struct{}
+
+func (SandboxWrap) ExecuteCmd(rawArgs []string) error {
+	panic("Not implemented on this OS")
+}

--- a/pkg/sidecarexec/sandbox_cmd_runner_linux.go
+++ b/pkg/sidecarexec/sandbox_cmd_runner_linux.go
@@ -1,0 +1,282 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sidecarexec
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	goexec "os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
+)
+
+var (
+	limitDir = os.Getenv("KAPPCTRL_SIDECAREXEC_LIMIT_DIR")
+)
+
+// Run executes exec.Cmd under new process/mount namespace.
+func (r SandboxCmdRunner) Run(cmd *goexec.Cmd, opts exec.RunOpts) error {
+	newRootDir, err := ioutil.TempDir("", "sidecarexecwrap-cmd")
+	if err != nil {
+		return fmt.Errorf("Creating new root dir: %s", err)
+	}
+
+	wrapArgs := sandboxWrapArgs{
+		NewRootDir: newRootDir,
+		Posix:      r.opts.RequiresPosix != nil && r.opts.RequiresPosix[filepath.Base(cmd.Path)],
+		Network:    r.opts.RequiresNetwork != nil && r.opts.RequiresNetwork[filepath.Base(cmd.Path)],
+
+		CmdDir:  cmd.Dir,
+		CmdPath: cmd.Path,
+		CmdArgs: cmd.Args[1:], // drop first arg (binary name)
+
+		VisiblePaths: opts.VisiblePaths,
+	}
+
+	// Roughly equivalent to: unshare -Urm -R / ...
+	cmd.Path = "/usr/bin/kapp-controller"
+	cmd.Args = []string{"kapp-controller", "--sidecarexecwrap", wrapArgs.AsString()}
+	cmd.Dir = "/"
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// TODO syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWPID?
+		Cloneflags:  syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS,
+		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Geteuid(), Size: 1}},
+		GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getegid(), Size: 1}},
+	}
+
+	// Create new non-configured network namespace if networking is not required
+	if !wrapArgs.Network {
+		cmd.SysProcAttr.Cloneflags = cmd.SysProcAttr.Cloneflags | syscall.CLONE_NEWNET
+	}
+
+	err = r.local.Run(cmd, opts)
+	if err != nil {
+		_ = os.RemoveAll(newRootDir) // remove error is lower priority
+		return err
+	}
+
+	// Propagate up any errors deleting root directory
+	// (want to notice any deletion problems asap)
+	err = os.RemoveAll(newRootDir)
+	if err != nil {
+		return fmt.Errorf("Deleting new root dir: %s", err)
+	}
+
+	return nil
+}
+
+// RunWithCancel executes exec.Cmd.
+// Kills execution immediately if value is read from cancelCh.
+func (SandboxCmdRunner) RunWithCancel(cmd *goexec.Cmd, cancelCh chan struct{}, opts exec.RunOpts) error {
+	return fmt.Errorf("RunWithCancel not implemented")
+}
+
+type sandboxWrapArgs struct {
+	NewRootDir string
+	Posix      bool
+	Network    bool
+
+	CmdDir  string
+	CmdPath string
+	CmdArgs []string
+
+	VisiblePaths []string
+}
+
+func newSandboxWrapArgs(str string) sandboxWrapArgs {
+	var args sandboxWrapArgs
+	err := json.Unmarshal([]byte(str), &args)
+	if err != nil {
+		panic(fmt.Sprintf("Internal inconsistency: invalid sandboxWrapArgs: %s", err))
+	}
+	return args
+}
+
+func (a sandboxWrapArgs) AsString() string {
+	bs, err := json.Marshal(a)
+	if err != nil {
+		panic(fmt.Sprintf("Internal inconsistency: invalid sandboxWrapArgs: %s", err))
+	}
+	return string(bs)
+}
+
+// SandboxWrap represents continuation of sandbox setup (mounting, ...)
+// which sandbox has initiated within a new user/mount namespace.
+type SandboxWrap struct{}
+
+type mountPoint struct {
+	Path      string
+	File      bool
+	Writeable bool
+	NonMount  bool
+	Content   string
+}
+
+// ExecuteCmd mounts various directories needed to execute sandboxed command.
+// As a last step it exec-s into given command, replacing the current process.
+func (w SandboxWrap) ExecuteCmd(rawArgs []string) error {
+	runtime.LockOSThread() // as a safety precaution for syscalls below
+
+	args := newSandboxWrapArgs(rawArgs[0])
+
+	// Keep default environment as minimal as possible
+	mounts := []mountPoint{
+		{Path: "usr/bin"},
+		{Path: "tmp", NonMount: true},
+	}
+
+	for _, path := range args.VisiblePaths {
+		if !strings.HasPrefix(path, limitDir) {
+			return fmt.Errorf("Expected visible path to start with '%s', but was '%s'", limitDir, path)
+		}
+		mounts = append(mounts, mountPoint{Path: path[1:], Writeable: true})
+	}
+
+	if args.Posix {
+		// Example: calling out to git
+		mounts = append(mounts, []mountPoint{
+			{Path: "etc", NonMount: true},
+			{Path: "etc/passwd", File: true, NonMount: true, Content: "root:x:0:0:/home/kapp-controller:/usr/sbin/nologin\n"},
+			{Path: "bin"}, // e.g. bin/sh was referenced by git executables
+			{Path: "lib"},
+			{Path: "lib64"}, // some dynamic libraries
+			{Path: "var/lib"},
+			{Path: "usr/lib"},
+			{Path: "usr/libexec"}, // internal git binaries
+			{Path: "usr/share"},   // internal git data
+			{Path: "usr/sbin"},
+			// TODO get rid of 'dev/null'? (used by vendir today)
+			{Path: "dev", NonMount: true},
+			{Path: "dev/null", NonMount: true, File: true},
+		}...)
+	}
+
+	if args.Network {
+		mounts = append(mounts, []mountPoint{
+			// Cannot mount whole 'etc' directory directly (mount returns exit status 32)
+			// Mounting individual child files/directories makes it work.
+			{Path: "etc/pki"},
+			{Path: "etc/resolv.conf", File: true},
+			{Path: "etc/hostname", File: true},
+			{Path: "etc/hosts", File: true},
+		}...)
+	}
+
+	err := w.configureMounts(mounts, args.NewRootDir)
+	if err != nil {
+		return err
+	}
+
+	err = w.pivotRoot(args.NewRootDir)
+	if err != nil {
+		return err
+	}
+
+	// Not all command specify execution directory
+	if len(args.CmdDir) > 0 {
+		err = os.Chdir(args.CmdDir)
+		if err != nil {
+			return fmt.Errorf("Chdir '%s': %s", args.CmdDir, err)
+		}
+	}
+
+	return syscall.Exec(args.CmdPath, append([]string{args.CmdPath}, args.CmdArgs...), os.Environ())
+}
+
+func (SandboxWrap) configureMounts(mounts []mountPoint, newRootDir string) error {
+	for _, mount := range mounts {
+		if mount.File {
+			file, err := os.Create(filepath.Join(newRootDir, mount.Path))
+			if err != nil {
+				return fmt.Errorf("Creating mount file '%s': %s", mount.Path, err)
+			}
+			if len(mount.Content) > 0 {
+				_, err = file.Write([]byte(mount.Content))
+				if err != nil {
+					return fmt.Errorf("Writing into file '%s': %s", mount.Path, err)
+				}
+			}
+			err = file.Close()
+			if err != nil {
+				return fmt.Errorf("Closing mount file '%s': %s", mount.Path, err)
+			}
+		} else {
+			err := os.MkdirAll(filepath.Join(newRootDir, mount.Path), 0700)
+			if err != nil {
+				return fmt.Errorf("Creating mount dir '%s': %s", mount.Path, err)
+			}
+		}
+	}
+
+	for _, mount := range mounts {
+		if mount.NonMount {
+			continue
+		}
+
+		srcPath := string(filepath.Separator) + mount.Path
+		dstPath := filepath.Join(newRootDir, mount.Path)
+
+		// Equivalent to: mount --bind /usr/sbin usr/sbin
+		err := syscall.Mount(srcPath, dstPath, "bind", syscall.MS_BIND, "")
+		if err != nil {
+			return fmt.Errorf("Mounting path '%s': %s", mount.Path, err)
+		}
+
+		// TODO readonly for files?
+		if !mount.Writeable && !mount.File {
+			// Equivalent to: mount -o remount,ro,bind etc
+			err = syscall.Mount("", dstPath, "", syscall.MS_REMOUNT|syscall.MS_BIND|syscall.MS_RDONLY, "")
+			if err != nil {
+				return fmt.Errorf("Remounting path '%s' as readonly: %s", mount.Path, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (SandboxWrap) pivotRoot(newRootDir string) error {
+	oldRootDir := filepath.Join(newRootDir, "/.pivot_root")
+
+	// Satisfy requirement of pivot_root (https://man7.org/linux/man-pages/man2/pivot_root.2.html)
+	err := syscall.Mount(newRootDir, newRootDir, "", syscall.MS_BIND|syscall.MS_REC, "")
+	if err != nil {
+		return fmt.Errorf("Remounting new root dir: %s", err)
+	}
+
+	err = os.MkdirAll(oldRootDir, 0700)
+	if err != nil {
+		return fmt.Errorf("Creating old root dir: %s", err)
+	}
+
+	err = syscall.PivotRoot(newRootDir, oldRootDir)
+	if err != nil {
+		return fmt.Errorf("Pivot root: %s", err)
+	}
+
+	err = os.Chdir("/")
+	if err != nil {
+		return fmt.Errorf("Chdir /: %s", err)
+	}
+
+	oldRootDir = "/.pivot_root"
+
+	err = syscall.Unmount(oldRootDir, syscall.MNT_DETACH)
+	if err != nil {
+		return fmt.Errorf("Unmounting old root: %s", err)
+	}
+
+	err = os.RemoveAll(oldRootDir)
+	if err != nil {
+		return fmt.Errorf("Removing old root dir: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/sidecarexec/server.go
+++ b/pkg/sidecarexec/server.go
@@ -31,12 +31,12 @@ type ServerOpts struct {
 }
 
 // NewServer returns a new Server.
-func NewServer(local exec.CmdRunner, opts ServerOpts, log logr.Logger) *Server {
+func NewServer(cmdRunner exec.CmdRunner, opts ServerOpts, log logr.Logger) *Server {
 	allowedCmdNames := map[string]struct{}{}
 	for _, cmd := range opts.AllowedCmdNames {
 		allowedCmdNames[cmd] = struct{}{}
 	}
-	return &Server{&CmdExec{local, allowedCmdNames}, log}
+	return &Server{&CmdExec{cmdRunner, allowedCmdNames}, log}
 }
 
 // Serve starts an RPC server.

--- a/pkg/sidecarexec/server.go
+++ b/pkg/sidecarexec/server.go
@@ -36,7 +36,7 @@ func NewServer(cmdRunner exec.CmdRunner, opts ServerOpts, log logr.Logger) *Serv
 	for _, cmd := range opts.AllowedCmdNames {
 		allowedCmdNames[cmd] = struct{}{}
 	}
-	return &Server{&CmdExec{cmdRunner, allowedCmdNames}, log}
+	return &Server{&CmdExec{cmdRunner, allowedCmdNames, log}, log}
 }
 
 // Serve starts an RPC server.

--- a/pkg/template/kbld.go
+++ b/pkg/template/kbld.go
@@ -63,7 +63,7 @@ func (t *Kbld) template(dirPath string, input io.Reader) exec.CmdRunResult {
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
 
-	err = t.cmdRunner.Run(cmd)
+	err = t.cmdRunner.Run(cmd, exec.RunOpts{VisiblePaths: []string{dirPath}})
 
 	result := exec.CmdRunResult{
 		Stdout: stdoutBs.String(),

--- a/pkg/template/values_test.go
+++ b/pkg/template/values_test.go
@@ -42,9 +42,9 @@ func TestValues(t *testing.T) {
 			}},
 		}}
 
-		paths, cleanup, err := subject.AsPaths(os.TempDir())
+		paths, valuesDir, err := subject.AsPaths(os.TempDir())
 		require.NoError(t, err)
-		t.Cleanup(cleanup)
+		defer valuesDir.Remove()
 
 		require.Len(t, paths, 5)
 		expectedValues := []string{
@@ -69,10 +69,10 @@ func TestValues(t *testing.T) {
 				}},
 			}}
 
-			paths, cleanup, err := subject.AsPaths(os.TempDir())
+			paths, valuesDir, err := subject.AsPaths(os.TempDir())
 			require.NoError(t, err)
 			require.Len(t, paths, 3)
-			t.Cleanup(cleanup)
+			defer valuesDir.Remove()
 
 			assertFileContents(t, paths[0], "parent:\n  child: some-name\n")
 			assertFileContents(t, paths[1], "parent:\n  child1:\n    child2: some-namespace\n")
@@ -88,10 +88,10 @@ func TestValues(t *testing.T) {
 				}},
 			}}
 
-			paths, cleanup, err := subject.AsPaths(os.TempDir())
+			paths, valuesDir, err := subject.AsPaths(os.TempDir())
 			require.NoError(t, err)
 			require.Len(t, paths, 2)
-			t.Cleanup(cleanup)
+			defer valuesDir.Remove()
 
 			expectedValues := []string{
 				"a_some-annotation-key: a_ann_val\n",
@@ -101,15 +101,14 @@ func TestValues(t *testing.T) {
 			for i, p := range paths {
 				assertFileContents(t, p, expectedValues[i])
 			}
-
 		})
 
 		t.Run("file names have encoding suffix due to templating engines such as cue requirement", func(t *testing.T) {
 			subject := subject
-			paths, cleanup, err := subject.AsPaths(os.TempDir())
+			paths, valuesDir, err := subject.AsPaths(os.TempDir())
 			require.NoError(t, err)
 			require.Len(t, paths, 5)
-			t.Cleanup(cleanup)
+			defer valuesDir.Remove()
 
 			for _, path := range paths {
 				assert.True(t, strings.HasSuffix(path, ".yaml"))
@@ -130,10 +129,10 @@ func TestValues(t *testing.T) {
 				}},
 			}}
 
-			paths, cleanup, err := subject.AsPaths(os.TempDir())
+			paths, valuesDir, err := subject.AsPaths(os.TempDir())
 			require.NoError(t, err)
 			require.Len(t, paths, 2)
-			t.Cleanup(cleanup)
+			defer valuesDir.Remove()
 
 			assertFileContents(t, paths[0], "some-annotation-key:\n  a_ann: a_ann_val\n  s_ann: s_ann_val\n  z_ann: z_ann_val\n")
 			assertFileContents(t, paths[1], "parent:\n  some-annotation-key:\n    a_ann: a_ann_val\n    s_ann: s_ann_val\n    z_ann: z_ann_val\n")
@@ -148,10 +147,10 @@ func TestValues(t *testing.T) {
 				}},
 			}}
 
-			paths, cleanup, err := subject.AsPaths(os.TempDir())
+			paths, valuesDir, err := subject.AsPaths(os.TempDir())
 			require.NoError(t, err)
 			require.Len(t, paths, 2)
-			t.Cleanup(cleanup)
+			defer valuesDir.Remove()
 
 			assertFileContents(t, paths[1], "a_name: some-namespace\n")
 		})


### PR DESCRIPTION
#### What this PR does / why we need it:
- executes fetcher/templaters in a limited environment (within a new user/mount namespace on linux)
- TODO we need to run test on all the clouds
  - [x] Minikube (gh action runs e2e in minikube; also use it locally)
  - [x] Kind (gh action runs e2e in kind)
  - [ ] GKE
  - [ ] GKE Autopilot
  - [ ] Azure
  - [ ] EKS
  - [ ] Openshift
  - [ ] TKG
- resolve outstanding TODOs in code

#### Which issue(s) this PR fixes:
n/a

#### Does this PR introduce a user-facing change?
no

```release-note
- Execute fetcher/templates in a limited environment
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
