### PR TITLE
`kctrl`: Garbage collect .imgpkg directory only if we create it

### DIFF
--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -71,15 +71,14 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 	}
 
 	// Make lock output directory if it does not exist
-	tmpImgpkgFolder := LockOutputFolder
-	_, err := os.Stat(tmpImgpkgFolder)
+	_, err := os.Stat(LockOutputFolder)
 	if err != nil && os.IsNotExist(err) {
-		err := os.Mkdir(tmpImgpkgFolder, os.ModePerm)
+		err := os.Mkdir(LockOutputFolder, os.ModePerm)
 		if err != nil {
 			return kcv1alpha1.AppSpec{}, err
 		}
+		defer os.RemoveAll(LockOutputFolder)
 	}
-	defer os.RemoveAll(LockOutputFolder)
 
 	// Build images and resolve references using reconciler
 	tempImgpkgLockPath := filepath.Join(LockOutputFolder, LockOutputFile)

--- a/cli/pkg/kctrl/cmd/package/repository/release/artifact_writer.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/artifact_writer.go
@@ -3,7 +3,6 @@ package release
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"time"
 
 	v1alpha12 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
@@ -15,15 +14,14 @@ import (
 
 type ArtifactWriter struct {
 	PackageRepoName string
-	TargetDir       string
 }
 
 const (
 	RepoVersionAnnKey = "kctrl.carvel.dev/repository-version"
 )
 
-func NewArtifactWriter(pkgRepoName string, directory string) *ArtifactWriter {
-	return &ArtifactWriter{PackageRepoName: pkgRepoName, TargetDir: directory}
+func NewArtifactWriter(pkgRepoName string) *ArtifactWriter {
+	return &ArtifactWriter{PackageRepoName: pkgRepoName}
 }
 
 func (w *ArtifactWriter) WritePackageRepositoryFile(imgpkgBundleLocation, version string) error {
@@ -52,9 +50,8 @@ func (w *ArtifactWriter) WritePackageRepositoryFile(imgpkgBundleLocation, versio
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(w.TargetDir, PkgRepositoryFileName)
 
-	return w.createOrOverwriteFile(path, packageRepoBytes)
+	return w.createOrOverwriteFile(PkgRepositoryFileName, packageRepoBytes)
 }
 
 func (w *ArtifactWriter) createOrOverwriteFile(path string, data []byte) error {

--- a/cli/pkg/kctrl/cmd/package/repository/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/release.go
@@ -118,30 +118,23 @@ func (o *ReleaseOptions) Run() error {
 		return err
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	o.ui.PrintInformationalText("kbld ensures that all image references are resolved to an immutable reference.")
 	o.ui.PrintActionableText("Lock image references using kbld")
 
-	packagesFolderPath := filepath.Join(wd, PackagesDirectory)
-	_, err = os.Stat(packagesFolderPath)
+	_, err = os.Stat(PackagesDirectory)
 	if err != nil && os.IsNotExist(err) {
 		return fmt.Errorf("Expected to find `packages` directory in the root")
 	}
 
 	// Make lock output directory if it does not exist
-	tmpImgpkgFolder := filepath.Join(wd, LockOutputFolder)
-	_, err = os.Stat(tmpImgpkgFolder)
+	_, err = os.Stat(LockOutputFolder)
 	if err != nil && os.IsNotExist(err) {
-		err := os.Mkdir(tmpImgpkgFolder, os.ModePerm)
+		err := os.Mkdir(LockOutputFolder, os.ModePerm)
 		if err != nil {
 			return err
 		}
+		defer os.RemoveAll(LockOutputFolder)
 	}
-	defer os.RemoveAll(filepath.Join(wd, LockOutputFolder))
 
 	tempImgpkgLockPath := filepath.Join(LockOutputFolder, LockOutputFile)
 
@@ -171,7 +164,7 @@ func (o *ReleaseOptions) Run() error {
 		}
 	}
 
-	artifactWriter := NewArtifactWriter(pkgRepoName, wd)
+	artifactWriter := NewArtifactWriter(pkgRepoName)
 	err = artifactWriter.WritePackageRepositoryFile(bundleURL, o.pkgRepoVersion)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
We do not want to delete user supplied `.imgpkg` folders.


##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
