### PR TITLE
Activate caching of images and bundles

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -187,13 +187,14 @@ func Run(opts Options, runLog logr.Logger) error {
 
 	{ // add controller for apps
 		appFactory := app.CRDAppFactory{
-			CoreClient: coreClient,
-			AppClient:  kcClient,
-			KcConfig:   kcConfig,
-			AppMetrics: appMetrics,
-			CmdRunner:  sidecarCmdExec,
-			Kubeconf:   kubeconf,
-			CompInfo:   compInfo,
+			CoreClient:  coreClient,
+			AppClient:   kcClient,
+			KcConfig:    kcConfig,
+			AppMetrics:  appMetrics,
+			CmdRunner:   sidecarCmdExec,
+			Kubeconf:    kubeconf,
+			CompInfo:    compInfo,
+
 		}
 		reconciler := app.NewReconciler(kcClient, runLog.WithName("app"),
 			appFactory, refTracker, updateStatusTracker, compInfo)
@@ -236,7 +237,7 @@ func Run(opts Options, runLog logr.Logger) error {
 	}
 
 	{ // add controller for pkgrepositories
-		appFactory := pkgrepository.AppFactory{coreClient, kcClient, kcConfig, sidecarCmdExec, kubeconf}
+		appFactory := pkgrepository.AppFactory{coreClient, kcClient, kcConfig, sidecarCmdExec,    kubeconf}
 
 		reconciler := pkgrepository.NewReconciler(kcClient, coreClient,
 			runLog.WithName("pkgr"), appFactory, refTracker, updateStatusTracker)

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -22,6 +22,7 @@ import (
 	kcconfig "github.com/vmware-tanzu/carvel-kapp-controller/pkg/config"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/kubeconfig"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/memdir"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/metrics"
 	pkginstall "github.com/vmware-tanzu/carvel-kapp-controller/pkg/packageinstall"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/pkgrepository"
@@ -185,6 +186,11 @@ func Run(opts Options, runLog logr.Logger) error {
 	kubeconf := kubeconfig.NewKubeconfig(coreClient, runLog)
 	compInfo := componentinfo.NewComponentInfo(coreClient, kubeconf, Version)
 
+	cacheFolderApps := memdir.NewTmpDir("cache-appcr")
+	err = cacheFolderApps.Create()
+	if err != nil {
+		return fmt.Errorf("Unable to create cache tmp directory for AppCRs: %s", err)
+	}
 	{ // add controller for apps
 		appFactory := app.CRDAppFactory{
 			CoreClient:  coreClient,
@@ -194,7 +200,7 @@ func Run(opts Options, runLog logr.Logger) error {
 			CmdRunner:   sidecarCmdExec,
 			Kubeconf:    kubeconf,
 			CompInfo:    compInfo,
-
+			CacheFolder: cacheFolderApps,
 		}
 		reconciler := app.NewReconciler(kcClient, runLog.WithName("app"),
 			appFactory, refTracker, updateStatusTracker, compInfo)
@@ -236,8 +242,21 @@ func Run(opts Options, runLog logr.Logger) error {
 		}
 	}
 
+	cacheFolderPkgRepoApps := memdir.NewTmpDir("cache-package-repo")
+	err = cacheFolderPkgRepoApps.Create()
+	if err != nil {
+		return fmt.Errorf("Unable to create cache tmp directory for AppCRs: %s", err)
+	}
+
 	{ // add controller for pkgrepositories
-		appFactory := pkgrepository.AppFactory{coreClient, kcClient, kcConfig, sidecarCmdExec,    kubeconf}
+		appFactory := pkgrepository.AppFactory{
+			CoreClient:  coreClient,
+			AppClient:   kcClient,
+			KcConfig:    kcConfig,
+			CmdRunner:   sidecarCmdExec,
+			Kubeconf:    kubeconf,
+			CacheFolder: cacheFolderPkgRepoApps,
+		}
 
 		reconciler := pkgrepository.NewReconciler(kcClient, coreClient,
 			runLog.WithName("pkgr"), appFactory, refTracker, updateStatusTracker)

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -4,19 +4,25 @@ set -e -x -o pipefail
 
 go clean -testcache
 
+GO=go
+if command -v richgo &> /dev/null
+then
+    GO=richgo
+fi
+
 if [ -z "$KAPPCTRL_E2E_NAMESPACE" ]; then
   echo "setting e2e namespace to: kappctrl-test";
   export KAPPCTRL_E2E_NAMESPACE="kappctrl-test"
 fi
 # create ns if not exists because the `apply -f -` won't complain on a no-op if the ns already exists.
 kubectl create ns $KAPPCTRL_E2E_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-go test ./test/e2e/kappcontroller -timeout 60m $@ | tee tmp/e2eoutput.txt
+$GO test ./test/e2e/kappcontroller -timeout 60m $@ | tee tmp/e2eoutput.txt
 
 if [ -z "$KAPPCTRL_E2E_SECRETGEN_CONTROLLER" ]; then
   echo "skipping secretgencontroller tests";
 else
   if [ "$KAPPCTRL_E2E_SECRETGEN_CONTROLLER" == "true" ]; then
-    go test ./test/e2e/secretgencontroller -timeout 60m $@ | tee -a tmp/e2eoutput.txt
+    $GO test ./test/e2e/secretgencontroller -timeout 60m $@ | tee -a tmp/e2eoutput.txt
   fi
 fi
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -8,6 +8,12 @@ fi
 
 set -u
 
-go test ./pkg/... ./cmd/... ./hack/... $@
+GO=go
+if command -v richgo &> /dev/null
+then
+    GO=richgo
+fi
+
+$GO test ./pkg/... ./cmd/... ./hack/... $@
 
 echo UNIT SUCCESS

--- a/pkg/app/app_factory.go
+++ b/pkg/app/app_factory.go
@@ -4,6 +4,8 @@
 package app
 
 import (
+	"path/filepath"
+
 	"github.com/go-logr/logr"
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kcclient "github.com/vmware-tanzu/carvel-kapp-controller/pkg/client/clientset/versioned"
@@ -12,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/fetch"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/kubeconfig"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/memdir"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/metrics"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 	vendirconf "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
@@ -29,13 +32,16 @@ type CRDAppFactory struct {
 	CmdRunner        exec.CmdRunner
 	Kubeconf         *kubeconfig.Kubeconfig
 	CompInfo         ComponentInfo
+	DeployFactory    deploy.Factory
+	CacheFolder      *memdir.TmpDir
 }
 
 // NewCRDApp creates a CRDApp injecting necessary dependencies.
 func (f *CRDAppFactory) NewCRDApp(app *kcv1alpha1.App, log logr.Logger) *CRDApp {
 	vendirOpts := fetch.VendirOpts{
-		SkipTLSConfig: f.KcConfig,
-		ConfigHook:    f.VendirConfigHook,
+		SkipTLSConfig:   f.KcConfig,
+		ConfigHook:      f.VendirConfigHook,
+		BaseCacheFolder: filepath.Join(f.CacheFolder.Path(), "apps"),
 	}
 
 	fetchFactory := fetch.NewFactory(f.CoreClient, vendirOpts, f.CmdRunner)

--- a/pkg/app/app_fetch.go
+++ b/pkg/app/app_fetch.go
@@ -39,7 +39,7 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 		return "", result
 	}
 
-	result = vendir.Run(conf, dstPath)
+	result = vendir.Run(conf, dstPath, a.cacheID())
 
 	// retry if error occurs before reporting failure.
 	// This is mainly done to support private registry
@@ -61,7 +61,7 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 				// no secrets/configmaps have changed, no point in retrying
 				continue
 			}
-			result = vendir.Run(newConf, dstPath)
+			result = vendir.Run(newConf, dstPath, a.cacheID())
 			if result.Error == nil {
 				break
 			}
@@ -77,4 +77,8 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 	}
 
 	return dstPath, result
+}
+
+func (a *App) cacheID() string {
+	return string(a.app.ObjectMeta.UID)
 }

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -60,7 +60,13 @@ func (a *App) reconcileDelete() error {
 	a.markObservedLatest()
 	a.setDeleting()
 
-	err := a.updateStatus("marking deleting")
+	vendir := a.fetchFactory.NewVendir(a.app.Namespace)
+	err := vendir.ClearCache(a.cacheID())
+	if err != nil {
+		return err
+	}
+
+	err = a.updateStatus("marking deleting")
 	if err != nil {
 		return err
 	}

--- a/pkg/app/app_reconcile_test.go
+++ b/pkg/app/app_reconcile_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -33,6 +34,7 @@ func Test_NoInspectReconcile_IfNoDeployAttempted(t *testing.T) {
 	// app to fail before deploy.
 	app := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:       uuid.NewUUID(),
 			Name:      "simple-app",
 			Namespace: "pkg-standalone",
 		},
@@ -87,6 +89,7 @@ func Test_NoInspectReconcile_IfInspectNotEnabled(t *testing.T) {
 
 	app := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:       uuid.NewUUID(),
 			Name:      "simple-app",
 			Namespace: "pkg-standalone",
 		},
@@ -167,6 +170,7 @@ func Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty(t *testing.
 	}
 	app := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:       uuid.NewUUID(),
 			Name:      "simple-app",
 			Namespace: "pkg-standalone",
 		},

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -405,6 +405,11 @@ func (v *Vendir) Run(conf []byte, workingDir string, cacheID string) exec.CmdRun
 	return result
 }
 
+// ClearCache removes all cache entries for the cacheID
+func (v *Vendir) ClearCache(cacheID string) error {
+	return os.RemoveAll(filepath.Join(v.opts.BaseCacheFolder, cacheID))
+}
+
 // ExtractImageRegistry returns the registry portion of a Docker image reference
 func ExtractImageRegistry(name string) string {
 	parts := strings.SplitN(name, "/", 2)

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	goexec "os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
@@ -37,8 +38,9 @@ type VendirOpts struct {
 	// ConfigHook provides an opportunity to make changes to vendir configuration
 	// before it's given to vendir for execution. If not provided it will default
 	// to the identity function.
-	ConfigHook    func(vendirconf.Config) vendirconf.Config
-	SkipTLSConfig SkipTLSConfig
+	ConfigHook      func(vendirconf.Config) vendirconf.Config
+	SkipTLSConfig   SkipTLSConfig
+	BaseCacheFolder string
 }
 
 // NewVendir returns vendir.
@@ -382,7 +384,7 @@ func (v *Vendir) shouldSkipTLSVerify(url string) bool {
 }
 
 // Run executes vendir command based on given configuration.
-func (v *Vendir) Run(conf []byte, workingDir string) exec.CmdRunResult {
+func (v *Vendir) Run(conf []byte, workingDir string, cacheID string) exec.CmdRunResult {
 	var stdoutBs, stderrBs bytes.Buffer
 
 	cmd := goexec.Command("vendir", "sync", "-f", "-", "--lock-file", os.DevNull)
@@ -390,6 +392,7 @@ func (v *Vendir) Run(conf []byte, workingDir string) exec.CmdRunResult {
 	cmd.Stdin = bytes.NewReader(conf)
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
+	cmd.Env = append(os.Environ(), "VENDIR_CACHE_DIR="+filepath.Join(v.opts.BaseCacheFolder, cacheID))
 
 	err := v.cmdRunner.Run(cmd)
 

--- a/pkg/pkgrepository/app.go
+++ b/pkg/pkgrepository/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/fetch"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/reftracker"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 type Hooks struct {
@@ -19,9 +20,10 @@ type Hooks struct {
 }
 
 type App struct {
-	app     v1alpha1.App
-	appPrev v1alpha1.App
-	hooks   Hooks
+	app        v1alpha1.App
+	appPrev    v1alpha1.App
+	pkgRepoUID types.UID
+	hooks      Hooks
 
 	fetchFactory    fetch.Factory
 	templateFactory template.Factory
@@ -33,13 +35,11 @@ type App struct {
 	flushAllStatusUpdates bool
 }
 
-func NewApp(app v1alpha1.App, hooks Hooks,
-	fetchFactory fetch.Factory, templateFactory template.Factory,
-	deployFactory deploy.Factory, log logr.Logger) *App {
-
+// NewApp creates a new instance of an App based on v1alpha1.App
+func NewApp(app v1alpha1.App, hooks Hooks, fetchFactory fetch.Factory, templateFactory template.Factory, deployFactory deploy.Factory, log logr.Logger, pkgRepoUID types.UID) *App {
 	return &App{app: app, appPrev: *(app.DeepCopy()), hooks: hooks,
 		fetchFactory: fetchFactory, templateFactory: templateFactory,
-		deployFactory: deployFactory, log: log}
+		deployFactory: deployFactory, log: log, pkgRepoUID: pkgRepoUID}
 }
 
 func (a *App) Name() string      { return a.app.Name }

--- a/pkg/pkgrepository/app_factory.go
+++ b/pkg/pkgrepository/app_factory.go
@@ -4,6 +4,8 @@
 package pkgrepository
 
 import (
+	"path/filepath"
+
 	"github.com/go-logr/logr"
 	kcv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	pkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
@@ -13,22 +15,28 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/fetch"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/kubeconfig"
+	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/memdir"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 	"k8s.io/client-go/kubernetes"
 )
 
 // AppFactory allows to create "hidden" Apps for reconciling PackageRepositories.
 type AppFactory struct {
-	CoreClient kubernetes.Interface
-	AppClient  kcclient.Interface
-	KcConfig   *config.Config
-	CmdRunner  exec.CmdRunner
-	Kubeconf   *kubeconfig.Kubeconfig
+	CoreClient  kubernetes.Interface
+	AppClient   kcclient.Interface
+	KcConfig    *config.Config
+	CmdRunner   exec.CmdRunner
+	Kubeconf    *kubeconfig.Kubeconfig
+	CacheFolder *memdir.TmpDir
 }
 
 // NewCRDPackageRepo constructs "hidden" App to reconcile PackageRepository.
 func (f *AppFactory) NewCRDPackageRepo(app *kcv1alpha1.App, pkgr *pkgv1alpha1.PackageRepository, log logr.Logger) *CRDApp {
-	fetchFactory := fetch.NewFactory(f.CoreClient, fetch.VendirOpts{SkipTLSConfig: f.KcConfig}, f.CmdRunner)
+	vendirOpts := fetch.VendirOpts{
+		SkipTLSConfig:   f.KcConfig,
+		BaseCacheFolder: filepath.Join(f.CacheFolder.Path(), "pkg-repo"),
+	}
+	fetchFactory := fetch.NewFactory(f.CoreClient, vendirOpts, f.CmdRunner)
 	templateFactory := template.NewFactory(f.CoreClient, fetchFactory, false, f.CmdRunner)
 	deployFactory := deploy.NewFactory(f.CoreClient, f.Kubeconf, nil, f.CmdRunner, log)
 	return NewCRDApp(app, pkgr, log, f.AppClient, fetchFactory, templateFactory, deployFactory)

--- a/pkg/pkgrepository/app_fetch.go
+++ b/pkg/pkgrepository/app_fetch.go
@@ -39,7 +39,7 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 		return "", result
 	}
 
-	result = vendir.Run(conf, dstPath)
+	result = vendir.Run(conf, dstPath, a.cacheID())
 
 	// retry if error occurs before reporting failure.
 	// This is mainly done to support private registry
@@ -61,7 +61,7 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 				// no secrets/configmaps have changed, no point in retrying
 				continue
 			}
-			result = vendir.Run(newConf, dstPath)
+			result = vendir.Run(newConf, dstPath, a.cacheID())
 			if result.Error == nil {
 				break
 			}
@@ -77,4 +77,8 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 	}
 
 	return dstPath, result
+}
+
+func (a *App) cacheID() string {
+	return string(a.pkgRepoUID)
 }

--- a/pkg/pkgrepository/app_reconcile.go
+++ b/pkg/pkgrepository/app_reconcile.go
@@ -53,7 +53,13 @@ func (a *App) reconcileDelete() error {
 	a.markObservedLatest()
 	a.setDeleting()
 
-	err := a.updateStatus("marking deleting")
+	vendir := a.fetchFactory.NewVendir(a.app.Namespace)
+	err := vendir.ClearCache(a.cacheID())
+	if err != nil {
+		return err
+	}
+
+	err = a.updateStatus("marking deleting")
 	if err != nil {
 		return err
 	}

--- a/pkg/pkgrepository/app_reconcile_test.go
+++ b/pkg/pkgrepository/app_reconcile_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -28,6 +29,7 @@ func Test_NoInspectReconcile_IfNoDeployAttempted(t *testing.T) {
 	// app to fail before deploy.
 	app := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
 			Name: "simple-app",
 		},
 		Spec: v1alpha1.AppSpec{
@@ -82,6 +84,7 @@ func Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty(t *testing.
 	}
 	app := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
 			Name: "simple-app",
 		},
 		Spec: v1alpha1.AppSpec{
@@ -138,6 +141,7 @@ func TestInvalidPackageRepositoryFormat(t *testing.T) {
 	}
 	app := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:  uuid.NewUUID(),
 			Name: "simple-app",
 		},
 		Spec: v1alpha1.AppSpec{

--- a/pkg/pkgrepository/crd_app.go
+++ b/pkg/pkgrepository/crd_app.go
@@ -37,7 +37,7 @@ func NewCRDApp(appModel *kcv1alpha1.App, packageRepo *pkgingv1alpha1.PackageRepo
 		BlockDeletion:   crdApp.blockDeletion,
 		UnblockDeletion: crdApp.unblockDeletion,
 		UpdateStatus:    crdApp.updateStatus,
-	}, fetchFactory, templateFactory, deployFactory, log)
+	}, fetchFactory, templateFactory, deployFactory, log, packageRepo.UID)
 
 	return crdApp
 }

--- a/test/e2e/assets/registry/no-auth-registry.yml
+++ b/test/e2e/assets/registry/no-auth-registry.yml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: registry
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: registry
+  name: registry-svc
+spec:
+  selector:
+    app: simple-registry
+  ports:
+    - port: 5050
+      targetPort: 5050
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-registry
+  namespace: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app:  simple-registry
+  template:
+    metadata:
+      labels:
+        app: simple-registry
+    spec:
+      containers:
+        - name: simple-registry
+          image: registry
+          env:
+            - name: REGISTRY_HTTP_ADDR
+              value: 0.0.0.0:5050
+            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+              value: /var/lib/tmp/registry
+          ports:
+            - containerPort: 5050
+          volumeMounts:
+            - mountPath: /var/lib
+              name: registry-sync
+      initContainers:
+        - name: registry-contents-populator
+          image: registry
+          command: [ "/bin/sh","-c", "tar -xf /tmp/tmp-registry -C /var/lib" ]
+          volumeMounts:
+            - mountPath: /tmp
+              name: registry-contents
+            - mountPath: /var/lib
+              name: registry-sync
+
+      volumes:
+        - name: registry-contents
+          configMap:
+            name: registry-contents
+        - name: registry-sync
+          emptyDir: { }

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -32,12 +32,15 @@ type RunOpts struct {
 	OnErrKubectl []string
 }
 
-func (k Kapp) Run(args []string) string {
+// Run executes kapp with the provided arguments
+func (k *Kapp) Run(args []string) string {
 	out, _ := k.RunWithOpts(args, RunOpts{})
 	return out
 }
 
-func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
+// RunWithOpts executes kapp with the provided arguments and allow for extra options
+func (k *Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
+	k.T.Helper()
 	if !opts.NoNamespace {
 		args = append(args, []string{"-n", k.Namespace}...)
 	}
@@ -99,7 +102,7 @@ func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	return stdoutStr, err
 }
 
-func (k Kapp) cmdDesc(args []string, opts RunOpts) string {
+func (k *Kapp) cmdDesc(args []string, opts RunOpts) string {
 	prefix := "kapp"
 	if opts.Redact {
 		return prefix + " -redacted-"

--- a/test/e2e/kappcontroller/imgpkg_bundle_test.go
+++ b/test/e2e/kappcontroller/imgpkg_bundle_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	v1alpha12 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,4 +120,358 @@ spec:
 
 		require.Equal(t, expectedStatus, cr.Status)
 	})
+}
+
+func Test_AppCR_FetchFromCaching(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
+
+	pkgiName := "pkgi-to-test-caching"
+	registryNamespace := "registry"
+	registryName := "test-registry"
+
+	cleanUp := func() {
+		// Delete App with kubectl first since kapp
+		// deletes ServiceAccount before App
+		kubectl.RunWithOpts([]string{"delete", "apps/" + pkgiName}, e2e.RunOpts{AllowError: true})
+		kapp.Run([]string{"delete", "-a", pkgiName})
+		kapp.Run([]string{"delete", "-a", registryName, "-n", registryNamespace})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy registry without auth", func() {
+		kapp.Run([]string{
+			"deploy", "-a", registryName,
+			"-f", "../assets/registry/no-auth-registry.yml",
+			"-f", "../assets/registry/registry-contents.yml",
+		})
+	})
+
+	var initialFetchUpdate metav1.Time
+	logger.Section("deploy PackageInstall", func() {
+		pkgiYaml := fmt.Sprintf(`---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: pkg.test.carvel.dev.1.0.0
+  namespace: %[1]s
+  annotations:
+    kapp.k14s.io/change-group: "package"
+spec:
+  refName: pkg.test.carvel.dev
+  version: 1.0.0
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-bundle@sha256:387e2fa04e3c9d7b89f03be4fd3fb661fa3496352ece38a7fc8cba6780c7131d
+      template:
+      - ytt: {}
+      - kbld:
+          paths:
+          - "-"
+          - ".imgpkg/images.yml"
+      deploy:
+      - kapp: {}
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/packageinstalls
+    kapp.k14s.io/change-rule: "upsert after upserting package"
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  packageRef:
+    refName: pkg.test.carvel.dev
+    versionSelection:
+      constraints: 1.0.0
+`, env.Namespace, pkgiName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgiName, "-f", "-"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgiYaml),
+			OnErrKubectl: []string{"get", "app", pkgiName, "-oyaml"},
+		})
+
+		kubectl.Run([]string{"get", "configmap", "e2e-test-map"})
+		output := kubectl.Run([]string{"get", "app", pkgiName, "-oyaml"})
+		var appcr v1alpha1.App
+		require.NoError(t, yaml.Unmarshal([]byte(output), &appcr))
+		require.Equal(t, 0, appcr.Status.Fetch.ExitCode)
+		initialFetchUpdate = appcr.Status.Fetch.UpdatedAt
+	})
+	defer kapp.Run([]string{"delete", "-a", pkgiName})
+
+	logger.Section("remove registry", func() {
+		kapp.Run([]string{"delete", "-a", registryName, "-n", registryNamespace})
+	})
+
+	logger.Section("wait for reconciliation and ensure no error occur while fetching", func() {
+		pkgiYaml := fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/packageinstalls
+    kapp.k14s.io/change-rule: "upsert after upserting package"
+spec:
+  paused: true
+  serviceAccountName: kappctrl-e2e-ns-sa
+  packageRef:
+    refName: pkg.test.carvel.dev
+    versionSelection:
+      constraints: 1.0.0
+`, env.Namespace, pkgiName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgiName, "-f", "-", "-p"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgiYaml),
+			OnErrKubectl: []string{"get", "app", pkgiName, "-oyaml"},
+		})
+
+		pkgiYaml = fmt.Sprintf(`
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/packageinstalls
+    kapp.k14s.io/change-rule: "upsert after upserting package"
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  packageRef:
+    refName: pkg.test.carvel.dev
+    versionSelection:
+      constraints: 1.0.0
+`, env.Namespace, pkgiName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgiName, "-f", "-", "-p"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgiYaml),
+			OnErrKubectl: []string{"get", "app", pkgiName, "-oyaml"},
+		})
+		waitForPKGIReconciliationOrFail(t, kubectl, pkgiName, initialFetchUpdate)
+
+		var appcr v1alpha1.App
+		output := kubectl.Run([]string{"get", "app", pkgiName, "-oyaml"})
+		require.NoError(t, yaml.Unmarshal([]byte(output), &appcr))
+		require.Equal(t, 0, appcr.Status.Fetch.ExitCode)
+	})
+}
+
+func Test_PackageRepo_FetchFromCaching(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
+
+	pkgrName := "pkgr-to-test-caching"
+	registryNamespace := "registry"
+	registryName := "test-registry"
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", pkgrName})
+		kapp.Run([]string{"delete", "-a", registryName, "-n", registryNamespace})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy registry without authentication", func() {
+		kapp.Run([]string{
+			"deploy", "-a", registryName,
+			"-f", "../assets/registry/no-auth-registry.yml",
+			"-f", "../assets/registry/registry-contents.yml",
+		})
+	})
+
+	logger.Section("deploy PackageRepository that auths to registry", func() {
+		pkgrYaml := fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  syncPeriod: 30s
+  fetch:
+    image:
+      url: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-repo@sha256:5deb3a248b2024da70b7a34bf561c91b23d2810bee5aa666d0fba9f10e26c273
+`, env.Namespace, pkgrName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgrName, "-f", "-"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgrYaml),
+			OnErrKubectl: []string{"get", "pkgr", "-A", "-oyaml"},
+		})
+	})
+
+	logger.Section("remove registry", func() {
+		kapp.Run([]string{"delete", "-a", registryName, "-n", registryNamespace})
+	})
+
+	logger.Section("pause/unpause package repository and check it does not fail", func() {
+		pkgrYaml := fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  paused: true
+  fetch:
+    image:
+      url: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-repo@sha256:5deb3a248b2024da70b7a34bf561c91b23d2810bee5aa666d0fba9f10e26c273
+`, env.Namespace, pkgrName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgrName, "-f", "-"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgrYaml),
+			OnErrKubectl: []string{"get", "pkgr", "-A", "-oyaml"},
+		})
+
+		pkgrYaml = fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  fetch:
+    image:
+      url: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-repo@sha256:5deb3a248b2024da70b7a34bf561c91b23d2810bee5aa666d0fba9f10e26c273
+`, env.Namespace, pkgrName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgrName, "-f", "-"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgrYaml),
+			OnErrKubectl: []string{"get", "pkgr", "-A", "-oyaml"},
+		})
+
+		var pkgr v1alpha12.PackageRepository
+		output := kubectl.Run([]string{"get", "packagerepository", pkgrName, "-oyaml"})
+		require.NoError(t, yaml.Unmarshal([]byte(output), &pkgr))
+		require.Equal(t, int64(3), pkgr.Status.ObservedGeneration)
+		require.Equal(t, 0, pkgr.Status.Fetch.ExitCode)
+	})
+}
+
+func Test_PackageRepo_DoesNotFetchFromCaching(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
+
+	pkgrName := "pkgr-to-test-caching"
+	registryNamespace := "registry"
+	registryName := "test-registry"
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", pkgrName})
+		kapp.Run([]string{"delete", "-a", registryName, "-n", registryNamespace})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy registry without authentication", func() {
+		kapp.Run([]string{
+			"deploy", "-a", registryName,
+			"-f", "../assets/registry/no-auth-registry.yml",
+			"-f", "../assets/registry/registry-contents.yml",
+		})
+	})
+
+	logger.Section("deploy PackageRepository that auths to registry", func() {
+		pkgrYaml := fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  syncPeriod: 30s
+  fetch:
+    image:
+      url: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-repo
+`, env.Namespace, pkgrName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgrName, "-f", "-"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgrYaml),
+			OnErrKubectl: []string{"get", "pkgr", "-A", "-oyaml"},
+		})
+
+		kubectl.Run([]string{"get", "package", "pkg.test.carvel.dev.1.0.0"})
+	})
+
+	logger.Section("remove registry", func() {
+		kapp.Run([]string{"delete", "-a", registryName, "-n", registryNamespace})
+	})
+
+	logger.Section("pause/unpause and check that it fails reconciling the package repository", func() {
+		pkgrYaml := fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  paused: true
+  fetch:
+    image:
+      url: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-repo
+`, env.Namespace, pkgrName, registryNamespace) + sas.ForNamespaceYAML()
+
+		kapp.RunWithOpts([]string{"deploy", "-a", pkgrName, "-f", "-"}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(pkgrYaml),
+			OnErrKubectl: []string{"get", "pkgr", "-A", "-oyaml"},
+		})
+		pkgrYaml = fmt.Sprintf(`---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  fetch:
+    image:
+      url: registry-svc.%[3]s.svc.cluster.local:5050/secret-test/test-repo
+`, env.Namespace, pkgrName, registryNamespace) + sas.ForNamespaceYAML()
+
+		_, err := kapp.RunWithOpts([]string{"deploy", "-a", pkgrName, "-f", "-"}, e2e.RunOpts{
+			StdinReader: strings.NewReader(pkgrYaml),
+			AllowError:  true,
+		})
+
+		require.Error(t, err, "Expected fetching error")
+	})
+}
+
+func waitForPKGIReconciliationOrFail(t *testing.T, kubectl e2e.Kubectl, pkgiName string, initialStartFetch metav1.Time) {
+	waitForStatusReconciliationOrFail(t, func(t *testing.T) *v1alpha1.AppStatusFetch {
+		output := kubectl.Run([]string{"get", "app", pkgiName, "-oyaml"})
+		var appcr v1alpha1.App
+
+		require.NoError(t, yaml.Unmarshal([]byte(output), &appcr))
+		return appcr.Status.Fetch
+	}, initialStartFetch)
+}
+
+func waitForStatusReconciliationOrFail(t *testing.T, getStatus func(t *testing.T) *v1alpha1.AppStatusFetch, initialStartFetch metav1.Time) {
+	for i := 0; i < 90; i++ {
+		fetchStatus := getStatus(t)
+		if fetchStatus.UpdatedAt != initialStartFetch {
+			break
+		}
+		if i == 89 {
+			fmt.Printf("%+v\n", fetchStatus)
+		}
+		require.Less(t, i, 89, "waited too much")
+		time.Sleep(1 * time.Second)
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
In this PR `kapp-controller` will start to cache images and bundles. This feature will allow `kapp-controller` to reconcile pre-existing applications and package repositories even if the registry is no longer available.
This only happens when the images/bundles are referenced by SHA and in the case of bundles if all the images are colocated.

#### Which issue(s) this PR fixes:
Fixes #664
Fixes #688
Fixes #689

#### Does this PR introduce a user-facing change?
```release-note
Allow `kapp-controller` to keep working even if the image registry is no longer available. This change also lowers the number of requests that `kapp-controller` needs to do to the registry, decreasing the load in these registries. 
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [X] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [X] Code is at least as readable and maintainable as it was before this
  change

