### PR TITLE
use pull_request_target to allow access to secrets

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ name: Add issues to project
 on:
   issues:
     types: ['opened']
-  pull_request:
+  pull_request_target:
     types: ['opened']
 
 jobs:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Allows the "add-to-project" github action to work for PRs from non-contributors. GitHub seems to allow access to secrets from these actions when they come from people with certain privileges, but will fail from other users.

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/