### PR TITLE
Adding a tag flag to override default imgpkg bundle tag

### DIFF
--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -97,19 +97,16 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 
 	bundleURL := ""
 	useKbldImagesLock := false
-	var tag string
+	tag := fmt.Sprintf("build-%d", time.Now().Unix())
 	if b.opts.BundleTag != "" {
 		tag = b.opts.BundleTag
-	} else {
-		tag = fmt.Sprintf("build-%d", time.Now().Unix())
 	}
 	for _, exportStep := range b.opts.BuildExport {
 		switch {
 		case exportStep.ImgpkgBundle != nil:
 			useKbldImagesLock = exportStep.ImgpkgBundle.UseKbldImagesLock
-			bundlePath := fmt.Sprintf("%s:%s", exportStep.ImgpkgBundle.Image, tag)
 			imgpkgRunner := ImgpkgRunner{
-				BundlePath:        bundlePath,
+				BundlePath:        fmt.Sprintf("%s:%s", exportStep.ImgpkgBundle.Image, tag),
 				Paths:             exportStep.IncludePaths,
 				UseKbldImagesLock: exportStep.ImgpkgBundle.UseKbldImagesLock,
 				ImgLockFilepath:   tempImgpkgLockPath,

--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	regname "github.com/google/go-containerregistry/pkg/name"
 	appinit "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/app/init"
 	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
 	cmdlocal "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/local"
@@ -109,10 +108,6 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 		case exportStep.ImgpkgBundle != nil:
 			useKbldImagesLock = exportStep.ImgpkgBundle.UseKbldImagesLock
 			bundlePath := fmt.Sprintf("%s:%s", exportStep.ImgpkgBundle.Image, tag)
-			_, err := regname.NewTag(bundlePath, regname.WeakValidation)
-			if err != nil {
-				return kcv1alpha1.AppSpec{}, err
-			}
 			imgpkgRunner := ImgpkgRunner{
 				BundlePath:        bundlePath,
 				Paths:             exportStep.IncludePaths,

--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -33,7 +33,7 @@ type AppSpecBuilderOpts struct {
 	BuildExport   []appinit.Export
 	BundleImage   string
 	Debug         bool
-	Tag           string
+	BundleTag     string
 }
 
 func NewAppSpecBuilder(depsFactory cmdcore.DepsFactory, logger logger.Logger, ui cmdcore.AuthoringUI, opts AppSpecBuilderOpts) *AppSpecBuilder {
@@ -98,8 +98,8 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 	bundleURL := ""
 	useKbldImagesLock := false
 	var tag string
-	if b.opts.Tag != "" {
-		tag = b.opts.Tag
+	if b.opts.BundleTag != "" {
+		tag = b.opts.BundleTag
 	} else {
 		tag = fmt.Sprintf("build-%d", time.Now().Unix())
 	}

--- a/cli/pkg/kctrl/cmd/app/release/imgpkg_runner.go
+++ b/cli/pkg/kctrl/cmd/app/release/imgpkg_runner.go
@@ -21,6 +21,7 @@ type ImgpkgRunner struct {
 	UseKbldImagesLock bool
 	ImgLockFilepath   string
 	UI                cmdcore.AuthoringUI
+	Tag               string
 }
 
 func (r ImgpkgRunner) Run() (string, error) {

--- a/cli/pkg/kctrl/cmd/app/release/imgpkg_runner.go
+++ b/cli/pkg/kctrl/cmd/app/release/imgpkg_runner.go
@@ -21,7 +21,6 @@ type ImgpkgRunner struct {
 	UseKbldImagesLock bool
 	ImgLockFilepath   string
 	UI                cmdcore.AuthoringUI
-	Tag               string
 }
 
 func (r ImgpkgRunner) Run() (string, error) {

--- a/cli/pkg/kctrl/cmd/app/release/release.go
+++ b/cli/pkg/kctrl/cmd/app/release/release.go
@@ -22,7 +22,7 @@ type ReleaseOptions struct {
 	chdir          string
 	outputLocation string
 	debug          bool
-	tag            string
+	bundleTag      string
 }
 
 const (
@@ -44,7 +44,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.chdir, "chdir", "", "Working directory with package-build and other config")
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", defaultArtifactDir, "Output location for artifacts")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
-	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag of the image/bundle to be pushed")
+	cmd.Flags().StringVarP(&o.bundleTag, "tag", "t", "", "Tag pushed with imgpkg bundle (default bundle-<TIMESTAMP>)")
 
 	return cmd
 }
@@ -69,7 +69,7 @@ func (o *ReleaseOptions) Run() error {
 		BuildDeploy:   appBuild.GetAppSpec().Deploy,
 		BuildExport:   *appBuild.GetExport(),
 		Debug:         o.debug,
-		Tag:           o.tag,
+		BundleTag:     o.bundleTag,
 	}
 	_, err = NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/app/release/release.go
+++ b/cli/pkg/kctrl/cmd/app/release/release.go
@@ -22,11 +22,11 @@ type ReleaseOptions struct {
 	chdir          string
 	outputLocation string
 	debug          bool
+	tag            string
 }
 
 const (
 	defaultArtifactDir = "carvel-artifacts"
-	defaultVersion     = "0.0.0+build.%d"
 )
 
 func NewReleaseOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger) *ReleaseOptions {
@@ -44,6 +44,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.chdir, "chdir", "", "Working directory with package-build and other config")
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", defaultArtifactDir, "Output location for artifacts")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
+	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag of the image/bundle to be pushed")
 
 	return cmd
 }
@@ -68,6 +69,7 @@ func (o *ReleaseOptions) Run() error {
 		BuildDeploy:   appBuild.GetAppSpec().Deploy,
 		BuildExport:   *appBuild.GetExport(),
 		Debug:         o.debug,
+		Tag:           o.tag,
 	}
 	_, err = NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/app/release/release.go
+++ b/cli/pkg/kctrl/cmd/app/release/release.go
@@ -22,7 +22,7 @@ type ReleaseOptions struct {
 	chdir          string
 	outputLocation string
 	debug          bool
-	bundleTag      string
+	tag            string
 }
 
 const (
@@ -44,7 +44,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.chdir, "chdir", "", "Working directory with package-build and other config")
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", defaultArtifactDir, "Output location for artifacts")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
-	cmd.Flags().StringVarP(&o.bundleTag, "tag", "t", "", "Tag pushed with imgpkg bundle (default bundle-<TIMESTAMP>)")
+	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default build-<TIMESTAMP>)")
 
 	return cmd
 }
@@ -69,7 +69,7 @@ func (o *ReleaseOptions) Run() error {
 		BuildDeploy:   appBuild.GetAppSpec().Deploy,
 		BuildExport:   *appBuild.GetExport(),
 		Debug:         o.debug,
-		BundleTag:     o.bundleTag,
+		BundleTag:     o.tag,
 	}
 	_, err = NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -59,7 +59,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", defaultArtifactDir, "Output location for artifacts")
 	cmd.Flags().StringVar(&o.repoOutputLocation, "repo-output", "", "Output location for artifacts in repository bundle format")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
-	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default bundle-<TIMESTAMP>)")
+	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default build-<TIMESTAMP>)")
 	cmd.Flags().BoolVar(&o.generateOpenAPISchema, "openapi-schema", true, "Generates openapi schema for ytt and helm templated files and adds it to generated package")
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -31,6 +31,7 @@ type ReleaseOptions struct {
 	outputLocation     string
 	repoOutputLocation string
 	debug              bool
+	tag                string
 }
 
 const (
@@ -57,6 +58,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", defaultArtifactDir, "Output location for artifacts")
 	cmd.Flags().StringVar(&o.repoOutputLocation, "repo-output", "", "Output location for artifacts in repository bundle format")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
+	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag of the image/bundle to be pushed")
 
 	return cmd
 }
@@ -111,6 +113,7 @@ func (o *ReleaseOptions) Run() error {
 		BuildDeploy:   buildAppSpec.Deploy,
 		BuildExport:   *pkgBuild.GetExport(),
 		Debug:         o.debug,
+		Tag:           o.tag,
 	}
 	appSpec, err := cmdapprelease.NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -59,7 +59,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", defaultArtifactDir, "Output location for artifacts")
 	cmd.Flags().StringVar(&o.repoOutputLocation, "repo-output", "", "Output location for artifacts in repository bundle format")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
-	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag of the image/bundle to be pushed")
+	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default bundle-<TIMESTAMP>)")
 	cmd.Flags().BoolVar(&o.generateOpenAPISchema, "openapi-schema", true, "Generates openapi schema for ytt and helm templated files and adds it to generated package")
 
 	return cmd
