### PR TITLE
Bump testing redis chart to latest [17.3.17]

### DIFF
--- a/examples/redis-helm.yml
+++ b/examples/redis-helm.yml
@@ -8,7 +8,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "16.10.0"
+      version: "17.3.17"
       repository:
         url: https://charts.bitnami.com/bitnami
   template:

--- a/test/e2e/kappcontroller/helm_test.go
+++ b/test/e2e/kappcontroller/helm_test.go
@@ -59,7 +59,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "16.10.0"
+      version: "17.3.17"
       repository:
         url: https://charts.bitnami.com/bitnami
   template:
@@ -174,7 +174,7 @@ spec:
   fetch:
   - helmChart:
       name: redis
-      version: "16.10.0"
+      version: "17.3.17"
       repository:
         url: https://charts.bitnami.com/bitnami
   - inline:


### PR DESCRIPTION
Signed-off-by: Neil Hickey <nhickey@vmware.com>

This fixes the tests to use a valid chart. I'm not sure how we make this more sustainable rather than tests failing causing us to bump. But perhaps thats fine for now

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
