### PR TITLE
Bump dependencies

### DIFF
--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -69,6 +69,8 @@ spec:
         env:
         - name: KAPPCTRL_SIDECAREXEC_SOCK
           value: /etc/kappctrl-mem-tmp/sidecarexec.sock
+        - name: IMGPKG_ACTIVE_KEYCHAINS
+          value: gke,aks,ecr
         volumeMounts:
         - name: template-fs
           mountPath: /etc/kappctrl-mem-tmp

--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -33,36 +33,25 @@
   version: v0.53.0
 - checksums:
     darwin:
-      amd64: bf839a539c90a22287904e2a83c4322bf00da3150d8d47cb9fb5eb59dfe41111
+      amd64: 5964af6123563b63cad7b9b5525d49814f8f2048a75bb811888d87618a358c30
     linux:
-      amd64: e8a9a3d37a125eca49b8c074ee2f5c84616e765f20ee6c6d60f79dae8f19af10
-      arm64: c5d7b4a39250778f1dd5f9763d3854003c44bb9622d3ac72f58b41aa92d55f7a
-  dev: true
-  name: imgpkg
-  repo: vmware-tanzu/carvel-imgpkg
-  urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.31.0
-- checksums:
-    darwin:
-      amd64: 5ee954207d6324f336341b2a81c0cb6147f08e7f892fbc52c28effc81bc2302f
-    linux:
-      amd64: eb66c8fd398925e2a2e68a2f65de3ca06207addd86cf207c07f7ad566dbe7b25
-      arm64: bbe6747135e0e4995a2378f1d556c0e0a20383391cf80dd4421748b028d3eb1c
+      amd64: 0b52c170f4a30c2b6213ff0048ecc89c9c25c3e4da56eb1e095fcdb335bd82ed
+      arm64: e66c0c6c8e3e89a49b7e6a8ad216d8f2b44e9b8d35345bfd85c354eea4f4177a
   dev: true
   name: vendir
   repo: vmware-tanzu/carvel-vendir
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.30.0
+  version: v0.32.0
 - checksums:
     linux:
-      amd64: 31960ff2f76a7379d9bac526ddf889fb79241191f1dbe2a24f7864ddcb3f6560
-      arm64: d24163e466f7884c55079d1050968e80a05b633830047116cdfd8ae28d35b0c0
+      amd64: c12d2cd638f2d066fec123d0bd7f010f32c643afdf288d39a4610b1f9cb32af3
+      arm64: d04b38d439ab8655abb4cb9ccc1efa8a3fe95f3f68af46d9137c6b7985491833
   dev: false
   name: helm
   repo: helm/helm
   tarballSubpath: '{{.OS}}-{{.Arch}}/helm'
   urlTemplate: https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-  version: v3.9.4
+  version: v3.10.1
 - checksums:
     linux:
       amd64: 53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb

--- a/test/e2e/kappcontroller/fetch_test.go
+++ b/test/e2e/kappcontroller/fetch_test.go
@@ -194,7 +194,7 @@ spec:
 			logger.Section("deploy", func() {
 				// if template stage succeeds, assume test pass
 				kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", tc.name},
-					e2e.RunOpts{StdinReader: strings.NewReader(tc.deploymentYAML)})
+					e2e.RunOpts{StdinReader: strings.NewReader(tc.deploymentYAML), OnErrKubectl: []string{"get", "app", "-oyaml"}})
 			})
 		})
 	}

--- a/test/e2e/kappcontroller/imgpkg_bundle_test.go
+++ b/test/e2e/kappcontroller/imgpkg_bundle_test.go
@@ -5,10 +5,10 @@ package kappcontroller
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 	corev1 "k8s.io/api/core/v1"
@@ -64,9 +64,7 @@ spec:
 
 		var cr v1alpha1.App
 		err := yaml.Unmarshal([]byte(out), &cr)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal: %s", err)
