### PR TITLE
Typo in Dockerfile causes ARCH to be ignored during build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go run ./hack/dependencies.go install -d out --arch ${TARGETARCH} --os ${TAR
 COPY . .
 # helpful ldflags reference: https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
 RUN --mount=type=cache,target=/root/.cache/go-build \
-  CGO_ENABLED=0 GOOS=${TARGETOS} GOSARCH=${TARGETARCH} \
+  CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
   go build -mod=vendor -ldflags="-X 'main.Version=$KCTRL_VER'" -trimpath -o out/kapp-controller ./cmd/controller
 
 # --- run image ---


### PR DESCRIPTION
#### What this PR does / why we need it:
arm64 support was recently added in #680 however there was a typo in the Dockerfile that sneaked through during the review process.  This PR fixes that typo.  I have already tested this in my own arm64 environment and was able to produce working images.

#### Which issue(s) this PR fixes:
Fixes https://github.com/vmware-tanzu/carvel-kapp-controller/issues/803

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
