### PR TITLE
Set wait-check-interval to 1s for benchmark tests

### DIFF
--- a/test/bench/pkgr_test.go
+++ b/test/bench/pkgr_test.go
@@ -57,12 +57,12 @@ func appName(fileName string) string {
 
 func deployAndDeletePkgr(b *testing.B, pkgrFileName string, totalPackages int) {
 	t1 := time.Now()
-	cmd := exec.Command("kapp", "deploy", "-f", pkgrFileName, "-a", appName(pkgrFileName), "-y")
+	cmd := exec.Command("kapp", "deploy", "-f", pkgrFileName, "-a", appName(pkgrFileName), "-y", "--wait-check-interval=1s")
 	output, err := cmd.Output()
 	require.NoError(b, err, string(output))
 	t2 := time.Now()
 
-	cmd = exec.Command("kapp", "delete", "-a", appName(pkgrFileName), "-y")
+	cmd = exec.Command("kapp", "delete", "-a", appName(pkgrFileName), "-y", "--wait-check-interval=1s")
 	output, err = cmd.Output()
 	require.NoError(b, err, string(output))
 	t3 := time.Now()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Set wait-check-interval to 1s for benchmark tests
With kapp v0.54.0 wait-check-interval is set to 3s which increases the time to wait for package repositories, hence we need to explicitly set it to 1s

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