@@ -115,7 +115,7 @@ func (o *ReleaseOptions) Run() error {
 		BuildDeploy:   buildAppSpec.Deploy,
 		BuildExport:   *pkgBuild.GetExport(),
 		Debug:         o.debug,
-		Tag:           o.tag,
+		BundleTag:     o.tag,
 	}
 	appSpec, err := cmdapprelease.NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -183,12 +183,188 @@ spec:
       - kbld:
           paths:
           - '-'
-          - .imgpkg/
+          - .imgpkg/images.yml
   valuesSchema:
     openAPIv3:
-      default: null
-      nullable: true
+      properties:
+        agent:
+          properties:
+            name:
+              default: mongodb-agent
+              type: string
+            version:
+              default: 11.12.0.7388-1
+              type: string
+          type: object
+        database:
+          description: Database
+          properties:
+            name:
+              default: mongodb-enterprise-database
+              type: string
+            version:
+              default: 2.0.2
+              type: string
+          type: object
+        initAppDb:
+          description: Application Database
+          properties:
+            name:
+              default: mongodb-enterprise-init-appdb
+              type: string
+            version:
+              default: 1.0.9
+              type: string
+          type: object
+        initDatabase:
+          properties:
+            name:
+              default: mongodb-enterprise-init-database
+              type: string
+            version:
+              default: 1.0.9
+              type: string
+          type: object
+        initOpsManager:
+          properties:
+            name:
+              default: mongodb-enterprise-init-ops-manager
+              type: string
+            version:
+              default: 1.0.7
+              type: string
+          type: object
+        managedSecurityContext:
+          default: false
+          description: Set this to true if your cluster is managing SecurityContext
+            for you. If running OpenShift (Cloud, Minishift, etc.), set this to true.
+          type: boolean
+        mongodb:
+          properties:
+            name:
+              default: mongodb-enterprise-appdb-database
+              type: string
+            repo:
+              default: quay.io/mongodb
+              type: string
+          type: object
+        multiCluster:
+          properties:
+            clusters:
+              default: []
+              type: array
+            kubeConfigSecretName:
+              default: mongodb-enterprise-operator-multi-cluster-kubeconfig
+              type: string
+          type: object
+        operator:
+          properties:
+            affinity:
+              default: '{}'
+              type: object
+            createOperatorServiceAccount:
+              default: true
+              description: Create operator-service account
+              type: boolean
+            deployment_name:
+              default: mongodb-enterprise-operator
+              description: Name of the deployment of the operator pod
+              type: string
+            env:
+              default: prod
+              description: Execution environment for the operator, dev or prod. Use
+                dev for more verbose logging
+              type: string
+            name:
+              default: mongodb-enterprise-operator
+              description: Name that will be assigned to most of internal Kubernetes
+                objects like Deployment, ServiceAccount, Role etc.
+              type: string
+            nodeSelector:
+              default: '{}'
+              type: object
+            operator_image_name:
+              default: mongodb-enterprise-operator
+              description: Name of the operator image
+              type: string
+            tolerations:
+              default: []
+              type: array
+            vaultSecretBackend:
+              properties:
+                enabled:
+                  default: false
+                  description: set to true if you want the operator to store secrets
+                    in Vault
+                  type: boolean
+                tlsSecretRef:
+                  default: ""
+                  type: string
+              type: object
+            version:
+              default: 1.16.0
+              description: Version of mongodb-enterprise-operator
+              type: string
+            watchedResources:
+              default: []
+              description: The Custom Resources that will be watched by the Operator.
+                Needs to be changed if only some of the CRDs are installed
+              items:
+                default: mongodb
+                type: string
+              type: array
+          type: object
+        opsManager:
+          description: Ops Manager
+          properties:
+            name:
+              default: mongodb-enterprise-ops-manager
+              type: string
+          type: object
+        registry:
+          description: Registry
+          properties:
+            agent:
+              default: quay.io/mongodb
+              type: string
+            appDb:
+              default: quay.io/mongodb
+              type: string
+            database:
+              default: quay.io/mongodb
+              type: string
+            imagePullSecrets:
+              default: ""
+              type: string
+            initAppDb:
+              default: quay.io/mongodb
+              type: string
+            initDatabase:
+              default: quay.io/mongodb
+              type: string
+            initOpsManager:
+              default: quay.io/mongodb
+              type: string
+            operator:
+              default: quay.io/mongodb
+              description: Specify if images are pulled from private registry
+              type: string
+            opsManager:
+              default: quay.io/mongodb
+              type: string
+            pullPolicy:
+              default: Always
+              description: 'TODO: specify for each image and move there?'
+              type: string
+          type: object
+        subresourceEnabled:
+          default: true
+          description: Set this to false to disable subresource utilization It might
+            be required on some versions of Openshift
+          type: boolean
+      type: object
   version: 1.0.0
