### PR TITLE
clean up sidecarexec socket file in case of previous unclean process termination

### DIFF
--- a/pkg/sidecarexec/client.go
+++ b/pkg/sidecarexec/client.go
@@ -5,6 +5,7 @@ package sidecarexec
 
 import (
 	"net/rpc"
+	"sync"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
 )
@@ -12,16 +13,12 @@ import (
 // Client provides access to sidecarexec API.
 type Client struct {
 	local     exec.CmdRunner
-	rpcClient *rpc.Client
+	rpcClient rpcClient
 }
 
 // NewClient returns a new Client.
 func NewClient(local exec.CmdRunner) (Client, error) {
-	rpcClient, err := rpc.DialHTTP(serverListenType, serverListenAddr)
-	if err != nil {
-		return Client{}, err
-	}
-	return Client{local, rpcClient}, nil
+	return Client{local, &reconnectingRPCClient{}}, nil
 }
 
 // CmdExec returns command execution implementation.
@@ -32,4 +29,54 @@ func (r Client) CmdExec() CmdExecClient {
 // OSConfig returns runtime environment configuration implementation.
 func (r Client) OSConfig() OSConfigClient {
 	return OSConfigClient{r.rpcClient}
+}
+
+type rpcClient interface {
+	Call(serviceMethod string, args any, reply any) error
+}
+
+type reconnectingRPCClient struct {
+	clientLock sync.Mutex
+	client     *rpc.Client
+}
+
+func (c *reconnectingRPCClient) Call(serviceMethod string, args any, reply any) error {
+	client, err := c.connect(nil)
+	if err != nil {
+		return err
+	}
+
+	err = client.Call(serviceMethod, args, reply)
+	if err == rpc.ErrShutdown {
+		refreshedClient, err := c.connect(client)
+		if err != nil {
+			return err
+		}
+
+		err = refreshedClient.Call(serviceMethod, args, reply)
+	}
+	return err
+}
+
+// connect a client (which is nil or disconnected) in a thread-safe manner.
+// This is intended for clients which encountered a connection error,
+// so that we only try to reconnect if we haven't already done so in a different thread.
+func (c *reconnectingRPCClient) connect(disconnectedClient *rpc.Client) (*rpc.Client, error) {
+	c.clientLock.Lock()
+	defer c.clientLock.Unlock()
+
+	if c.client != nil {
+		if disconnectedClient == nil || disconnectedClient != c.client {
+			return c.client, nil
+		}
+		_ = c.client.Close()
+		c.client = nil
+	}
+
+	client, err := rpc.DialHTTP(serverListenType, serverListenAddr)
+	if err != nil {
+		return nil, err
+	}
+	c.client = client
+	return c.client, nil
 }

--- a/pkg/sidecarexec/cmd_exec_client.go
+++ b/pkg/sidecarexec/cmd_exec_client.go
@@ -6,7 +6,6 @@ package sidecarexec
 import (
 	"fmt"
 	"io/ioutil"
-	"net/rpc"
 	goexec "os/exec"
 	"path/filepath"
 
@@ -17,7 +16,7 @@ import (
 // except for kapp commands which continue to run locally.
 type CmdExecClient struct {
 	local     exec.CmdRunner
-	rpcClient *rpc.Client
+	rpcClient rpcClient
 }
 
 var _ exec.CmdRunner = CmdExecClient{}

--- a/pkg/sidecarexec/os_config_client.go
+++ b/pkg/sidecarexec/os_config_client.go
@@ -5,14 +5,13 @@ package sidecarexec
 
 import (
 	"fmt"
-	"net/rpc"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/config"
 )
 
 // OSConfigClient communicates over RPC client to configure runtime environment.
 type OSConfigClient struct {
-	rpcClient *rpc.Client
+	rpcClient rpcClient
 }
 
 var _ config.OSConfig = OSConfigClient{}

--- a/pkg/sidecarexec/server.go
+++ b/pkg/sidecarexec/server.go
@@ -56,6 +56,15 @@ func (r *Server) Serve() error {
 
 	rpc.HandleHTTP()
 
+	// Socket file may not be cleaned up upon unexpected process termination
+	// and without removal will result in "already in use" error messages.
+	if serverListenType == "unix" {
+		err = os.RemoveAll(serverListenAddr)
+		if err != nil {
+			return fmt.Errorf("Removing (unbinding) all listen addr: %s", err)
+		}
+	}
+
 	listener, err := net.Listen(serverListenType, serverListenAddr)
 	if err != nil {
 		return fmt.Errorf("Listening RPC: %s", err)


### PR DESCRIPTION
#### What this PR does / why we need it:

addresses https://github.com/vmware-tanzu/carvel-kapp-controller/issues/878

#### Does this PR introduce a user-facing change?
no

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
