### PR TITLE
Ensure that default version is valid semver. Add error checks.

### DIFF
--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -60,7 +60,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 
 func (o *ReleaseOptions) Run() error {
 	if o.pkgVersion == "" {
-		o.pkgVersion = fmt.Sprintf("build-%d", time.Now().Unix())
+		o.pkgVersion = fmt.Sprintf(defaultVersion, time.Now().Unix())
 	}
 
 	if o.chdir != "" {
@@ -99,9 +99,13 @@ func (o *ReleaseOptions) Run() error {
 		}
 	}
 
+	buildAppSpec := pkgBuild.GetAppSpec()
+	if buildAppSpec == nil {
+		return fmt.Errorf("Releasing package: `kctrl pkg init` was not run successfully. (hint: re-run the `init` command)")
+	}
 	builderOpts := cmdapprelease.AppSpecBuilderOpts{
-		BuildTemplate: pkgBuild.GetAppSpec().Template,
-		BuildDeploy:   pkgBuild.GetAppSpec().Deploy,
+		BuildTemplate: buildAppSpec.Template,
+		BuildDeploy:   buildAppSpec.Deploy,
 		BuildExport:   *pkgBuild.GetExport(),
 		Debug:         o.debug,
 	}


### PR DESCRIPTION
Additional check added for malformed `package-build`
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Removes misleading error if package-build is malformed
-  Ensures that valid server is used in case the user does not supply a version explicitly


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
