### PR TITLE
Restructure help sections for all commands

### DIFF
--- a/cli/pkg/kctrl/cmd/app/app.go
+++ b/cli/pkg/kctrl/cmd/app/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cppforlife/color"
 	"github.com/spf13/cobra"
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kcpkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +19,9 @@ func NewCmd() *cobra.Command {
 		Use:     "app",
 		Aliases: []string{"a"},
 		Short:   "App",
+		Annotations: map[string]string{
+			cmdcore.AppHelpGroup.Key: cmdcore.AppHelpGroup.Value,
+		},
 	}
 	return cmd
 }

--- a/cli/pkg/kctrl/cmd/app/delete.go
+++ b/cli/pkg/kctrl/cmd/app/delete.go
@@ -43,10 +43,11 @@ func NewDeleteOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.L
 
 func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "delete",
-		Short:       "Delete app",
-		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
-		Annotations: map[string]string{TTYByDefaultKey: ""},
+		Use:   "delete",
+		Short: "Delete app",
+		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: "",
+			cmdcore.AppManagementCommandsHelpGroup.Key: cmdcore.AppManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/get.go
+++ b/cli/pkg/kctrl/cmd/app/get.go
@@ -36,6 +36,9 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 		Aliases: []string{"g"},
 		Short:   "Get details for app",
 		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{
+			cmdcore.AppManagementCommandsHelpGroup.Key: cmdcore.AppManagementCommandsHelpGroup.Value,
+		},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/kick.go
+++ b/cli/pkg/kctrl/cmd/app/kick.go
@@ -37,10 +37,11 @@ func NewKickOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Log
 
 func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "kick",
