### PR TITLE
Fix deployment to add the env keys to the correct pod

### DIFF
--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -392,7 +392,7 @@ func (v *Vendir) Run(conf []byte, workingDir string, cacheID string) exec.CmdRun
 	cmd.Stdin = bytes.NewReader(conf)
 	cmd.Stdout = &stdoutBs
 	cmd.Stderr = &stderrBs
-	cmd.Env = append(os.Environ(), "VENDIR_CACHE_DIR="+filepath.Join(v.opts.BaseCacheFolder, cacheID))
+	cmd.Env = []string{"VENDIR_CACHE_DIR=" + filepath.Join(v.opts.BaseCacheFolder, cacheID)}
 
 	err := v.cmdRunner.Run(cmd)
 

--- a/pkg/sidecarexec/cmd_exec.go
+++ b/pkg/sidecarexec/cmd_exec.go
@@ -6,6 +6,7 @@ package sidecarexec
 import (
 	"bytes"
 	"fmt"
+	"os"
 	goexec "os/exec"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
@@ -45,8 +46,9 @@ func (r CmdExec) Run(input CmdInput, output *CmdOutput) error {
 	if len(input.Stdin) > 0 {
 		cmd.Stdin = bytes.NewBuffer(input.Stdin)
 	}
+	cmd.Env = os.Environ()
 	if len(input.Env) > 0 {
-		cmd.Env = input.Env
+		cmd.Env = append(cmd.Env, input.Env...)
 	}
 	if len(input.Dir) > 0 {
 		cmd.Dir = input.Dir


### PR DESCRIPTION
#### What this PR does / why we need it:
The environment variable to select the enable keychain use needs to be added to the `kapp-controller` pod and not the sidecar.

#### Which issue(s) this PR fixes:
Fixes #1067 

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
