### PR TITLE
Remove file path on automated release note generated

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -42,20 +42,25 @@ jobs:
           minikube start --driver=docker --wait=all
           docker buildx create minikube --use --driver=kubernetes --bootstrap
           ./hack/build-release.sh
+          # Create release folder to store all the output artifacts
+          mkdir release
+          cp ./tmp/release.yml  release/release.yml
           cd cli
           ./hack/build-binaries.sh
-          shasum -a 256 ./kctrl-* | tee -a ../tmp/checksums.txt
+          cp ./kctrl-* ../release/
 
       - name: Run Package build
         run: |
           constraintVersion="${{ github.ref_name }}"
           ./cli/kctrl-linux-amd64 pkg release -y -v ${constraintVersion:1} --debug
           mv ./carvel-artifacts/packages/kapp-controller.carvel.dev/metadata.yml ./carvel-artifacts/packages/kapp-controller.carvel.dev/package-metadata.yml
-          shasum -a 256 ./carvel-artifacts/packages/kapp-controller.carvel.dev/package.yml | tee -a ./tmp/checksums.txt
-          shasum -a 256 ./carvel-artifacts/packages/kapp-controller.carvel.dev/package-metadata.yml | tee -a ./tmp/checksums.txt
-          
+          mv ./carvel-artifacts/packages/kapp-controller.carvel.dev/* release/
+
       - name: Add to formatted checksum
         run: |
+          pushd release
+          shasum -a 256 ./release.yml ./kctrl-* ./package.yml ./package-metada.yml | tee ../tmp/checksums.txt
+          popd
           echo "# :open_file_folder: Files Checksum" | tee ./tmp/checksums-formatted.txt
           echo '```' | tee -a ./tmp/checksums-formatted.txt
           cat ./tmp/checksums.txt | tee -a ./tmp/checksums-formatted.txt
@@ -68,11 +73,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           body_path: ./tmp/checksums-formatted.txt
           files: |
-            ./cli/kctrl-*
-            ./tmp/release.yml
+            ./release/*
             ./tmp/checksums.txt
-            ./carvel-artifacts/packages/kapp-controller.carvel.dev/package.yml
-            ./carvel-artifacts/packages/kapp-controller.carvel.dev/package-metadata.yml
           draft: true
           prerelease: true
 
@@ -118,14 +120,14 @@ jobs:
               }
             }
             console.log(checksums)
-            return `${checksums['release.yml']}  ./tmp/release.yml
+            return `${checksums['release.yml']}  ./release.yml
             ${checksums['kctrl-darwin-amd64']}  ./kctrl-darwin-amd64
             ${checksums['kctrl-darwin-arm64']}  ./kctrl-darwin-arm64
             ${checksums['kctrl-linux-amd64']}  ./kctrl-linux-amd64
             ${checksums['kctrl-linux-arm64']}  ./kctrl-linux-arm64
             ${checksums['kctrl-windows-amd64.exe']}  ./kctrl-windows-amd64.exe
-            ${checksums['package.yml']}  ./carvel-artifacts/packages/kapp-controller.carvel.dev/package.yml
-            ${checksums['package-metadata.yml']}  ./carvel-artifacts/packages/kapp-controller.carvel.dev/package-metadata.yml`
+            ${checksums['package.yml']}  ./package.yml
+            ${checksums['package-metadata.yml']}  ./package-metadata.yml`
 
       - name: Verify uploaded artifacts
         if: startsWith(github.ref, 'refs/tags/')

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -10,6 +10,6 @@ source $(dirname "$0")/version-util.sh
 
 ytt -f config/ -f config-release -v kapp_controller_version="$(get_kappctrl_ver)" --data-values-env=KCTRL | kbld --imgpkg-lock-output .imgpkg/images.yml -f- > ./tmp/release.yml
 
-shasum -a 256 ./tmp/release*.yml | tee ./tmp/checksums.txt
+shasum -a 256 ./tmp/release.yml
 
 echo SUCCESS


### PR DESCRIPTION
#### What this PR does / why we need it:
The automated creation of release notes contains paths of the artifacts, but in reality, when uploaded to Github these paths are not preserved. 
What this PR accomplishes is removing these paths so that the release notes better match the artifacts locations in Github

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

