### PR TITLE
Introduce dry run flag for kctrl package install and package repo add

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/package_install_dry_run.go
+++ b/cli/pkg/kctrl/cmd/package/installed/package_install_dry_run.go
@@ -1,0 +1,147 @@
+package installed
+
+import (
+	"fmt"
+
+	cmdcore "github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/cmd/core"
+	kcpkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
+	versions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type PackageInstalledDryRun struct {
+	*CreateOrUpdateOptions
+}
+
+func (d PackageInstalledDryRun) PrintResources() error {
+	const yamlSeperator = "---\n"
+	packageInstall := &kcpkgv1alpha1.PackageInstall{
+		TypeMeta:   metav1.TypeMeta{Kind: "PackageInstall", APIVersion: "packaging.carvel.dev/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: d.Name, Namespace: d.NamespaceFlags.Name},
+		Spec: kcpkgv1alpha1.PackageInstallSpec{
+			PackageRef: &kcpkgv1alpha1.PackageRef{
+				RefName: d.CreateOrUpdateOptions.packageName,
+				VersionSelection: &versions.VersionSelectionSemver{
+					Constraints: d.version,
+					Prereleases: &versions.VersionSelectionSemverPrereleases{},
+				},
+			},
+		},
+	}
+
+	rbacResourcesYAML := ""
+	createRBAC := d.serviceAccountName != ""
+	if createRBAC {
+		packageInstall.Spec.ServiceAccountName = d.serviceAccountName
+	} else {
+		packageInstall.Spec.ServiceAccountName = d.createdAnnotations.ServiceAccountAnnValue()
+
+		serviceAccount := &corev1.ServiceAccount{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      d.createdAnnotations.ServiceAccountAnnValue(),
+				Namespace: d.NamespaceFlags.Name,
+				Annotations: map[string]string{
+					KctrlPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+					TanzuPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+				},
+			},
+		}
+		serviceAccountYAML, err := yaml.Marshal(serviceAccount)
+		if err != nil {
+			return fmt.Errorf("Marshalling ServiceAccount YAML: %s", err)
+		}
+
+		clusterRole := &rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: d.createdAnnotations.ClusterRoleAnnValue(),
+				Annotations: map[string]string{
+					KctrlPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+					TanzuPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+				},
+			},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"*"}, Verbs: []string{"*"}, Resources: []string{"*"}},
+			},
+		}
+		clusterRoleYAML, err := yaml.Marshal(clusterRole)
+		if err != nil {
+			return fmt.Errorf("Marshalling ClusterRole YAML: %s", err)
+		}
+
+		clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: d.createdAnnotations.ClusterRoleBindingAnnValue(),
+				Annotations: map[string]string{
+					KctrlPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+					TanzuPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+				},
+			},
+			Subjects: []rbacv1.Subject{{Kind: KindServiceAccount.AsString(), Name: d.createdAnnotations.ServiceAccountAnnValue(), Namespace: d.NamespaceFlags.Name}},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     KindClusterRole.AsString(),
+				Name:     d.createdAnnotations.ClusterRoleAnnValue(),
+			},
+		}
+		clusterRoleBindingYAML, err := yaml.Marshal(clusterRoleBinding)
+		if err != nil {
+			return fmt.Errorf("Marshalling ClusterRoleBinding YAML: %s", err)
+		}
+
+		rbacResourcesYAML = yamlSeperator + string(serviceAccountYAML) + yamlSeperator + string(clusterRoleYAML) + yamlSeperator + string(clusterRoleBindingYAML)
+	}
+
+	secretResourcesYAML := ""
+	createSecret := d.values && d.valuesFile != ""
+	if createSecret {
+		var err error
+		dataValues := make(map[string]string)
+
+		datavaluesBytes, err := cmdcore.NewInputFile(d.valuesFile).Bytes()
+		if err != nil {
+			return fmt.Errorf("Reading data values file '%s': %s", d.valuesFile, err.Error())
+		}
+		dataValues[valuesFileKey] = string(datavaluesBytes)
+
+		secret := &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      d.createdAnnotations.SecretAnnValue(),
+				Namespace: d.NamespaceFlags.Name,
+				Annotations: map[string]string{
+					KctrlPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+					TanzuPkgAnnotation: d.createdAnnotations.PackageAnnValue(),
+				},
+			},
+			StringData: dataValues,
+		}
+		secretYAML, err := yaml.Marshal(secret)
+		if err != nil {
+			return fmt.Errorf("Marshalling Secret YAML: %s", err)
+		}
+		secretResourcesYAML = yamlSeperator + string(secretYAML)
+
+		packageInstall.Spec.Values = []kcpkgv1alpha1.PackageInstallValues{
+			{
+				SecretRef: &kcpkgv1alpha1.PackageInstallValuesSecretRef{
+					Name: d.createdAnnotations.SecretAnnValue(),
+				},
+			},
+		}
+	}
+	d.addCreatedResourceAnnotations(&packageInstall.ObjectMeta, createRBAC, createSecret, false)
+
+	packageInstallYAML, err := yaml.Marshal(packageInstall)
+	if err != nil {
+		return fmt.Errorf("Marshalling PackageInstall YAML: %s", err)
+	}
+
+	d.ui.PrintLinef(rbacResourcesYAML + secretResourcesYAML + yamlSeperator + string(packageInstallYAML))
+	return nil
+}