+
 `,
 		},
 		{
@@ -323,7 +499,7 @@ spec:
       - kbld:
           paths:
           - '-'
-          - .imgpkg/
+          - .imgpkg/images.yml
   valuesSchema:
     openAPIv3:
       default: null
@@ -462,7 +638,7 @@ spec:
       - kbld:
           paths:
           - '-'
-          - .imgpkg/
+          - .imgpkg/images.yml
   valuesSchema:
     openAPIv3:
       default: null
@@ -607,11 +783,71 @@ spec:
       - kbld:
           paths:
           - '-'
-          - .imgpkg/
+          - .imgpkg/images.yml
   valuesSchema:
     openAPIv3:
-      default: null
-      nullable: true
+      properties:
+        env:
+          properties:
+            hello_msg:
+              default: hello
+              description: response provided by the server
+              type: string
+          type: object
+        fullnameOverride:
+          default: ""
+          type: string
+        imageProp:
+          properties:
+            pullPolicy:
+              default: IfNotPresent
+              type: string
+            repository:
+              default: docker.io/dkalinin/k8s-simple-app
+              type: string
+            tag:
+              default: latest
+              description: Overrides the image tag whose default is the chart appVersion.
+              type: string
+          type: object
+        imagePullSecrets:
+          default: []
+          type: array
+        nameOverride:
+          default: ""
+          type: string
+        podAnnotations:
+          default: '{}'
+          type: object
+        replicaCount:
+          default: 1
+          type: integer
+        service:
+          properties:
+            port:
+              default: 80
+              type: integer
+            type:
+              default: ClusterIP
+              type: string
+          type: object
+        serviceAccount:
+          properties:
+            annotations:
+              default: '{}'
+              description: Annotations to add to the service account
+              type: object
+            create:
+              default: true
+              description: Specifies whether a service account should be created
+              type: boolean
+            name:
+              default: ""
+              description: The name of the service account to use. If not set and
+                create is true, a name is generated using the fullname template
+              type: string
+          type: object
+      type: object
   version: 1.0.0
 `,
 		},
