### PR TITLE
Skip waiting for resources in package repository apps

### DIFF
--- a/pkg/pkgrepository/package_repo_app.go
+++ b/pkg/pkgrepository/package_repo_app.go
@@ -31,6 +31,8 @@ func NewPackageRepoApp(pkgRepository *pkgingv1alpha1.PackageRepository) (*kcv1al
 		// but does not allow listing of most resources in such namespaces --
 		// instead of spinning wheels trying to list, scope to "current" namespace
 		"--dangerous-scope-to-fallback-allowed-namespaces=true",
+		// Skip waiting since there are no wait rules defined for Packages
+		"--wait=false",
 	}
 
 	if kappDebug {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Skip waiting for resources in package repository apps
There are no wait rules defined for packages, so there's nothing to wait for.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
