### PR TITLE
Add check on pkgi conditions while waiting for app pause

### DIFF
--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -255,4 +255,17 @@ key2: value2
 		})
 		require.Contains(t, err.Error(), "not found")
 	})
+
+	logger.Section("package installed update with missing old version", func() {
+		kappCtrl.RunWithOpts([]string{"package", "installed", "create", "--package-install", pkgiName,
+			"-p", packageMetadataName, "--version", packageVersion1,
+			"--values-file", "-"}, RunOpts{StdinReader: strings.NewReader(valuesFile1)})
+
+		kapp.RunWithOpts([]string{"deploy", "-a", appName, "-f", "-"}, RunOpts{
+			StdinReader: strings.NewReader(packageMetadata + "\n" + packageCR2)})
+
+		kappCtrl.RunWithOpts([]string{"package", "installed", "update", "--package-install", pkgiName,
+			"-p", packageMetadataName, "--version", packageVersion2,
+			"--values-file", "-"}, RunOpts{StdinReader: strings.NewReader(valuesFile2)})
+	})
 }


### PR DESCRIPTION
When a package install for which the installed package version is now removed from the cluster, the app cr is never paused and so we need to check for the failing condition in package install

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
