### PR TITLE
Implement leader election using client-go tools

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -48,11 +48,6 @@ func runLeaderElection(lock *resourcelock.LeaseLock, ctx context.Context, id str
 		RetryPeriod:     2 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(c context.Context) {
-				log := zap.New(zap.UseDevMode(false)).WithName("kc")
-				logf.SetLogger(log)
-				klog.SetLogger(log)
-				mainLog := log.WithName("main")
-				mainLog.Info("kapp-controller", "version", Version)
 				err := Run(ctrlOpts, log.WithName("controller"))
 				if err != nil {
 					mainLog.Error(err, "Exited run with error")
@@ -93,7 +88,11 @@ func main() {
 		sidecarexecMain()
 		return
 	}
-
+	log := zap.New(zap.UseDevMode(false)).WithName("kc")
+	logf.SetLogger(log)
+	klog.SetLogger(log)
+	mainLog := log.WithName("main")
+	mainLog.Info("kapp-controller", "version", Version)
 	var (
 		leaseLockName      string
 		leaseLockNamespace string


### PR DESCRIPTION
Signed-off-by: Víctor Martínez Bevià <vicmarbev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Implements leader election to improve availability

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #838 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
kapp-controller is now able to run multiple replicas thanks to leader-election mechanism
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