-		}
+		require.NoError(t, err)
 
 		expectedStatus := v1alpha1.AppStatus{
 			GenericStatus: v1alpha1.GenericStatus{
@@ -101,20 +99,15 @@ spec:
 			cr.Status.Deploy.KappDeployStatus = nil
 
 			// fetch
-			if !strings.Contains(cr.Status.Fetch.Stdout, "- imgpkgBundle") {
-				t.Fatalf("Expected to find imgpkgBundle contents in fetch stdout but got:\n%s", cr.Status.Fetch.Stdout)
-			}
-			if !strings.Contains(cr.Status.Fetch.Stdout, "image: index.docker.io/k8slt/kappctrl-e2e-bundle@sha256:83f86234f68a980490ec66f2d347ad4c8148713073c0993760b8eaaef3eb48d7") {
-				t.Fatalf("Expected to find imgpkgBundle contents in fetch stdout but got:\n%s", cr.Status.Fetch.Stdout)
-			}
+			require.Contains(t, cr.Status.Fetch.Stdout, "- imgpkgBundle")
+			require.Contains(t, cr.Status.Fetch.Stdout, "image: index.docker.io/k8slt/kappctrl-e2e-bundle@sha256:83f86234f68a980490ec66f2d347ad4c8148713073c0993760b8eaaef3eb48d7")
 			cr.Status.Fetch.StartedAt = metav1.Time{}
 			cr.Status.Fetch.UpdatedAt = metav1.Time{}
 			cr.Status.Fetch.Stdout = ""
 
 			// inspect
-			if !strings.Contains(cr.Status.Inspect.Stdout, "simple-app") && !strings.Contains(cr.Status.Inspect.Stdout, "Succeeded") {
-				t.Fatalf("Expected to find simple-app resources created but got:\n%s", cr.Status.Inspect.Stdout)
-			}
+			require.Contains(t, cr.Status.Inspect.Stdout, "simple-app")
+			require.Contains(t, cr.Status.Inspect.Stdout, "Succeeded")
 			cr.Status.Inspect.UpdatedAt = metav1.Time{}
 			cr.Status.Inspect.Stdout = ""
 
@@ -123,8 +116,6 @@ spec:
 			cr.Status.Template.Stderr = ""
 		}
 
-		if !reflect.DeepEqual(expectedStatus, cr.Status) {
-			t.Fatalf("\nStatus is not same:\nExpected:\n%#v\nGot:\n%#v\n", expectedStatus, cr.Status)
-		}
+		require.Equal(t, expectedStatus, cr.Status)
 	})
 }

--- a/test/e2e/kappcontroller/package_repo_test.go
+++ b/test/e2e/kappcontroller/package_repo_test.go
@@ -66,7 +66,7 @@ spec:
 				}},
 				ObservedGeneration:  1,
 				FriendlyDescription: "Reconcile failed: Fetching resources: Error (see .status.usefulErrorMessage for details)",
-				UsefulErrorMessage:  "vendir: Error: Syncing directory '0':\n  Syncing directory '.' with imgpkgBundle contents:\n    Imgpkg: exit status 1 (stderr: imgpkg: Error: Fetching image:\n  GET https://index.docker.io/v2/k8slt/i-dont-exist/manifests/latest:\n    UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:k8slt/i-dont-exist Type:repository]]\n)\n",
+				UsefulErrorMessage:  "vendir: Error: Syncing directory '0':\n  Syncing directory '.' with imgpkgBundle contents:\n    Fetching image:\n      GET https://index.docker.io/v2/k8slt/i-dont-exist/manifests/latest:\n        UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:k8slt/i-dont-exist Type:repository]]\n",
 			},
 			ConsecutiveReconcileFailures: 1,
 		}
@@ -177,16 +177,15 @@ spec:
 
 	verifyPkg := func(resourceName, imgRef string) {
 		out := kubectl.Run([]string{"get", resourceName, "-o", "yaml"})
-		assert.Contains(t, out, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
-		assert.Contains(t, out, "image: "+imgRef+"\n")
+		require.Contains(t, out, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
+		require.Contains(t, out, "image: "+imgRef+"\n")
 	}
 
 	logger.Section("deploy pkg repository", func() {
 		kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(yamlRepo)})
 
 		out := kubectl.Run([]string{"get", "pkgm/pkg.test.carvel.dev", "-o", "yaml"})
-		assert.Contains(t, out, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
-
+		require.Contains(t, out, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
 		verifyPkg("pkg/pkg.test.carvel.dev.1.0.0", "index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75")
 		verifyPkg("pkg/pkg.test.carvel.dev.2.0.0", "index.docker.io/k8slt/kctrl-example-pkg@sha256:73713d922b5f561c0db2a7ea5f4f6384f7d2d6289886f8400a8aaf5e8fdf134a")
 	})
@@ -207,7 +206,7 @@ spec:
 		kapp.RunWithOpts([]string{"deploy", "-a", name, "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(updatedRepo)})
 
 		out := kubectl.Run([]string{"get", "pkgm/pkg.test.carvel.dev", "-o", "yaml"})
-		assert.Contains(t, out, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
+		require.Contains(t, out, "packaging.carvel.dev/package-repository-ref: kappctrl-test/basic.test.carvel.dev")
 
 		// Note that location of Packages has also changed to k8slt/kc-e2e-test-repo-copied
 		// since kbld is being applied with imgpkg's images.yml relocation data


### PR DESCRIPTION


#### What this PR does / why we need it:

Bumps dependencies
- helm to version 3.10.1
- vendir to version 0.32.0

Removed no longer needed imgpkg dependency

Updated the deployment to ensure kapp-controller enables by default all the IAAS keychains when talking to the OCI Registries

#### Additional Notes for your reviewer:
There will be a PR to update the [documentation of OpenShift in step 3](https://carvel.dev/kapp-controller/docs/v0.41.0/install/#openshift) to reflect the changes made with keychains in `imgpkg`

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
