### PR TITLE
Use all component info fields in Downward API example

### DIFF
--- a/examples/simple-app-downward-api/app.yml
+++ b/examples/simple-app-downward-api/app.yml
@@ -21,6 +21,8 @@ spec:
               kubernetesVersion: {}
             - name: kcV
               kappControllerVersion: {}
+            - name: k8sApis
+              kubernetesAPIs: {}
       inline:
         paths:
           filename.yaml: |
@@ -37,7 +39,7 @@ spec:
                     env:
                     #@overlay/match by="name"
                     - name: HELLO_MSG
-                      value: #@ "from {} namespace, deployed by kapp-controller v{}, hosted on kubernetes v{}".format(data.values.ns, data.values.kcV, data.values.k8sV)
+                      value: #@ "from {} namespace, deployed by kapp-controller v{}, hosted on kubernetes v{}, supporting api-versions {}".format(data.values.ns, data.values.kcV, data.values.k8sV, data.values.k8sApis)
   #! sample output: <h1>Hello from default namespace, deployed by kapp-controller v0.40.0+develop, hosted on kubernetes v1.23.3!</h1>
   deploy:
   - kapp: {}

--- a/examples/simple-app-downward-api/app.yml
+++ b/examples/simple-app-downward-api/app.yml
@@ -40,6 +40,6 @@ spec:
                     #@overlay/match by="name"
                     - name: HELLO_MSG
                       value: #@ "from {} namespace, deployed by kapp-controller v{}, hosted on kubernetes v{}, supporting api-versions {}".format(data.values.ns, data.values.kcV, data.values.k8sV, data.values.k8sApis)
-  #! sample output: <h1>Hello from default namespace, deployed by kapp-controller v0.40.0+develop, hosted on kubernetes v1.23.3!</h1>
+  #! sample output: <h1>Hello from default namespace, deployed by kapp-controller v0.40.0+develop, hosted on kubernetes v1.23.3, supporting api-versions ["data.packaging.carvel.dev/v1alpha1", "apps/v1"] ...</h1>
   deploy:
   - kapp: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Make the Downward API example a little more complete by including the `kubernetesAPIs` field as well.

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change
