### PR TITLE
kctrl: Handle errors in status after successful local reconciliation.

### DIFF
--- a/cli/pkg/kctrl/cmd/package/available/get.go
+++ b/cli/pkg/kctrl/cmd/package/available/get.go
@@ -173,7 +173,7 @@ func (o *GetOptions) show(client pkgclient.Interface, pkgName, pkgVersion string
 
 		row = append(row, []uitable.Value{
 			uitable.NewValueString(pkg.Spec.Version),
-			uitable.NewValueString(pkg.Spec.ReleasedAt.String()),
+			uitable.NewValueString(formatTimestamp(pkg.Spec.ReleasedAt)),
 			uitable.NewValueString(wordwrap.WrapString(pkg.Spec.CapactiyRequirementsDescription, 80)),
 			uitable.NewValueString(wordwrap.WrapString(pkg.Spec.ReleaseNotes, 80)),
 			uitable.NewValueStrings(pkg.Spec.Licenses),
@@ -228,7 +228,7 @@ func (o *GetOptions) showVersions(pkgList *v1alpha1.PackageList) error {
 	for _, pkg := range pkgList.Items {
 		table.Rows = append(table.Rows, []uitable.Value{
 			uitable.NewValueString(pkg.Spec.Version),
-			uitable.NewValueString(pkg.Spec.ReleasedAt.String()),
+			uitable.NewValueString(formatTimestamp(pkg.Spec.ReleasedAt)),
 		})
 	}
 

--- a/cli/pkg/kctrl/cmd/package/available/list.go
+++ b/cli/pkg/kctrl/cmd/package/available/list.go
@@ -194,11 +194,18 @@ func (o *ListOptions) listPackages() error {
 			cmdcore.NewValueNamespace(pkg.Namespace),
 			uitable.NewValueString(pkg.Spec.RefName),
 			cmdcore.NewValueSemver(pkg.Spec.Version),
-			uitable.NewValueString(pkg.Spec.ReleasedAt.String()),
+			uitable.NewValueString(formatTimestamp(pkg.Spec.ReleasedAt)),
 		})
 	}
 
 	o.ui.PrintTable(table)
 
 	return err
+}
+
+func formatTimestamp(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "-"
+	}
+	return timestamp.String()
 }

--- a/cli/test/e2e/package_available_test.go
+++ b/cli/test/e2e/package_available_test.go
@@ -133,12 +133,12 @@ spec:
 			{
 				"name":        packageName,
 				"version":     "1.0.0",
-				"released_at": "0001-01-01 00:00:00 +0000 UTC",
+				"released_at": "-",
 			},
 			{
 				"name":        packageName,
 				"version":     "1.1.0",
-				"released_at": "0001-01-01 00:00:00 +0000 UTC",
+				"released_at": "-",
 			},
 		}
 		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
@@ -164,11 +164,11 @@ spec:
 		expectedOutputRows = []map[string]string{
 			{
 				"version":     "1.0.0",
-				"released_at": "0001-01-01 00:00:00 +0000 UTC",
+				"released_at": "-",
 			},
 			{
 				"version":     "1.1.0",
-				"released_at": "0001-01-01 00:00:00 +0000 UTC",
+				"released_at": "-",
 			},
 		}
 		require.Exactly(t, expectedOutputRows, output.Tables[1].Rows)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
We need to check for errors that might have happened after successful reconciliations (which won't return an error) explicitly. This PR also adds a check that formats `ReleasedAt` values better.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes parts of #837, namely :
- kctrl pkg release cmd will fail with error no .imgpkg/images.yml file even if YAML supplied is broken

Resolves #700 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Handle errors while building images for releases better
```

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
