### PR TITLE
add package details to child app cr annotations so that they can be used in app cr downward api

### DIFF
--- a/pkg/packageinstall/app.go
+++ b/pkg/packageinstall/app.go
@@ -43,6 +43,13 @@ func NewApp(existingApp *v1alpha1.App, pkgInstall *pkgingv1alpha1.PackageInstall
 
 	desiredApp.Name = pkgInstall.Name
 	desiredApp.Namespace = pkgInstall.Namespace
+
+	if desiredApp.Annotations == nil {
+		desiredApp.Annotations = map[string]string{}
+	}
+	desiredApp.Annotations["packaging.carvel.dev/package-ref-name"] = pkgVersion.Spec.RefName
+	desiredApp.Annotations["packaging.carvel.dev/package-version"] = pkgVersion.Spec.Version
+
 	desiredApp.Spec = *pkgVersion.Spec.Template.Spec
 	desiredApp.Spec.ServiceAccountName = pkgInstall.Spec.ServiceAccountName
 	if pkgInstall.Spec.SyncPeriod == nil {

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -562,3 +562,46 @@ func TestAppCustomFetchSecretNames(t *testing.T) {
 
 	require.Equal(t, expectedApp, app, "App does not match expected app")
 }
+
+func TestAppPackageDetailsAnnotations(t *testing.T) {
+	ipkg := &pkgingv1alpha1.PackageInstall{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "default",
+		},
+		Spec: pkgingv1alpha1.PackageInstallSpec{},
+	}
+
+	pkgVersion := datapkgingv1alpha1.Package{
+		Spec: datapkgingv1alpha1.PackageSpec{
+			RefName: "expec-pkg",
+			Version: "1.5.0",
+			Template: datapkgingv1alpha1.AppTemplateSpec{
+				Spec: &kcv1alpha1.AppSpec{},
+			},
+		},
+	}
+
+	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion)
+	require.NoError(t, err)
+
+	trueVal := true
+	expectedObjectMeta := metav1.ObjectMeta{
+		Name:      "app",
+		Namespace: "default",
+		Annotations: map[string]string{
+			"packaging.carvel.dev/package-ref-name": "expec-pkg",
+			"packaging.carvel.dev/package-version":  "1.5.0",
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion:         "packaging.carvel.dev/v1alpha1",
+			Kind:               "PackageInstall",
+			Name:               "app",
+			UID:                "",
+			Controller:         &trueVal,
+			BlockOwnerDeletion: &trueVal,
+		}},
+	}
+
+	require.Equal(t, expectedObjectMeta, app.ObjectMeta)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
change: add package details to child app cr annotations so that they can be used in app cr downward api

this info might be useful for template authors to propagate to some resources on the cluster. additionally it might be useful information to k8s operators that may decide certain functionality is available based on a version (e.g. imagine an operator that fails an upgrade of an operator before all of its CRs are on supported versions.)

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
