### PR TITLE
Disable ytt validations while building packages

### DIFF
--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -34,6 +34,8 @@ type AppSpecBuilderOpts struct {
 	BundleImage   string
 	Debug         bool
 	BundleTag     string
+
+	BuildYttValidations bool
 }
 
 func NewAppSpecBuilder(depsFactory cmdcore.DepsFactory, logger logger.Logger, ui cmdcore.AuthoringUI, opts AppSpecBuilderOpts) *AppSpecBuilder {
@@ -83,7 +85,7 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 
 	// Build images and resolve references using reconciler
 	tempImgpkgLockPath := filepath.Join(LockOutputFolder, LockOutputFile)
-	cmdRunner := NewReleaseCmdRunner(os.Stdout, b.opts.Debug, tempImgpkgLockPath, b.ui)
+	cmdRunner := NewReleaseCmdRunner(os.Stdout, b.opts.Debug, tempImgpkgLockPath, b.opts.BuildYttValidations, b.ui)
 	reconciler := cmdlocal.NewReconciler(b.depsFactory, cmdRunner, b.logger)
 
 	err = reconciler.Reconcile(buildConfigs, cmdlocal.ReconcileOpts{

--- a/cli/pkg/kctrl/cmd/app/release/release_cmd_runner.go
+++ b/cli/pkg/kctrl/cmd/app/release/release_cmd_runner.go
@@ -39,6 +39,9 @@ func (r ReleaseCmdRunner) Run(cmd *goexec.Cmd) error {
 	if filepath.Base(cmd.Path) == "kbld" {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("--imgpkg-lock-output=%s", r.tempImgLockFilepath))
 	}
+	if filepath.Base(cmd.Path) == "ytt" {
+		cmd.Args = append(cmd.Args, "--dangerous-data-values-disable-validation")
+	}
 	if r.fullOutput {
 		cmd.Stdout = io.MultiWriter(r.log, cmd.Stdout)
 		cmd.Stderr = io.MultiWriter(r.log, cmd.Stderr)

--- a/cli/pkg/kctrl/cmd/app/release/release_cmd_runner.go
+++ b/cli/pkg/kctrl/cmd/app/release/release_cmd_runner.go
@@ -18,13 +18,15 @@ type ReleaseCmdRunner struct {
 	log                 io.Writer
 	fullOutput          bool
 	tempImgLockFilepath string
+	buildYttValidations bool
 	ui                  cmdcore.AuthoringUI
 }
 
 var _ exec.CmdRunner = &ReleaseCmdRunner{}
 
-func NewReleaseCmdRunner(log io.Writer, fullOutput bool, tempImgLockFilepath string, ui cmdcore.AuthoringUI) *ReleaseCmdRunner {
-	return &ReleaseCmdRunner{log: log, fullOutput: fullOutput, tempImgLockFilepath: tempImgLockFilepath, ui: ui}
+func NewReleaseCmdRunner(log io.Writer, fullOutput bool, tempImgLockFilepath string, buildYttValidation bool, ui cmdcore.AuthoringUI) *ReleaseCmdRunner {
+	return &ReleaseCmdRunner{log: log, fullOutput: fullOutput, tempImgLockFilepath: tempImgLockFilepath,
+		buildYttValidations: buildYttValidation, ui: ui}
 }
 
 func (r ReleaseCmdRunner) Run(cmd *goexec.Cmd) error {
@@ -39,7 +41,7 @@ func (r ReleaseCmdRunner) Run(cmd *goexec.Cmd) error {
 	if filepath.Base(cmd.Path) == "kbld" {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("--imgpkg-lock-output=%s", r.tempImgLockFilepath))
 	}
-	if filepath.Base(cmd.Path) == "ytt" {
+	if filepath.Base(cmd.Path) == "ytt" && !r.buildYttValidations {
 		cmd.Args = append(cmd.Args, "--dangerous-data-values-disable-validation")
 	}
 	if r.fullOutput {

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -32,6 +32,7 @@ type ReleaseOptions struct {
 	repoOutputLocation    string
 	debug                 bool
 	generateOpenAPISchema bool
+	buildYttValidations   bool
 	tag                   string
 }
 
@@ -61,6 +62,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Print verbose debug output")
 	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default build-<TIMESTAMP>)")
 	cmd.Flags().BoolVar(&o.generateOpenAPISchema, "openapi-schema", true, "Generates openapi schema for ytt and helm templated files and adds it to generated package")
+	cmd.Flags().BoolVar(&o.buildYttValidations, "build-ytt-validations", true, "Ignore ytt validation errors while releasing packages")
 
 	return cmd
 }
@@ -111,11 +113,12 @@ func (o *ReleaseOptions) Run() error {
 		return fmt.Errorf("Releasing package: 'package init' was not run successfully. (hint: re-run the 'init' command)")
 	}
 	builderOpts := cmdapprelease.AppSpecBuilderOpts{
-		BuildTemplate: buildAppSpec.Template,
-		BuildDeploy:   buildAppSpec.Deploy,
-		BuildExport:   pkgBuild.GetExport(),
-		Debug:         o.debug,
-		BundleTag:     o.tag,
+		BuildTemplate:       buildAppSpec.Template,
+		BuildDeploy:         buildAppSpec.Deploy,
+		BuildExport:         pkgBuild.GetExport(),
+		Debug:               o.debug,
+		BundleTag:           o.tag,
+		BuildYttValidations: o.buildYttValidations,
 	}
 	appSpec, err := cmdapprelease.NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/test/e2e/package_release_with_restricitve_values_schema_test.go
+++ b/cli/test/e2e/package_release_with_restricitve_values_schema_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackageReleaseWithRestrictiveValuesSchema(t *testing.T) {
@@ -141,8 +143,13 @@ status:
 		t.Fatal(err)
 	}
 
-	logger.Section("run package release", func() {
+	logger.Section("run package release with ytt validations", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir}, RunOpts{NoNamespace: true, AllowError: true})
+		require.Error(t, err)
+	})
+
+	logger.Section("run package release with ytt validations deactivated", func() {
 		// Verify that validation checks are not performed while running ytt to build packages
-		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir, "build-ytt-validations=false"}, RunOpts{NoNamespace: true})
+		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir, "--build-ytt-validations=false"}, RunOpts{NoNamespace: true})
 	})
 }

