### PR TITLE
Refine documentation of the AppTemplateValuesSource

### DIFF
--- a/pkg/apis/kappctrl/v1alpha1/types_template.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_template.go
@@ -62,7 +62,9 @@ type AppTemplateHelmTemplate struct {
 
 // +k8s:openapi-gen=true
 type AppTemplateValuesSource struct {
+	// Reference to a Secret. The keys will be used as data value file names, and the values as the content of the corresponding data values file (typically a multiline yaml)
 	SecretRef    *AppTemplateValuesSourceRef   `json:"secretRef,omitempty" protobuf:"bytes,1,opt,name=secretRef"`
+	// Reference to a ConfigMap. The keys will be used as data value file names, and the values as the content of the corresponding data values file (typically a multiline yaml)
 	ConfigMapRef *AppTemplateValuesSourceRef   `json:"configMapRef,omitempty" protobuf:"bytes,2,opt,name=configMapRef"`
 	Path         string                        `json:"path,omitempty" protobuf:"bytes,3,opt,name=path"`
 	DownwardAPI  *AppTemplateValuesDownwardAPI `json:"downwardAPI,omitempty" protobuf:"bytes,4,opt,name=downwardAPI"`


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Missing CRD doc for template valuesFrom secret

![image](https://user-images.githubusercontent.com/4748380/212137568-b047d23e-7fe5-4235-a74f-56671c3f060c.png)

See related slack thread https://kubernetes.slack.com/archives/CH8KCCKA5/p1673453880059389

#### Does this PR introduce a user-facing change?

CRD doc refines

See example secret in https://github.com/vmware-tanzu/carvel-kapp-controller/blob/ad24bdc3e41219b176f88280a469e9fd21979339/examples/simple-app-git/2.yml#L21-L31

Relates to https://github.com/vmware-tanzu/carvel/pull/613

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