@@ -688,7 +924,7 @@ spec:
 					StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
 
 			// Below key's values will be changed during every run, hence adding these keys to be ignored
-			keysToBeIgnored := []string{"creationTimestamp:", "releasedAt:", "image"}
+			keysToBeIgnored := []string{"creationTimestamp:", "releasedAt:", "image:"}
 
 			// Verify PackageMetadata artifact
 			out, err := readFile(pkgDir + "metadata.yml")
@@ -747,7 +983,6 @@ func replaceSpaces(result string) string {
 	return result
 }
 
-// TODO: Make regex more strict. Removes 'images.yaml' from '.imgpkg/images.yml' right now
 func clearKeys(keys []string, out string) string {
 	for _, key := range keys {
 		r := regexp.MustCompile(key + ".*")
@@ -809,6 +1044,251 @@ func (p promptOutput) WaitFor(text string) {
 		fmt.Printf("Timed out waiting for text '%s'", text)
 		p.t.Fail()
 	}
+}
+
+func TestE2EInitAndReleaseCaseDisableOpenAPISchemaGeneration(t *testing.T) {
+	input := E2EAuthoringTestCase{
+		Name: "Disable OpenAPI Schema generation while releasing the package",
+		InitInteraction: Interaction{
+			Prompts: []string{
+				"Enter the package reference name",
+				"Enter source",
+				"Enter helm chart repository URL",
+				"Enter helm chart name",
+				"Enter helm chart version",
+			},
+			Inputs: []string{
+				"testpackage.corp.dev",
+				"3",
+				"https://mongodb.github.io/helm-charts",
+				"enterprise-operator",
+				"1.16.0",
+			},
+		},
+		ExpectedPkgBuild: `
+apiVersion: kctrl.carvel.dev/v1alpha1
+kind: PackageBuild
+metadata:
+  name: testpackage.corp.dev
+spec:
+  template:
+    spec:
+      app:
+        spec:
+          deploy:
+          - kapp: {}
+          template:
+          - helmTemplate:
+              path: upstream
+          - ytt:
+              paths:
+              - '-'
+          - kbld: {}
+      export:
+      - includePaths:
+        - upstream
+`,
+		ExpectedPkgResource: `
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: testpackage.corp.dev.0.0.0
+spec:
+  refName: testpackage.corp.dev
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - git: {}
+      template:
+      - helmTemplate:
+          path: upstream
+      - ytt:
+          paths:
+          - '-'
+      - kbld: {}
+  valuesSchema:
+    openAPIv3: null
+  version: 0.0.0
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: testpackage.corp.dev
+spec:
+  displayName: testpackage
+  longDescription: testpackage.corp.dev
+  shortDescription: testpackage.corp.dev
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    kctrl.carvel.dev/local-fetch-0: .
+  name: testpackage
+spec:
+  packageRef:
+    refName: testpackage.corp.dev
+    versionSelection:
+      constraints: 0.0.0
+  serviceAccountName: testpackage-sa
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0
+`,
+		ExpectedVendir: `
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - helmChart:
+      name: enterprise-operator
+      repository:
+        url: https://mongodb.github.io/helm-charts
+      version: 1.16.0
+    path: .
+  path: upstream
+kind: Config
+minimumRequiredVersion: ""
+`,
+		ExpectedPackageMetadata: `
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: testpackage.corp.dev
+spec:
+  displayName: testpackage
+  longDescription: testpackage.corp.dev
+  shortDescription: testpackage.corp.dev
+`,
+		ExpectedPackage: `
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: testpackage.corp.dev.1.0.0
+spec:
+  refName: testpackage.corp.dev
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - imgpkgBundle:
+      template:
+      - helmTemplate:
+          path: upstream
+      - ytt:
+          paths:
+          - '-'
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+  valuesSchema:
+    openAPIv3: null
+  version: 1.0.0
+`,
+	}
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+	kappCli := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
+
+	cleanUp := func() {
+		os.RemoveAll(workingDir)
+	}
+	cleanUp()
+	defer cleanUp()
+
+	err := os.Mkdir(workingDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const pkgDir = "./carvel-artifacts/packages/testpackage.corp.dev/"
+	promptOutput := newPromptOutput(t)
+	go input.InitInteraction.Run(promptOutput)
+
+	logger.Section(fmt.Sprintf("%s: Package init", input.Name), func() {
+		kappCtrl.RunWithOpts([]string{"pkg", "init", "--tty=true", "--chdir", workingDir},
+			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
+				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
+
+		// Below key's values will be changed during every run, hence adding these keys to be ignored
+		keysToBeIgnored := []string{"creationTimestamp:", "releasedAt:"}
+
+		// Error if upstream folder doesn't exist
+		_, err = os.Stat(filepath.Join(workingDir, "upstream"))
+		require.NoError(t, err)
+
+		// Verify PackageBuild
+		out, err := readFile("package-build.yml")
+		require.NoErrorf(t, err, "Expected to read package-build.yml")
+		expectedPackageBuild := strings.TrimSpace(replaceSpaces(input.ExpectedPkgBuild))
+		out = clearKeys(keysToBeIgnored, strings.TrimSpace(replaceSpaces(out)))
+		require.Equal(t, expectedPackageBuild, out, "Expected PackageBuild output to match")
+
+		// Verify package resources
+		out, err = readFile("package-resources.yml")
+		require.NoErrorf(t, err, "Expected to read package-resources.yml")
+		expectedPackageResources := strings.TrimSpace(replaceSpaces(input.ExpectedPkgResource))
+		out = clearKeys(keysToBeIgnored, strings.TrimSpace(replaceSpaces(out)))
+		require.Equal(t, expectedPackageResources, out, "Expected package resources output to match")
+
+		// Verify vendir
+		out, err = readFile("vendir.yml")
+		require.NoErrorf(t, err, "Expected to read vendir.yml")
+		expectedVendirOutput := strings.TrimSpace(replaceSpaces(input.ExpectedVendir))
+		out = clearKeys(keysToBeIgnored, strings.TrimSpace(replaceSpaces(out)))
+		require.Equal(t, expectedVendirOutput, out, "Expected vendir output to match")
+	})
+
+	logger.Section(fmt.Sprintf("%s: Package release", input.Name), func() {
+		releaseInteraction := Interaction{
+			Prompts: []string{"Enter the registry URL"},
+			Inputs:  []string{env.Image},
+		}
+
+		go releaseInteraction.Run(promptOutput)
+
+		kappCtrl.RunWithOpts([]string{"pkg", "release", "--version", "1.0.0", "--tty=true", "--chdir", workingDir, "--openapi-schema=false"},
+			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
+				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
+
+		// Below key's values will be changed during every run, hence adding these keys to be ignored
+		keysToBeIgnored := []string{"creationTimestamp:", "releasedAt:", "image:"}
+
+		// Verify PackageMetadata artifact
+		out, err := readFile(pkgDir + "metadata.yml")
+		require.NoErrorf(t, err, "Expected to read metadata.yml")
+		expectedPackageMetadata := strings.TrimSpace(replaceSpaces(input.ExpectedPackageMetadata))
+		out = clearKeys(keysToBeIgnored, strings.TrimSpace(replaceSpaces(out)))
+		require.Equal(t, expectedPackageMetadata, out, "Expected PackageMetadata to match")
+
+		// Verify Package artifact
+		out, err = readFile(pkgDir + "package.yml")
+		require.NoErrorf(t, err, "Expected to read package.yml")
+		expectedPackage := strings.TrimSpace(replaceSpaces(input.ExpectedPackage))
+		out = clearKeys(keysToBeIgnored, strings.TrimSpace(replaceSpaces(out)))
+		require.Equal(t, expectedPackage, out, "Expected Package to match")
+	})
+
+	logger.Section(fmt.Sprintf("%s: Testing and installing created Package", input.Name), func() {
+		cleanUpInstalledPkg := func() {
+			kappCli.RunWithOpts([]string{"delete", "-a", "test-package"},
+				RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
+			kappCtrl.RunWithOpts([]string{"pkg", "installed", "delete", "-i", "test"},
+				RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
+		}
+		defer cleanUpInstalledPkg()
+
+		kappCli.RunWithOpts([]string{"deploy", "-a", "test-package", "-f", filepath.Join(workingDir, pkgDir), "-c"},
+			RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
+		kappCtrl.RunWithOpts([]string{"pkg", "available", "list"},
+			RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
+		kappCtrl.RunWithOpts([]string{"pkg", "install", "-p", "testpackage.corp.dev", "-i", "test", "--version", "1.0.0"},
+			RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
+	})
 }
 
 func TestE2EInitAndReleaseByAddingTag(t *testing.T) {
@@ -930,5 +1410,68 @@ spec:
 			RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
 		kappCtrl.RunWithOpts([]string{"pkg", "install", "-p", "testpackage.corp.dev", "-i", "test", "--version", "1.0.0"},
 			RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})
+	})
+}
+
+func TestE2EInitAndReleaseByAddingInvalidTag(t *testing.T) {
+	input := E2EAuthoringTestCase{
+		Name: "Add tag for imgpkg bundle while releasing the package",
+		InitInteraction: Interaction{
+			Prompts: []string{
+				"Enter the package reference name",
+				"Enter source",
+				"Enter Git URL",
+				"Enter Git Reference",
+				"Enter the paths which contain Kubernetes manifests",
+			},
+			Inputs: []string{
+				"testpackage.corp.dev",
+				"4",
+				"https://github.com/vmware-tanzu/carvel-kapp",
+				"origin/develop",
+				"examples/simple-app-example/config-1.yml",
+			},
+		},
+	}
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	cleanUp := func() {
+		os.RemoveAll(workingDir)
+	}
+	cleanUp()
+	defer cleanUp()
+
+	err := os.Mkdir(workingDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const pkgDir = "./carvel-artifacts/packages/testpackage.corp.dev/"
+	promptOutput := newPromptOutput(t)
+	go input.InitInteraction.Run(promptOutput)
+
+	logger.Section(fmt.Sprintf("%s: Package init", input.Name), func() {
+		kappCtrl.RunWithOpts([]string{"pkg", "init", "--tty=true", "--chdir", workingDir},
+			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
+				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
+
+		// Error if upstream folder doesn't exist
+		_, err = os.Stat(filepath.Join(workingDir, "upstream"))
+		require.NoError(t, err)
+	})
+
+	logger.Section(fmt.Sprintf("%s: Package release", input.Name), func() {
+		releaseInteraction := Interaction{
+			Prompts: []string{"Enter the registry URL"},
+			Inputs:  []string{env.Image},
+		}
+
+		go releaseInteraction.Run(promptOutput)
+		tag := "1.0.0+"
+		_, err := kappCtrl.RunWithOpts([]string{"pkg", "release", "--version", "1.0.0", "--tty=true", "--chdir", workingDir, "--tag", tag},
+			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
+				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true, AllowError: true})
+		require.Error(t, err)
 	})
 }

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -1291,7 +1291,7 @@ spec:
 	})
 }
 
-func TestE2EInitAndReleaseByAddingTag(t *testing.T) {
+func TestPackageInitAndReleaseWithTagOption(t *testing.T) {
 	input := E2EAuthoringTestCase{
 		Name: "Add tag for imgpkg bundle while releasing the package",
 		InitInteraction: Interaction{
@@ -1413,7 +1413,7 @@ spec:
 	})
 }
 
-func TestE2EInitAndReleaseByAddingInvalidTag(t *testing.T) {
+func TestPackageInitAndReleaseWithInvalidTag(t *testing.T) {
 	input := E2EAuthoringTestCase{
 		Name: "Add tag for imgpkg bundle while releasing the package",
 		InitInteraction: Interaction{


### PR DESCRIPTION
Adding a tag flag to override default imgpkg bundle tag

#### What this PR does / why we need it:
Today, by default, `pkg release` while generating imgpkg bundle add `bundle-<TIMESTAMP>` as tag. This PR adds a flag to `pkg release` which will override that tag with the flag value. 

#### Which issue(s) this PR fixes:
<!--
# 
-->
Fixes #873

#### Does this PR introduce a user-facing change?
Yes


#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR vmware-tanzu/carvel#568
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
