### PR TITLE
Support positional arguments for pkg repo kick while using package command tree

### DIFF
--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -186,7 +186,7 @@ func AddPackageCommands(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcor
 	pkgrepoCmd.AddCommand(pkgrepo.NewDeleteCmd(pkgrepo.NewDeleteOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgrepo.NewAddCmd(pkgrepo.NewAddOrUpdateOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgrepo.NewUpdateCmd(pkgrepo.NewAddOrUpdateOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
-	pkgrepoCmd.AddCommand(pkgrepo.NewKickCmd(pkgrepo.NewKickOptions(o.ui, o.depsFactory, o.logger), flagsFactory))
+	pkgrepoCmd.AddCommand(pkgrepo.NewKickCmd(pkgrepo.NewKickOptions(o.ui, o.depsFactory, o.logger, opts), flagsFactory))
 	pkgrepoCmd.AddCommand(pkgreporel.NewReleaseCmd(pkgreporel.NewReleaseOptions(o.ui, o.depsFactory, o.logger)))
 
 	pkgiCmd := pkginst.NewCmd()

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -43,6 +43,11 @@ func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		Use:   "kick",
 		Short: "Trigger reconciliation for repository",
 		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Example: cmdcore.Examples{
+			cmdcore.Example{"Trigger reconciliation for repository",
+				[]string{"package", "repository", "kick", "-r", "sample-repo"}},
+		}.Description("-r", o.pkgCmdTreeOpts),
+		SilenceUsage: true,
 		Annotations: map[string]string{cmdapp.TTYByDefaultKey: "",
 			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -30,10 +30,12 @@ type KickOptions struct {
 
 	NamespaceFlags cmdcore.NamespaceFlags
 	Name           string
+
+	pkgCmdTreeOpts cmdcore.PackageCommandTreeOpts
 }
 
-func NewKickOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger) *KickOptions {
-	return &KickOptions{ui: ui, statusUI: cmdcore.NewStatusLoggingUI(ui), depsFactory: depsFactory, logger: logger}
+func NewKickOptions(ui ui.UI, depsFactory cmdcore.DepsFactory, logger logger.Logger, pkgCmdTreeOpts cmdcore.PackageCommandTreeOpts) *KickOptions {
+	return &KickOptions{ui: ui, statusUI: cmdcore.NewStatusLoggingUI(ui), depsFactory: depsFactory, logger: logger, pkgCmdTreeOpts: pkgCmdTreeOpts}
 }
 
 func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command {
@@ -46,7 +48,14 @@ func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 	}
 
 	o.NamespaceFlags.Set(cmd, flagsFactory)
-	cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set repository name (required)")
+
+	if !o.pkgCmdTreeOpts.PositionalArgs {
+		cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set repository name (required)")
+	} else {
+		cmd.Use = "kick REPOSITORY_NAME"
+		cmd.Args = cobra.ExactArgs(1)
+	}
+
 	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
- Support positional arguments for pkg repo kick while using package command tree
- Add example for package repository kick

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1042 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