--- a/cli/test/e2e/package_release_with_restricitve_values_schema_test.go
+++ b/cli/test/e2e/package_release_with_restricitve_values_schema_test.go
@@ -143,6 +143,6 @@ status:
 
 	logger.Section("run package release", func() {
 		// Verify that validation checks are not performed while running ytt to build packages
-		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir}, RunOpts{NoNamespace: true})
+		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir, "build-ytt-validations=false"}, RunOpts{NoNamespace: true})
 	})
 }

--- a/cli/test/e2e/package_release_with_restricitve_values_schema_test.go
+++ b/cli/test/e2e/package_release_with_restricitve_values_schema_test.go
@@ -1,0 +1,148 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestPackageReleaseWithRestrictiveValuesSchema(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	configYAML := `
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pkg-cm
+  namespace: #@ data.values.namespace
+data:
+  foo: bar
+`
+	schemaYAML := `
+#@data/values-schema
+---
+#@schema/validation min_len=1
+namespace: ""
+`
+	packageBuildYAML := fmt.Sprintf(`
+apiVersion: kctrl.carvel.dev/v1alpha1
+kind: PackageBuild
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com
+spec:
+  release:
+  - resource: {}
+  template:
+    spec:
+      app:
+        spec:
+          deploy:
+          - kapp: {}
+          template:
+          - ytt:
+              paths:
+              - config
+          - kbld: {}
+      export:
+      - imgpkgBundle:
+          image: %s
+          useKbldImagesLock: true
+        includePaths:
+        - config
+`, env.Image)
+	packageResourcesYAML := `
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com.0.0.0
+spec:
+  refName: samplepackage.corp.com
+  releasedAt: null
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - git: {}
+      template:
+      - ytt:
+        paths:
+        - config
+      - kbld: {}
+  valuesSchema:
+    openAPIv3: null
+  version: 0.0.0
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com
+spec:
+  displayName: samplepackage
+  longDescription: samplepackage.corp.com
+  shortDescription: samplepackage.corp.com
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    kctrl.carvel.dev/local-fetch-0: .
+  creationTimestamp: null
+  name: samplepackage
+spec:
+  packageRef:
+  refName: samplepackage.corp.com
+  versionSelection:
+    constraints: 0.0.0
+  serviceAccountName: samplepackage-sa
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0
+`
+
+	cleanUp := func() {
+		os.RemoveAll(workingDir)
+	}
+	cleanUp()
+	defer cleanUp()
+
+	configDir := "config"
+	err := os.Mkdir(workingDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Mkdir(path.Join(workingDir, configDir), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, configDir, "config.yaml"), []byte(configYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, configDir, "schema.yaml"), []byte(schemaYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, "package-build.yml"), []byte(packageBuildYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, "package-resources.yml"), []byte(packageResourcesYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Section("run package release", func() {
+		// Verify that validation checks are not performed while running ytt to build packages
+		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir}, RunOpts{NoNamespace: true})
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
`kctrl` runs the values in the packaged config through `ytt` and `kbld` so that it can build any dependent images. Since, we do not expect validated values to be passed at this stage. We should be skipping the validation checks.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1028 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
The `package release` command now supports values schemas defining values without valid defaults
```

#### Additional Notes for your reviewer:
- I think given how validations are put together and how `ytt` is, it would not produce invalid YAML if a value is missing. So `kbld` can definitely parse `ytt` output.
- Looks like a test for this would require piping for testing packages built from local (we do not have this today)

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
