### PR TITLE
Enhance prompt output reader to store buffered output and update tests

### DIFF
--- a/cli/hack/test-all.sh
+++ b/cli/hack/test-all.sh
@@ -6,6 +6,9 @@ set -e -x -u
 
 export KCTRL_BINARY_PATH="$PWD/kctrl"
 
+# Enable todebug tests using prompt output in the workflow
+# export KCTRL_DEBUG_BUFERED_OUTPUT_TESTS=true
+
 ./hack/test.sh
 ./hack/test-e2e.sh
 

--- a/cli/hack/test-all.sh
+++ b/cli/hack/test-all.sh
@@ -6,7 +6,7 @@ set -e -x -u
 
 export KCTRL_BINARY_PATH="$PWD/kctrl"
 
-# Enable todebug tests using prompt output in the workflow
+# Enable to debug tests using prompt output in the workflow
 # export KCTRL_DEBUG_BUFERED_OUTPUT_TESTS=true
 
 ./hack/test.sh

--- a/cli/test/e2e/package_repo_release_test.go
+++ b/cli/test/e2e/package_repo_release_test.go
@@ -48,7 +48,7 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 
 		kappCtrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir},
 			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
-				StdoutWriter: promptOutput.BufferedWriter(), Interactive: true})
+				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
 
 		keysToBeIgnored := []string{"creationTimestamp:", "image"}
 		verifyPackageRepoBuild(t, keysToBeIgnored)

--- a/cli/test/e2e/package_repo_release_test.go
+++ b/cli/test/e2e/package_repo_release_test.go
@@ -35,9 +35,9 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 		promptOutput := newPromptOutput(t)
 
 		go func() {
-			promptOutput.WaitFor("The host must be authorized to push images to a registry")
+			promptOutput.WaitFor("Enter the package repository name")
 			promptOutput.Write("testpackagerepo.corp.dev")
-			promptOutput.WaitFor("The bundle created needs to be pushed to an OCI registry")
+			promptOutput.WaitFor("Enter the registry url")
 			promptOutput.Write(env.Image)
 		}()
 
@@ -48,7 +48,7 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 
 		kappCtrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir},
 			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
-				StdoutWriter: promptOutput.OutputWriter(), Interactive: true})
+				StdoutWriter: promptOutput.BufferedWriter(), Interactive: true})
 
 		keysToBeIgnored := []string{"creationTimestamp:", "image"}
 		verifyPackageRepoBuild(t, keysToBeIgnored)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
De-flakes and makes tests involving interactive behaviour more legible

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
- The "KCTRL_DEBUG_BUFERED_OUTPUT_TESTS" env variable helps debug tests using prompt output if set to "true". This might help out when we add more tests (table tests maybe?)

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
