### PR TITLE
Ensure that updated package specs are copied over from package spec

### DIFF
--- a/cli/pkg/kctrl/cmd/package/release/artefact_writer.go
+++ b/cli/pkg/kctrl/cmd/package/release/artefact_writer.go
@@ -86,15 +86,11 @@ func (w *ArtifactWriter) writePackageMetadata(path string) error {
 
 func (w *ArtifactWriter) writePackage(path string, appSpec *kcv1alpha1.AppSpec, valuesSchema kcdatav1alpha1.ValuesSchema) error {
 	w.packageTemplate.SetName(fmt.Sprintf("%s.%s", w.packageName, w.version))
-	w.packageTemplate.Spec = kcdatav1alpha1.PackageSpec{
-		ReleasedAt: metav1.Now(),
-		Version:    w.version,
-		RefName:    w.packageName,
-		Template: kcdatav1alpha1.AppTemplateSpec{
-			Spec: appSpec,
-		},
-		ValuesSchema: valuesSchema,
-	}
+	w.packageTemplate.Spec.ReleasedAt = metav1.Now()
+	w.packageTemplate.Spec.Version = w.version
+	w.packageTemplate.Spec.RefName = w.packageName
+	w.packageTemplate.Spec.Template = kcdatav1alpha1.AppTemplateSpec{Spec: appSpec}
+	w.packageTemplate.Spec.ValuesSchema = valuesSchema
 
 	packageBytes, err := yaml.Marshal(w.packageTemplate)
 	if err != nil {

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (
@@ -15,7 +18,7 @@ import (
 )
 
 const (
-	workingDir = "kcrl-test"
+	workingDir = "kctrl-test"
 )
 
 func TestPackageInitAndRelease(t *testing.T) {

--- a/cli/test/e2e/release_with_changed_spec_test.go
+++ b/cli/test/e2e/release_with_changed_spec_test.go
@@ -1,0 +1,155 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	packageBuildFile     = "package-build.yml"
+	packageResourcesFile = "package-resources.yml"
+)
+
+func TestPackageReleaseWithChangedSpec(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	cleanUp := func() {
+		os.RemoveAll(workingDir)
+	}
+	cleanUp()
+	defer cleanUp()
+
+	refName := "test-kctrl.carvel.dev"
+	releaseNotes := "Made things better"
+	shortDescription := "shorter description"
+	longDescription := "longer description"
+
+	packageBuild := fmt.Sprintf(`
+apiVersion: kctrl.carvel.dev/v1alpha1
+kind: PackageBuild
+metadata:
+  creationTimestamp: null
+  name: %s
+spec:
+  release:
+  - resource: {}
+  template:
+    spec:
+      app:
+        spec:
+          deploy:
+          - kapp: {}
+          template:
+          - ytt:
+              paths:
+              - config
+          - kbld: {}
+      export:
+      - imgpkgBundle:
+          image: %s
+          useKbldImagesLock: true
+        includePaths:
+        - config
+`, refName, env.Image)
+
+	packageResources := fmt.Sprintf(`
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  creationTimestamp: null
+  name: %s.0.0.0
+spec:
+  licenses:
+  - MIT
+  refName: %s
+  releasedAt: null
+  releaseNotes: %s
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - git: {}
+      template:
+      - ytt:
+        paths:
+        - config
+      - kbld: {}
+  valuesSchema:
+    openAPIv3: null
+  version: 0.0.0
+
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  creationTimestamp: null
+  name: %s
+spec:
+  displayName: test-kctrl
+  longDescription: %s
+  shortDescription: %s
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    kctrl.carvel.dev/local-fetch-0: .
+  creationTimestamp: null
+  name: test-kctrl
+spec:
+  packageRef:
+  refName: test-kctrl.carvel.dev
+  versionSelection:
+    constraints: 0.0.0
+  serviceAccountName: test-kctrl-sa
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0
+`, refName, refName, releaseNotes, refName, longDescription, shortDescription)
+
+	configManifests := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kctrl-test
+data:
+  foo: bar	
+`
+
+	// Create manifest and files created by `init` command (with changes)
+	err := os.MkdirAll(filepath.Join(workingDir, "config"), os.ModePerm)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(workingDir, packageResourcesFile), []byte(packageResources), os.ModePerm)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(workingDir, packageBuildFile), []byte(packageBuild), os.ModePerm)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(workingDir, "config", "config.yml"), []byte(configManifests), os.ModePerm)
+	require.NoError(t, err)
+
+	logger.Section("release package", func() {
+		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir}, RunOpts{NoNamespace: true})
+
+		packagePath := "carvel-artifacts/packages"
+		packageOutput, err := os.ReadFile(filepath.Join(workingDir, packagePath, refName, "package.yml"))
+		require.NoError(t, err)
+		require.Contains(t, string(packageOutput), fmt.Sprintf("releaseNotes: %s", releaseNotes))
+		require.Contains(t, string(packageOutput), "licenses:\n  - MIT")
+
+		packageMetadataOutput, err := os.ReadFile(filepath.Join(workingDir, packagePath, refName, "metadata.yml"))
+		require.NoError(t, err)
+		require.Contains(t, string(packageMetadataOutput), fmt.Sprintf("shortDescription: %s", shortDescription))
+		require.Contains(t, string(packageMetadataOutput), fmt.Sprintf("longDescription: %s", longDescription))
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Release was not copying over fields in app spec while releasing a package

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #849 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
- Fix: fields in app spec from `package-resources.yml` are not copied over while releasing
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