-		Short:       "Trigger reconciliation for app",
-		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
-		Annotations: map[string]string{TTYByDefaultKey: ""},
+		Use:   "kick",
+		Short: "Trigger reconciliation for app",
+		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: "",
+			cmdcore.AppManagementCommandsHelpGroup.Key: cmdcore.AppManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/list.go
+++ b/cli/pkg/kctrl/cmd/app/list.go
@@ -35,6 +35,9 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		Aliases: []string{"l", "ls"},
 		Short:   "List Apps",
 		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{
+			cmdcore.AppManagementCommandsHelpGroup.Key: cmdcore.AppManagementCommandsHelpGroup.Value,
+		},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/pause.go
+++ b/cli/pkg/kctrl/cmd/app/pause.go
@@ -33,11 +33,12 @@ func NewPauseOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Lo
 
 func NewPauseCmd(o *PauseOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "pause",
-		Aliases:     []string{"p"},
-		Short:       "Pause reconciliation for app",
-		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
-		Annotations: map[string]string{TTYByDefaultKey: ""},
+		Use:     "pause",
+		Aliases: []string{"p"},
+		Short:   "Pause reconciliation for app",
+		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: "",
+			cmdcore.AppManagementCommandsHelpGroup.Key: cmdcore.AppManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/app/status.go
+++ b/cli/pkg/kctrl/cmd/app/status.go
@@ -29,11 +29,12 @@ func NewStatusOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.L
 
 func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "status",
-		Aliases:     []string{"s"},
-		Short:       "View status of app",
-		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
-		Annotations: map[string]string{TTYByDefaultKey: ""},
+		Use:     "status",
+		Aliases: []string{"s"},
+		Short:   "View status of app",
+		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{TTYByDefaultKey: "",
+			cmdcore.AppManagementCommandsHelpGroup.Key: cmdcore.AppManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/core/help_sections.go
+++ b/cli/pkg/kctrl/cmd/core/help_sections.go
@@ -17,6 +17,36 @@ var (
 		Value: "package",
 		Title: "Package Commands:",
 	}
+	PackageRepoHelpGroup = cobrautil.HelpSection{
+		Key:   cmdGroupKey,
+		Value: "repository",
+		Title: "Package Repository Commands:",
+	}
+	AppHelpGroup = cobrautil.HelpSection{
+		Key:   cmdGroupKey,
+		Value: "app",
+		Title: "App Commands:",
+	}
+	DevHelpGroup = cobrautil.HelpSection{
+		Key:   cmdGroupKey,
+		Value: "dev",
+		Title: "Development Commands:",
+	}
+	PackageManagementCommandsHelpGroup = cobrautil.HelpSection{
+		Key:   cmdGroupKey,
+		Value: "package-management",
+		Title: "Package Management Commands:",
+	}
+	PackageAuthoringCommandsHelpGroup = cobrautil.HelpSection{
+		Key:   cmdGroupKey,
+		Value: "package-authoring",
+		Title: "Package Authoring Commands:",
+	}
+	AppManagementCommandsHelpGroup = cobrautil.HelpSection{
+		Key:   cmdGroupKey,
+		Value: "app-management",
+		Title: "App Management Commands:",
+	}
 	RestOfCommandsHelpGroup = cobrautil.HelpSection{
 		Key:   cmdGroupKey,
 		Value: "", // default

--- a/cli/pkg/kctrl/cmd/core/help_sections.go
+++ b/cli/pkg/kctrl/cmd/core/help_sections.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	cmdGroupKey = "kapp-group"
+	cmdGroupKey = "kctrl-group"
 )
 
 var (

--- a/cli/pkg/kctrl/cmd/dev/cmd.go
+++ b/cli/pkg/kctrl/cmd/dev/cmd.go
@@ -44,6 +44,9 @@ func NewCmd(o *DevOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 		Use:   "dev",
 		Short: "Deploy App CRs and packaging CRs",
 		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{
+			cmdcore.DevHelpGroup.Key: cmdcore.DevHelpGroup.Value,
+		},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
+	appinit "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app/init"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/dev"
 	cmdpkg "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/package"
@@ -107,6 +108,7 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 	appCmd.AddCommand(app.NewPauseCmd(app.NewPauseOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewKickCmd(app.NewKickOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewDeleteCmd(app.NewDeleteOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
+	appCmd.AddCommand(appinit.NewInitCmd(appinit.NewInitOptions(o.ui, o.depsFactory, o.logger)))
 	cmd.AddCommand(appCmd)
 
 	cmd.AddCommand(dev.NewCmd(dev.NewDevOptions(o.ui, o.depsFactory, o.logger), flagsFactory))

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cppforlife/go-cli-ui/ui"
 	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app"
-	appinit "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app/init"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	"github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/dev"
 	cmdpkg "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/package"
@@ -73,6 +72,8 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 
 	cmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
 		cmdcore.PackageHelpGroup,
+		cmdcore.AppHelpGroup,
+		cmdcore.DevHelpGroup,
 		cmdcore.RestOfCommandsHelpGroup,
 	}))
 
@@ -85,18 +86,27 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 	cmd.AddCommand(NewVersionCmd(NewVersionOptions(o.ui, o.depsFactory), flagsFactory))
 
 	pkgCmd := cmdpkg.NewCmd()
+	pkgCmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
+		cmdcore.PackageManagementCommandsHelpGroup,
+		cmdcore.PackageAuthoringCommandsHelpGroup,
+		cmdcore.PackageRepoHelpGroup,
+		cmdcore.RestOfCommandsHelpGroup,
+	}))
 	AddPackageCommands(o, pkgCmd, flagsFactory, pkgOpts)
 
 	cmd.AddCommand(pkgCmd)
 
 	appCmd := app.NewCmd()
+	appCmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
+		cmdcore.AppManagementCommandsHelpGroup,
+		cmdcore.RestOfCommandsHelpGroup,
+	}))
 	appCmd.AddCommand(app.NewGetCmd(app.NewGetOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewListCmd(app.NewListOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewStatusCmd(app.NewStatusOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewPauseCmd(app.NewPauseOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewKickCmd(app.NewKickOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
 	appCmd.AddCommand(app.NewDeleteCmd(app.NewDeleteOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
-	appCmd.AddCommand(appinit.NewInitCmd(appinit.NewInitOptions(o.ui, o.depsFactory, o.logger)))
 	cmd.AddCommand(appCmd)
 
 	cmd.AddCommand(dev.NewCmd(dev.NewDevOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
@@ -167,6 +177,10 @@ func configureTTY(o *KctrlOptions, cmd *cobra.Command) {
 
 func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore.FlagsFactory, opts cmdcore.PackageCommandTreeOpts) {
 	pkgrepoCmd := pkgrepo.NewCmd()
+	pkgrepoCmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
+		cmdcore.PackageManagementCommandsHelpGroup,
+		cmdcore.PackageAuthoringCommandsHelpGroup,
+	}))
 	pkgrepoCmd.AddCommand(pkgrepo.NewListCmd(pkgrepo.NewListOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgrepo.NewGetCmd(pkgrepo.NewGetOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgrepo.NewDeleteCmd(pkgrepo.NewDeleteOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
@@ -176,6 +190,9 @@ func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcor
 	pkgrepoCmd.AddCommand(pkgreporel.NewReleaseCmd(pkgreporel.NewReleaseOptions(o.ui, o.depsFactory, o.logger)))
 
 	pkgiCmd := pkginst.NewCmd()
+	pkgiCmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
+		cmdcore.PackageManagementCommandsHelpGroup,
+	}))
 	pkgiCmd.AddCommand(pkginst.NewListCmd(pkginst.NewListOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgiCmd.AddCommand(pkginst.NewGetCmd(pkginst.NewGetOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgiCmd.AddCommand(pkginst.NewCreateCmd(pkginst.NewCreateOrUpdateOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
@@ -186,6 +203,9 @@ func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcor
 	pkgiCmd.AddCommand(pkginst.NewStatusCmd(pkginst.NewStatusOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 
 	pkgaCmd := pkgavail.NewCmd()
+	pkgaCmd.SetUsageTemplate(cobrautil.HelpSectionsUsageTemplate([]cobrautil.HelpSection{
+		cmdcore.PackageManagementCommandsHelpGroup,
+	}))
 	pkgaCmd.AddCommand(pkgavail.NewListCmd(pkgavail.NewListOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgaCmd.AddCommand(pkgavail.NewGetCmd(pkgavail.NewGetOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 

--- a/cli/pkg/kctrl/cmd/package/available/cmd.go
+++ b/cli/pkg/kctrl/cmd/package/available/cmd.go
@@ -5,6 +5,7 @@ package available
 
 import (
 	"github.com/spf13/cobra"
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 )
 
 func NewCmd() *cobra.Command {
@@ -12,6 +13,9 @@ func NewCmd() *cobra.Command {
 		Use:     "available",
 		Aliases: []string{"a"},
 		Short:   "Manage available packages",
+		Annotations: map[string]string{
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value,
+		},
 	}
 	return cmd
 }

--- a/cli/pkg/kctrl/cmd/package/available/get.go
+++ b/cli/pkg/kctrl/cmd/package/available/get.go
@@ -55,7 +55,8 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 				[]string{"package", "available", "get", "-p", "cert-manager.community.tanzu.vmware.com/1.0.0", "--values-schema"}},
 		}.Description("-p", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{"table": ""},
+		Annotations: map[string]string{"table": "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)

--- a/cli/pkg/kctrl/cmd/package/available/list.go
+++ b/cli/pkg/kctrl/cmd/package/available/list.go
@@ -60,7 +60,8 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 				[]string{"package", "available", "list", "-p", "cert-manager.community.tanzu.vmware.com"}},
 		}.Description("-p", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{"table": ""},
+		Annotations: map[string]string{"table": "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List available packages in all namespaces")

--- a/cli/pkg/kctrl/cmd/package/init/init.go
+++ b/cli/pkg/kctrl/cmd/package/init/init.go
@@ -45,6 +45,9 @@ func NewInitCmd(o *InitOptions) *cobra.Command {
 		Use:   "init",
 		Short: "Initialize Package (experimental)",
 		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageAuthoringCommandsHelpGroup.Value,
+		},
 	}
 
 	cmd.Flags().StringVar(&o.chdir, "chdir", "", "Location of the working directory")

--- a/cli/pkg/kctrl/cmd/package/installed/cmd.go
+++ b/cli/pkg/kctrl/cmd/package/installed/cmd.go
@@ -5,6 +5,7 @@ package installed
 
 import (
 	"github.com/spf13/cobra"
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 )
 
 func NewCmd() *cobra.Command {
@@ -12,6 +13,9 @@ func NewCmd() *cobra.Command {
 		Use:     "installed",
 		Aliases: []string{"i"},
 		Short:   "Manage installed packages",
+		Annotations: map[string]string{
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value,
+		},
 	}
 	return cmd
 }

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -78,7 +78,8 @@ func NewCreateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 				[]string{"package", "installed", "create", "-i", "cert-man", "-p", "cert-manager.community.tanzu.vmware.com", "--version", "1.6.1", "--service-account-name", "existing-sa"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 	o.SecureNamespaceFlags.Set(cmd)
@@ -121,7 +122,8 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 				[]string{"package", "install", "-i", "cert-man", "-p", "cert-manager.community.tanzu.vmware.com", "--version", "1.6.1", "--service-account-name", "existing-sa"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 	o.SecureNamespaceFlags.Set(cmd)
@@ -163,7 +165,8 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 				[]string{"package", "installed", "update", "-i", "cert-man", "--values", "false"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 	o.SecureNamespaceFlags.Set(cmd)

--- a/cli/pkg/kctrl/cmd/package/installed/delete.go
+++ b/cli/pkg/kctrl/cmd/package/installed/delete.go
@@ -58,7 +58,8 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 				[]string{"package", "installed", "delete", "-i", "cert-man"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 

--- a/cli/pkg/kctrl/cmd/package/installed/get.go
+++ b/cli/pkg/kctrl/cmd/package/installed/get.go
@@ -56,7 +56,8 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 				[]string{"package", "installed", "get", "-i", "cert-man", "--values-file-output", "values.yml"}},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{"table": ""},
+		Annotations: map[string]string{"table": "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 

--- a/cli/pkg/kctrl/cmd/package/installed/list.go
+++ b/cli/pkg/kctrl/cmd/package/installed/list.go
@@ -44,7 +44,8 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 				[]string{"package", "installed", "list", "-A"}},
 		}.Description("", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{"table": ""},
+		Annotations: map[string]string{"table": "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List installed packages in all namespaces")

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -52,7 +52,8 @@ func NewPauseCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobr
 			},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)
@@ -78,7 +79,8 @@ func NewKickCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobra
 			},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -44,7 +44,8 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 			},
 		}.Description("-i", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -47,6 +47,9 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 		Use:   "release",
 		Short: "Release package (experimental)",
 		RunE:  func(cmd *cobra.Command, args []string) error { return o.Run() },
+		Annotations: map[string]string{
+			cmdcore.PackageAuthoringCommandsHelpGroup.Key: cmdcore.PackageAuthoringCommandsHelpGroup.Value,
+		},
 	}
 
 	cmd.Flags().StringVarP(&o.pkgVersion, "version", "v", "", "Version to be released")

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -55,7 +55,8 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 				[]string{"package", "repository", "add", "-r", "tce", "--url", "projects.registry.vmware.com/tce/main:0.9.1"}},
 		}.Description("-r", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
@@ -92,7 +93,8 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 				[]string{"package", "repository", "update", "-r", "tce", "--url", "projects.registry.vmware.com/tce/main:0.9.2"}},
 		}.Description("-r", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)

--- a/cli/pkg/kctrl/cmd/package/repository/cmd.go
+++ b/cli/pkg/kctrl/cmd/package/repository/cmd.go
@@ -5,6 +5,7 @@ package repository
 
 import (
 	"github.com/spf13/cobra"
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 )
 
 func NewCmd() *cobra.Command {
@@ -12,6 +13,9 @@ func NewCmd() *cobra.Command {
 		Use:     "repository",
 		Aliases: []string{"repo", "r"},
 		Short:   "Manage package repositories",
+		Annotations: map[string]string{
+			cmdcore.PackageRepoHelpGroup.Key: cmdcore.PackageRepoHelpGroup.Value,
+		},
 	}
 	return cmd
 }

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -45,7 +45,8 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 				[]string{"package", "repository", "delete", "-r", "tce"}},
 		}.Description("-r", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)

--- a/cli/pkg/kctrl/cmd/package/repository/get.go
+++ b/cli/pkg/kctrl/cmd/package/repository/get.go
@@ -42,7 +42,8 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 				[]string{"package", "repository", "get", "-r", "tce"}},
 		}.Description("-r", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{"table": ""},
+		Annotations: map[string]string{"table": "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -38,10 +38,11 @@ func NewKickOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Log
 
 func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "kick",
-		Short:       "Trigger reconciliation for repository",
-		RunE:        func(_ *cobra.Command, _ []string) error { return o.Run() },
-		Annotations: map[string]string{cmdapp.TTYByDefaultKey: ""},
+		Use:   "kick",
+		Short: "Trigger reconciliation for repository",
+		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)

--- a/cli/pkg/kctrl/cmd/package/repository/list.go
+++ b/cli/pkg/kctrl/cmd/package/repository/list.go
@@ -45,7 +45,8 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 				[]string{"package", "repository", "list", "A"}},
 		}.Description("", o.pkgCmdTreeOpts),
 		SilenceUsage: true,
-		Annotations:  map[string]string{"table": ""},
+		Annotations: map[string]string{"table": "",
+			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List repositories in all namespaces")

--- a/cli/pkg/kctrl/cmd/package/repository/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/release.go
@@ -52,6 +52,9 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 		Use:   "release",
 		Short: "Build and create a package repository (experimental)",
 		RunE:  func(_ *cobra.Command, args []string) error { return o.Run() },
+		Annotations: map[string]string{
+			cmdcore.PackageAuthoringCommandsHelpGroup.Key: cmdcore.PackageAuthoringCommandsHelpGroup.Value,
+		},
 	}
 
 	cmd.Flags().StringVarP(&o.pkgRepoVersion, "version", "v", "", "Version to be released")

--- a/cli/test/e2e/help_test.go
+++ b/cli/test/e2e/help_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestHelpCommandGroup(t *testing.T) {
 	env := BuildEnv(t)
-	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, Logger{}}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, Logger{}}
 
-	_, err := kapp.RunWithOpts([]string{"app-group"}, RunOpts{NoNamespace: true, AllowError: true})
+	_, err := kappCtrl.RunWithOpts([]string{"package"}, RunOpts{NoNamespace: true, AllowError: true})
 	if err == nil {
 		t.Fatalf("Expected error")
 	}
-	if !strings.Contains(err.Error(), "Error: Use one of available subcommands: delete, deploy") {
+	if !strings.Contains(err.Error(), "Error: Use one of available subcommands: available, init, install, installed, release, repository") {
 		t.Fatalf("Expected helpful error message, but was '%s'", err.Error())
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
It adds sections to the `--help` command for app and package commands
As described on issue #632 

Additionally, it adds a help test for `kctrl` which was previously testing `kapp` (it was not supposed to)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
- Refactor help sections to be more structured
```

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
