### PR TITLE
Bump most components to latest in kc 0.41

### DIFF
--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -1,36 +1,36 @@
 - checksums:
     darwin:
-      amd64: 579012ac80cc0d55c3a6dde2dfc0ff5bf8a4f74c775295be99faf691cc18595e
+      amd64: a50a8065c6d80226aa979bb708992ca4da9dd2ec2df2c6c4d5c6e9b4b9f3e6f8
     linux:
-      amd64: 29e647beeacbcc2be5f2f481e405c73bcd6d7563bd229ff924a7997b6f2edd5f
-      arm64: 62b8b0698bb9a88d5cfb91ed2f42853dff4f6b4f59f61036df07ad38ca10267b
+      amd64: b3fbce9c6828c7eea09491c24fe49ddba7afe09e4405db33373d2776c91b1e6c
+      arm64: 4d36b859c01d9899e87a65e5533cb37ab62b17ee8120dd0454b417608130e431
   dev: true
   name: ytt
   repo: vmware-tanzu/carvel-ytt
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.43.0
+  version: v0.44.0
 - checksums:
     darwin:
-      amd64: f0fa574d1dd1c4dcd6a763d38e746a918477ac61a6cd52e8e9e1bba6714259c9
+      amd64: 8c8dd97986bc558b676ea3195566e293ae0ee19b31c57104d76adaf01592b4a2
     linux:
-      amd64: 1c3f0e4171063eef70cdabf1730d3557af992aeafb423755e71e9d5f1aea2c9b
-      arm64: 54e92ff92e66a4b86d7768019cb3b40c87e0e6084380c9a765679b2d342fc4f8
+      amd64: bbae1d86b627b1a78cf9d0e1b911377fa55f2dbc058b964cdada8382bf6432dd
+      arm64: d7e182e1544a34fd3bc7dcd5c8bb347216a651ffc33e1130c08889d3adc01335
   dev: true
   name: kbld
   repo: vmware-tanzu/carvel-kbld
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.35.0
+  version: v0.36.0
 - checksums:
     darwin:
-      amd64: 2b466b9f8bbc8719334cadf917769b27affc10c95c9ded3e76be283cfd3d4721
+      amd64: 2521971ce334e32af32942aece39c9cdc7a2a9c982c386c2aa61db1a2527a10e
     linux:
-      amd64: c2c7381a152216c8600408b4dee26aee48390f1e23d8ef209af8d9eb1edd60fc
-      arm64: b4ec066f491c687218eca7e986bdedda6e2680d2bcc3ae1495eb34597aeb2bd1
+      amd64: 886cd9d634214904ee34f44510abe85ce60acbbe4529131ad97bee387d6327fe
+      arm64: 1afa5624183464b4c9dca7a7f63ea51c7f78d74a722e11ec4a774c8e68fb5784
   dev: true
   name: kapp
   repo: vmware-tanzu/carvel-kapp
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.53.0
+  version: v0.54.0
 - checksums:
     darwin:
       amd64: bf839a539c90a22287904e2a83c4322bf00da3150d8d47cb9fb5eb59dfe41111
@@ -55,14 +55,14 @@
   version: v0.30.0
 - checksums:
     linux:
-      amd64: 31960ff2f76a7379d9bac526ddf889fb79241191f1dbe2a24f7864ddcb3f6560
-      arm64: d24163e466f7884c55079d1050968e80a05b633830047116cdfd8ae28d35b0c0
+      amd64: 2315941a13291c277dac9f65e75ead56386440d3907e0540bf157ae70f188347
+      arm64: 57fa17b6bb040a3788116557a72579f2180ea9620b4ee8a9b7244e5901df02e4
   dev: false
   name: helm
   repo: helm/helm
   tarballSubpath: '{{.OS}}-{{.Arch}}/helm'
   urlTemplate: https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-  version: v3.9.4
+  version: v3.10.2
 - checksums:
     linux:
       amd64: 53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb

--- a/test/bench/pkgr_test.go
+++ b/test/bench/pkgr_test.go
@@ -57,12 +57,12 @@ func appName(fileName string) string {
 
 func deployAndDeletePkgr(b *testing.B, pkgrFileName string, totalPackages int) {
 	t1 := time.Now()
-	cmd := exec.Command("kapp", "deploy", "-f", pkgrFileName, "-a", appName(pkgrFileName), "-y")
+	cmd := exec.Command("kapp", "deploy", "-f", pkgrFileName, "-a", appName(pkgrFileName), "-y", "--wait-check-interval=1s")
 	output, err := cmd.Output()
 	require.NoError(b, err, string(output))
 	t2 := time.Now()
 
-	cmd = exec.Command("kapp", "delete", "-a", appName(pkgrFileName), "-y")
+	cmd = exec.Command("kapp", "delete", "-a", appName(pkgrFileName), "-y", "--wait-check-interval=1s")
 	output, err = cmd.Output()
 	require.NoError(b, err, string(output))
 	t3 := time.Now()

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -54,6 +54,9 @@ func (k Kapp) RunWithOpts(args []string, opts RunOpts) (string, error) {
 	if args[0] == "deploy" {
 		args = append(args, []string{"--wait-timeout", "3m"}...)
 	}
+	if args[0] == "deploy" || args[0] == "delete" {
+		args = append(args, "--wait-check-interval=1s")
+	}
 
 	k.L.Debugf("Running '%s'...\n", k.cmdDesc(args, opts))
 


### PR DESCRIPTION
This is an experimental PR to move all (most) dependencies to latest to reduce toil in maintaining multiple versions of each component.

Signed-off-by: Neil Hickey <nhickey@vmware.com>

# Version Matrix:
| v0.44.0 | ytt |
| v0.36.0 | kbld |
| v0.54.0 | kapp |
| v3.10.2 | helm |
| v0.31.0 | imgpkg |
| v0.30.0 | vendir |
| v3.7.3 | sops |
| v1.0.0 | age | 
| v0.4.3 | cue |


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
