### PR TITLE
Set kapp wait-check-interval to 1s for e2e tests

### DIFF
--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -57,6 +57,9 @@ func (k *Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	if args[0] == "deploy" {
 		args = append(args, []string{"--wait-timeout", "3m"}...)
 	}
+	if args[0] == "deploy" || args[0] == "delete" {
+		args = append(args, "--wait-check-interval=1s")
+	}
 
 	k.L.Debugf("Running '%s'...\n", k.cmdDesc(args, opts))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Set kapp wait-check-interval to 1s for e2e tests.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
