### PR TITLE
Add new kapp flags to allowed change opts

### DIFF
--- a/pkg/deploy/kapp_restrict.go
+++ b/pkg/deploy/kapp_restrict.go
@@ -48,6 +48,7 @@ var (
 		"--apply-default-update-strategy",
 		"--apply-ignored",
 		"--apply-timeout",
+		"--exit-early-on-apply-error",
 
 		// Waiting
 		"--wait",
@@ -55,6 +56,7 @@ var (
 		"--wait-concurrency",
 		"--wait-ignored",
 		"--wait-timeout",
+		"--exit-early-on-wait-error",
 	}
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add new kapp flags available from kapp [v0.53.0](https://github.com/vmware-tanzu/carvel-kapp/releases/tag/v0.53.0) to allowed change opts
- `--exit-early-on-apply-error`
- `--exit-early-on-wait-error`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
