### PR TITLE
Install imgpkg before running release workflow

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Install Carvel Tools
         run: ./hack/install-deps.sh
 
+      - name: Install imgpkg
+        uses: vmware-tanzu/carvel-setup-action@v1
+        with:
+          only: imgpkg
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -118,7 +123,7 @@ jobs:
             ${checksums['kctrl-darwin-arm64']}  ./kctrl-darwin-arm64
             ${checksums['kctrl-linux-amd64']}  ./kctrl-linux-amd64
             ${checksums['kctrl-linux-arm64']}  ./kctrl-linux-arm64
-            ${checksums['kctrl-windows-amd64.exe']}  ./kctrl-windows-amd64.exe`
+            ${checksums['kctrl-windows-amd64.exe']}  ./kctrl-windows-amd64.exe
             ${checksums['package.yml']}  ./carvel-artifacts/packages/kapp-controller.carvel.dev/package.yml
             ${checksums['package-metadata.yml']}  ./carvel-artifacts/packages/kapp-controller.carvel.dev/package-metadata.yml`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Since, we have introduced package generation using `kctrl`, we need imgpkg for the release.

#### Additional Notes for your reviewer:
We can swap this out when `kctrl` uses imgpkg as a package. This let's lector; have needed dependencies for the time being

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

