### PR TITLE
Update image with ver instead of sha in package-repository.yml

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/release/artifact_writer.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/artifact_writer.go
@@ -22,7 +22,7 @@ func NewArtifactWriter(pkgRepoName string, directory string) *ArtifactWriter {
 	return &ArtifactWriter{PackageRepoName: pkgRepoName, TargetDir: directory}
 }
 
-func (w *ArtifactWriter) WritePackageRepositoryFile(imgpkgBundleLocation string) error {
+func (w *ArtifactWriter) WritePackageRepositoryFile(bundleURLWithSHARef, bundleURLWithVerRef string) error {
 	packageRepository := v1alpha1.PackageRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRepository",
@@ -31,11 +31,14 @@ func (w *ArtifactWriter) WritePackageRepositoryFile(imgpkgBundleLocation string)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              w.PackageRepoName,
 			CreationTimestamp: metav1.NewTime(time.Now()),
+			Annotations: map[string]string{
+				"sha-ref": bundleURLWithSHARef,
+			},
 		},
 		Spec: v1alpha1.PackageRepositorySpec{
 			Fetch: &v1alpha1.PackageRepositoryFetch{
 				ImgpkgBundle: &v1alpha12.AppFetchImgpkgBundle{
-					Image: imgpkgBundleLocation,
+					Image: bundleURLWithVerRef,
 				},
 			},
 		},

--- a/cli/pkg/kctrl/cmd/package/repository/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/release.go
@@ -154,7 +154,7 @@ func (o *ReleaseOptions) Run() error {
 	}
 	o.ui.PrintCmdExecutionOutput(fmt.Sprintf("\n$ %s", strings.Join(cmd.Args, " ")))
 
-	var bundleURL string
+	var bundleURLWithSHARef string
 
 	switch {
 	case pkgRepoBuild.Spec.Export.ImgpkgBundle != nil:
@@ -165,14 +165,16 @@ func (o *ReleaseOptions) Run() error {
 			ImgLockFilepath:   tempImgpkgLockPath,
 			UI:                o.ui,
 		}
-		bundleURL, err = imgpkgRunner.Run()
+		bundleURLWithSHARef, err = imgpkgRunner.Run()
 		if err != nil {
 			return err
 		}
 	}
 
 	artifactWriter := NewArtifactWriter(pkgRepoName, wd)
-	err = artifactWriter.WritePackageRepositoryFile(bundleURL)
+	repoURL := strings.Split(bundleURLWithSHARef, "@sha")[0]
+	bundleURLWithVerRef := strings.Join([]string{repoURL, o.pkgRepoVersion}, ":")
+	err = artifactWriter.WritePackageRepositoryFile(bundleURLWithSHARef, bundleURLWithVerRef)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Update image with ver instead of sha in package-repository.yml

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Package-repository.yml file created by the pkg repo release command has sha digest as a tag for the pkg repo bundle. When we kapp deploy or kubectl apply this file and list the available repository on the cluster, we see the tag as sha-digest rather than human readable tag.

This PR adds the version as the tag rather than `sha-digest`. Also, it adds the sha-digest as metadata annotation.

#### Which issue(s) this PR fixes:

#874

Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
