### PR TITLE
Refresh package install after pausing it during updation

### DIFF
--- a/cli/go.sum
+++ b/cli/go.sum
@@ -252,7 +252,6 @@ github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72/go.mod h1:2w+qxVu2KSGW78Ex/XaIqfh/OvBgjEsmN53S4T8vEyA=
 github.com/cppforlife/cobrautil v0.0.0-20220907150944-da5ee3a6ab1f h1:KkqeYFcNT2SHYUR5cGJ0YZoIZW12yFf36OBWFStufvk=
 github.com/cppforlife/cobrautil v0.0.0-20220907150944-da5ee3a6ab1f/go.mod h1:2w+qxVu2KSGW78Ex/XaIqfh/OvBgjEsmN53S4T8vEyA=
 github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835 h1:mYQweUIBD+TBRjIeQnJmXr0GSVMpI6O0takyb/aaOgo=

--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -62,6 +62,14 @@ spec:
       deploy:
       - kapp: {}`
 
+	valuesFile1 := `
+key1: value1
+`
+
+	valuesFile2 := `
+key2: value2
+`
+
 	packageCR1 := fmt.Sprintf(packageCR, packageName1, packageVersion1)
 
 	packageCR2 := fmt.Sprintf(packageCR, packageName2, packageVersion2)
@@ -95,7 +103,9 @@ spec:
 	})
 
 	logger.Section("Installing test package", func() {
-		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "create", "--package-install", pkgiName, "-p", packageMetadataName, "--version", packageVersion1}, RunOpts{})
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "create", "--package-install", pkgiName,
+			"-p", packageMetadataName, "--version", packageVersion1,
+			"--values-file", "-"}, RunOpts{StdinReader: strings.NewReader(valuesFile1)})
 		require.NoError(t, err)
 	})
 
@@ -156,13 +166,13 @@ spec:
 	})
 
 	logger.Section("package installed update", func() {
-
 		_, err := kappCtrl.RunWithOpts([]string{
 			"package", "installed", "update",
 			"--package-install", pkgiName,
 			"-p", packageMetadataName,
 			"--version", packageVersion2,
-		}, RunOpts{})
+			"--values-file", "-",
+		}, RunOpts{StdinReader: strings.NewReader(valuesFile2)})
 		require.NoError(t, err)
 
 		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "get", "--package-install", pkgiName, "--json"}, RunOpts{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Refresh package install after pausing it during updation. 
Pausing a package install causes a change in observedGeneration, due to this it needs to be refreshed to be able to update it later on.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #924

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