--- a/cli/pkg/kctrl/cmd/package/installed/package_install_dry_run.go
+++ b/cli/pkg/kctrl/cmd/package/installed/package_install_dry_run.go
@@ -33,10 +33,8 @@ func (d PackageInstalledDryRun) PrintResources() error {
 	}
 
 	rbacResourcesYAML := ""
-	createRBAC := d.serviceAccountName != ""
+	createRBAC := d.serviceAccountName == ""
 	if createRBAC {
-		packageInstall.Spec.ServiceAccountName = d.serviceAccountName
-	} else {
 		packageInstall.Spec.ServiceAccountName = d.createdAnnotations.ServiceAccountAnnValue()
 
 		serviceAccount := &corev1.ServiceAccount{
@@ -52,7 +50,7 @@ func (d PackageInstalledDryRun) PrintResources() error {
 		}
 		serviceAccountYAML, err := yaml.Marshal(serviceAccount)
 		if err != nil {
-			return fmt.Errorf("Marshalling ServiceAccount YAML: %s", err)
+			return fmt.Errorf("Marshaling ServiceAccount YAML: %s", err)
 		}
 
 		clusterRole := &rbacv1.ClusterRole{
@@ -70,7 +68,7 @@ func (d PackageInstalledDryRun) PrintResources() error {
 		}
 		clusterRoleYAML, err := yaml.Marshal(clusterRole)
 		if err != nil {
-			return fmt.Errorf("Marshalling ClusterRole YAML: %s", err)
+			return fmt.Errorf("Marshaling ClusterRole YAML: %s", err)
 		}
 
 		clusterRoleBinding := &rbacv1.ClusterRoleBinding{
@@ -91,10 +89,12 @@ func (d PackageInstalledDryRun) PrintResources() error {
 		}
 		clusterRoleBindingYAML, err := yaml.Marshal(clusterRoleBinding)
 		if err != nil {
-			return fmt.Errorf("Marshalling ClusterRoleBinding YAML: %s", err)
+			return fmt.Errorf("Marshaling ClusterRoleBinding YAML: %s", err)
 		}
 
 		rbacResourcesYAML = yamlSeperator + string(serviceAccountYAML) + yamlSeperator + string(clusterRoleYAML) + yamlSeperator + string(clusterRoleBindingYAML)
+	} else {
+		packageInstall.Spec.ServiceAccountName = d.serviceAccountName
 	}
 
 	secretResourcesYAML := ""
@@ -123,7 +123,7 @@ func (d PackageInstalledDryRun) PrintResources() error {
 		}
 		secretYAML, err := yaml.Marshal(secret)
 		if err != nil {
-			return fmt.Errorf("Marshalling Secret YAML: %s", err)
+			return fmt.Errorf("Marshaling Secret YAML: %s", err)
 		}
 		secretResourcesYAML = yamlSeperator + string(secretYAML)
 
@@ -139,9 +139,9 @@ func (d PackageInstalledDryRun) PrintResources() error {
 
 	packageInstallYAML, err := yaml.Marshal(packageInstall)
 	if err != nil {
-		return fmt.Errorf("Marshalling PackageInstall YAML: %s", err)
+		return fmt.Errorf("Marshaling PackageInstall YAML: %s", err)
 	}
 
-	d.ui.PrintLinef(rbacResourcesYAML + secretResourcesYAML + yamlSeperator + string(packageInstallYAML))
+	d.ui.PrintBlock([]byte(rbacResourcesYAML + secretResourcesYAML + yamlSeperator + string(packageInstallYAML)))
 	return nil
 }

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -298,9 +298,9 @@ func (o AddOrUpdateOptions) dryRun() error {
 
 	packageRepoYaml, err := yaml.Marshal(packageRepo)
 	if err != nil {
-		return fmt.Errorf("Marshalling PackageRepository YAML: %s", err)
+		return fmt.Errorf("Marshaling PackageRepository YAML: %s", err)
 	}
-	o.ui.PrintLinef(string(packageRepoYaml))
+	o.ui.PrintBlock(packageRepoYaml)
 
 	return nil
 }

--- a/cli/test/e2e/package_install_dry_run_test.go
+++ b/cli/test/e2e/package_install_dry_run_test.go
@@ -1,0 +1,164 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageInstallDryRun(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	logger.Section("package install dry-run", func() {
+		expectedOutput := `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    packaging.carvel.dev/package: test-kctrl-test
+    tkg.tanzu.vmware.com/tanzu-package: test-kctrl-test
+  creationTimestamp: null
+  name: test-kctrl-test-sa
+  namespace: kctrl-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    packaging.carvel.dev/package: test-kctrl-test
+    tkg.tanzu.vmware.com/tanzu-package: test-kctrl-test
+  creationTimestamp: null
+  name: test-kctrl-test-cluster-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    packaging.carvel.dev/package: test-kctrl-test
+    tkg.tanzu.vmware.com/tanzu-package: test-kctrl-test
+  creationTimestamp: null
+  name: test-kctrl-test-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-kctrl-test-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: test-kctrl-test-sa
+  namespace: kctrl-test
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  creationTimestamp: null
+  name: test
+  namespace: kctrl-test
+spec:
+  packageRef:
+    refName: test.carvel.dev
+    versionSelection:
+      constraints: 1.0.0
+      prereleases: {}
+  serviceAccountName: test-kctrl-test-sa
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0`
+
+		output := kappCtrl.Run([]string{"package", "install", "-i", "test", "-p", "test.carvel.dev", "--version", "1.0.0", "--dry-run"})
+		require.Contains(t, output, expectedOutput)
+	})
+
+	logger.Section("package install dry-run with service account", func() {
+		expectedOutput := `---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    packaging.carvel.dev/package-ClusterRole: test-kctrl-test-cluster-role
+    packaging.carvel.dev/package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
+    packaging.carvel.dev/package-ServiceAccount: test-kctrl-test-sa
+    tkg.tanzu.vmware.com/tanzu-package-ClusterRole: test-kctrl-test-cluster-role
+    tkg.tanzu.vmware.com/tanzu-package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
+    tkg.tanzu.vmware.com/tanzu-package-ServiceAccount: test-kctrl-test-sa
+  creationTimestamp: null
+  name: test
+  namespace: kctrl-test
+spec:
+  packageRef:
+    refName: test.carvel.dev
+    versionSelection:
+      constraints: 1.0.0
+      prereleases: {}
+  serviceAccountName: test-svc-acc
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0`
+
+		output := kappCtrl.Run([]string{"package", "install", "-i", "test", "-p", "test.carvel.dev", "--version", "1.0.0",
+			"--service-account-name", "test-svc-acc", "--dry-run"})
+		require.Contains(t, output, expectedOutput)
+	})
+
+	logger.Section("package install dry-run with service account and values file", func() {
+		expectedOutput := `---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    packaging.carvel.dev/package: test-kctrl-test
+    tkg.tanzu.vmware.com/tanzu-package: test-kctrl-test
+  creationTimestamp: null
+  name: test-kctrl-test-values
+  namespace: kctrl-test
+stringData:
+  values.yaml: |
+    foo: bar
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    packaging.carvel.dev/package-ClusterRole: test-kctrl-test-cluster-role
+    packaging.carvel.dev/package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
+    packaging.carvel.dev/package-Secret: test-kctrl-test-values
+    packaging.carvel.dev/package-ServiceAccount: test-kctrl-test-sa
+    tkg.tanzu.vmware.com/tanzu-package-ClusterRole: test-kctrl-test-cluster-role
+    tkg.tanzu.vmware.com/tanzu-package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
+    tkg.tanzu.vmware.com/tanzu-package-Secret: test-kctrl-test-values
+    tkg.tanzu.vmware.com/tanzu-package-ServiceAccount: test-kctrl-test-sa
+  creationTimestamp: null
+  name: test
+  namespace: kctrl-test
+spec:
+  packageRef:
+    refName: test.carvel.dev
+    versionSelection:
+      constraints: 1.0.0
+      prereleases: {}
+  serviceAccountName: test-svc-acc
+  values:
+  - secretRef:
+      name: test-kctrl-test-values
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0`
+
+		output, _ := kappCtrl.RunWithOpts([]string{"package", "install", "-i", "test", "-p", "test.carvel.dev", "--version", "1.0.0", "--values-file", "-",
+			"--service-account-name", "test-svc-acc", "--dry-run"},
+			RunOpts{StdinReader: strings.NewReader("foo: bar\n")})
+		require.Contains(t, output, expectedOutput)
+	})
+}

--- a/cli/test/e2e/package_install_dry_run_test.go
+++ b/cli/test/e2e/package_install_dry_run_test.go
@@ -60,6 +60,13 @@ subjects:
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
+  annotations:
+    packaging.carvel.dev/package-ClusterRole: test-kctrl-test-cluster-role
+    packaging.carvel.dev/package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
+    packaging.carvel.dev/package-ServiceAccount: test-kctrl-test-sa
+    tkg.tanzu.vmware.com/tanzu-package-ClusterRole: test-kctrl-test-cluster-role
+    tkg.tanzu.vmware.com/tanzu-package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
+    tkg.tanzu.vmware.com/tanzu-package-ServiceAccount: test-kctrl-test-sa
   creationTimestamp: null
   name: test
   namespace: kctrl-test
@@ -84,13 +91,6 @@ status:
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
-  annotations:
-    packaging.carvel.dev/package-ClusterRole: test-kctrl-test-cluster-role
-    packaging.carvel.dev/package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
-    packaging.carvel.dev/package-ServiceAccount: test-kctrl-test-sa
-    tkg.tanzu.vmware.com/tanzu-package-ClusterRole: test-kctrl-test-cluster-role
-    tkg.tanzu.vmware.com/tanzu-package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
-    tkg.tanzu.vmware.com/tanzu-package-ServiceAccount: test-kctrl-test-sa
   creationTimestamp: null
   name: test
   namespace: kctrl-test
@@ -130,14 +130,8 @@ apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
   annotations:
-    packaging.carvel.dev/package-ClusterRole: test-kctrl-test-cluster-role
-    packaging.carvel.dev/package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
     packaging.carvel.dev/package-Secret: test-kctrl-test-values
-    packaging.carvel.dev/package-ServiceAccount: test-kctrl-test-sa
-    tkg.tanzu.vmware.com/tanzu-package-ClusterRole: test-kctrl-test-cluster-role
-    tkg.tanzu.vmware.com/tanzu-package-ClusterRoleBinding: test-kctrl-test-cluster-rolebinding
     tkg.tanzu.vmware.com/tanzu-package-Secret: test-kctrl-test-values
-    tkg.tanzu.vmware.com/tanzu-package-ServiceAccount: test-kctrl-test-sa
   creationTimestamp: null
   name: test
   namespace: kctrl-test

--- a/cli/test/e2e/package_repo_dry_run_test.go
+++ b/cli/test/e2e/package_repo_dry_run_test.go
@@ -1,0 +1,33 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageRepoDryRun(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	logger.Section("dry-run package repo add", func() {
+		expectedOutput := `apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  creationTimestamp: null
+  name: test-repo
+  namespace: kctrl-test
+spec:
+  fetch:
+    imgpkgBundle:
+      image: registry.carvel.dev/project/repo:1.0.0
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0`
+
+		output := kappCtrl.Run([]string{"package", "repo", "add", "-r", "test-repo", "--url", "registry.carvel.dev/project/repo:1.0.0", "--dry-run"})
+		require.Contains(t, output, expectedOutput)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
It introduces a flag that let's users observe the resource YAML that `kctrl` would apply, without applying them to the cluster

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1029 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Introduced dry-run flag for `package install` and `package repo add`
```

#### Additional Notes for your reviewer:
To ensure that we do not introduce a lot of branching, this implementation implements logic for dry-run completely separately from the existing workflow.

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
kctrl command reference will have to be updated
```
