### PR TITLE
configurable tls cipher suites

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -29,6 +29,7 @@ func main() {
 	flag.BoolVar(&ctrlOpts.APIPriorityAndFairness, "enable-api-priority-and-fairness", true, "Enable/disable APIPriorityAndFairness feature gate for apiserver. Recommended to disable for <= k8s 1.19.")
 	flag.BoolVar(&sidecarexec, "sidecarexec", false, "Run sidecarexec")
 	flag.BoolVar(&ctrlOpts.StartAPIServer, "start-api-server", true, "Start apiserver")
+	flag.StringVar(&ctrlOpts.TLSCipherSuites, "tls-cipher-suites", "", "comma separated list of acceptable cipher suites. Empty list will use defaults from underlying libraries.")
 	flag.Parse()
 
 	if sidecarexec {

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -10,6 +10,7 @@ import (
 	_ "net/http/pprof" // Pprof related
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -28,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/sidecarexec"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Initialize gcp client auth plugin
+	"k8s.io/component-base/cli/flag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -49,6 +51,7 @@ type Options struct {
 	MetricsBindAddress     string
 	APIPriorityAndFairness bool
 	StartAPIServer         bool
+	TLSCipherSuites        string
 }
 
 // Based on https://github.com/kubernetes-sigs/controller-runtime/blob/8f633b179e1c704a6e40440b528252f147a3362a/examples/builtins/main.go
@@ -115,11 +118,18 @@ func Run(opts Options, runLog logr.Logger) error {
 		if err != nil {
 			return fmt.Errorf("Building pkg kappctrl client: %s", err)
 		}
+
+		cSuites, err := parseTLSCipherSuites(opts.TLSCipherSuites)
+		if err != nil {
+			return err
+		}
+
 		server, err := apiserver.NewAPIServer(pkgRestConfig, coreClient, pkgKcClient, apiserver.NewAPIServerOpts{
 			GlobalNamespace:              opts.PackagingGloablNS,
 			BindPort:                     bindPort,
 			EnableAPIPriorityAndFairness: opts.APIPriorityAndFairness,
 			Logger:                       runLog.WithName("apiserver"),
+			TLSCipherSuites:              cSuites,
 		})
 		if err != nil {
 			return fmt.Errorf("Building API server: %s", err)
@@ -265,4 +275,21 @@ func Run(opts Options, runLog logr.Logger) error {
 	}
 
 	return nil
+}
+
+// parseTLSCipherSuites tries to validate and return the user-input ciphers or returns a default list
+// implementation largely stolen from: https://github.com/antrea-io/antrea/blob/25ff93d8987c6b9e3a2062254da6d7d70c623410/pkg/util/cipher/cipher.go#L32
+func parseTLSCipherSuites(opts string) ([]string, error) {
+	csStrList := strings.Split(strings.ReplaceAll(opts, " ", ""), ",")
+	if len(csStrList) == 1 && csStrList[0] == "" {
+		return nil, nil
+	}
+
+	// check to make sure they all parse - this just a fail-fast
+	_, err := flag.TLSCipherSuites(csStrList)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse TLSCipherSuites: %s", err)
+	}
+
+	return csStrList, nil
 }

--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -27,6 +27,7 @@ spec:
         #@ if/end data.values.dangerous_enable_pprof:
         - -dangerous-enable-pprof=true
         - #@ "-enable-api-priority-and-fairness={}".format(data.values.enable_api_priority_and_fairness)
+        - #@ "-tls-cipher-suites={}".format(data.values.tls_cipher_suites)
         env:
         - name: KAPPCTRL_MEM_TMP_DIR
           value: /etc/kappctrl-mem-tmp

--- a/config/values.yml
+++ b/config/values.yml
@@ -9,6 +9,9 @@ enable_api_priority_and_fairness: true
 
 dangerous_enable_pprof: false
 
+#! comma separated list of cipher suites - empty for language defaults
+tls_cipher_suites: ""
+
 push_images: false
 image_cache: true
 image_repo: docker.io/k14stest/kapp-controller-test

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/component-base v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 )
@@ -117,7 +118,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
-	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.32 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -85,6 +85,15 @@ type NewAPIServerOpts struct {
 	// v1.19 and earlier clusters - our libraries use the beta version of those APIs but they used to be alpha.
 	EnableAPIPriorityAndFairness bool
 
+	// TLSCipherSuites is the list of cipher suites the api server will be willing to use. Empty list defaults to the underlying
+	// libraries' defaults, which is usually fine especially if you don't expose the APIServer outside the cluster.
+	// see also: https://golang.org/pkg/crypto/tls/#pkg-constants
+	// According to Antrea, who we mostly copied:
+	// Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+	// prefer TLS1.3 Cipher Suites whenever possible.
+	TLSCipherSuites []string
+
+	// Logger is a logger
 	Logger logr.Logger
 }
 
@@ -162,6 +171,7 @@ func newServerConfig(aggClient aggregatorclient.Interface, opts NewAPIServerOpts
 	// Set the PairName and CertDirectory to generate the certificate files.
 	recommendedOptions.SecureServing.ServerCert.CertDirectory = selfSignedCertDir
 	recommendedOptions.SecureServing.ServerCert.PairName = "kapp-controller"
+	recommendedOptions.SecureServing.CipherSuites = opts.TLSCipherSuites
 
 	// ports below 1024 are probably the wrong port, see https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports
 	if opts.BindPort < 1024 {


### PR DESCRIPTION
this change allows users of kapp-controller to customize the cryptographic algorithms that the API server will use for TLS. 

While the APIServer is by default only accessible within the cluster, users may still wish to customize this list especially if they expose the APIServer.

Manual tests show that if bad cipher suites are provided the pod promptly enters crashloopbackoff with an error message in the logs like:
```
{"level":"error","ts":1663351527.0906084,"logger":"kc.main","msg":"Exited run with error","error":"unable to parse TLSCipherSuites: Cipher suite FOO not supported or doesn't exist","stacktrace":"main.main\n\tgithub.com/vmware-tanzu/carvel-kapp-controller/cmd/controller/main.go:49\nruntime.main\n\truntime/proc.go:250"}
```

Additional manual tests showed that the default behavior is unchanged, but when a select set of cipher suites are applied then handshakes with other cipher algorithms cannot be completed.