### PR TITLE
De-flake package repo tests. 

### DIFF
--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -53,10 +53,7 @@ func TestPackageRepository(t *testing.T) {
 	})
 
 	logger.Section("adding a repository", func() {
-		out := kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL})
-		require.Contains(t, out, "Fetch succeeded")
-		require.Contains(t, out, "Template succeeded")
-		require.Contains(t, out, "Deploy succeeded")
+		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL})
 
 		kubectl.Run([]string{"get", kind, pkgrName})
 		kubectl.Run([]string{"get", "pkgm/pkg.test.carvel.dev"})
@@ -66,8 +63,7 @@ func TestPackageRepository(t *testing.T) {
 
 	logger.Section("kicking a repository", func() {
 		out := kappCtrl.Run([]string{"package", "repository", "kick", "-r", pkgrName})
-		require.Contains(t, out, "Fetch succeeded")
-		require.Contains(t, out, "Template succeeded")
+
 		require.Contains(t, out, "Deploy succeeded")
 	})
 
@@ -114,12 +110,9 @@ func TestPackageRepository(t *testing.T) {
 
 		kubectl.Run([]string{"get", kind, pkgrName})
 
-		out := kappCtrl.Run([]string{"package", "repository", "update", "-r", pkgrName, "--url", pkgrURL})
-		require.Contains(t, out, "Fetch succeeded")
-		require.Contains(t, out, "Template succeeded")
-		require.Contains(t, out, "Deploy succeeded")
+		kappCtrl.Run([]string{"package", "repository", "update", "-r", pkgrName, "--url", pkgrURL})
 
-		out = kappCtrl.Run([]string{"package", "repository", "get", "-r", pkgrName, "--json"})
+		out := kappCtrl.Run([]string{"package", "repository", "get", "-r", pkgrName, "--json"})
 
 		output := uitest.JSONUIFromBytes(t, []byte(out))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Deflaking `kctrl package repo *` tests by doing necessary checks only
(Issue is illustrated further in #753 [here](https://github.com/vmware-tanzu/carvel-kapp-controller/issues/753#issuecomment-1184819420))

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
