### PR TITLE
`kctrl`: Flag to create namespace when adding new repo

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -161,11 +161,11 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 
 		_, err = coreClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
 		if err != nil {
-			if errors.IsAlreadyExists(err) {
-				o.statusUI.PrintMessagef("The namespace '%s' already exists", o.NamespaceFlags.Name)
-			} else {
+			if !errors.IsAlreadyExists(err) {
 				return err
 			}
+		} else {
+			o.statusUI.PrintMessagef("Created namespace '%s'", o.NamespaceFlags.Name)
 		}
 	}
 

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -146,8 +146,6 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 	}
 
 	if o.CreateNamespace {
-		o.statusUI.PrintMessagef("Creating namespace '%s'", o.NamespaceFlags.Name)
-
 		coreClient, err := o.depsFactory.CoreClient()
 		if err != nil {
 			return err

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -20,14 +20,12 @@ func TestPackageRepository(t *testing.T) {
 	pkgrName := "test-package-repository"
 	pkgrURL := `index.docker.io/k8slt/kc-e2e-test-repo:latest`
 
-	existingRepoNamespace := "carvel-test-repos-a"
-	newRepoNamespace := "carvel-test-repos-b"
+	newRepoNamespace := "carvel-test-repo-a"
 
 	kind := "PackageRepository"
 
 	cleanUp := func() {
 		RemoveClusterResource(t, kind, pkgrName, env.Namespace, kubectl)
-		RemoveClusterResource(t, kind, pkgrName, existingRepoNamespace, kubectl)
 		RemoveClusterResource(t, kind, pkgrName, newRepoNamespace, kubectl)
 	}
 
@@ -139,11 +137,9 @@ func TestPackageRepository(t *testing.T) {
 	})
 
 	logger.Section("creating a repository in a namespace that already exists", func() {
-		kubectl.Run([]string{"create", "namespace", existingRepoNamespace})
+		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", env.Namespace, "--create-namespace"})
 
-		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", existingRepoNamespace, "--create-namespace"})
-
-		kubectl.Run([]string{"get", kind, pkgrName, "-n", existingRepoNamespace})
+		kubectl.Run([]string{"get", kind, pkgrName, "-n", env.Namespace})
 	})
 
 }

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -127,4 +127,21 @@ func TestPackageRepository(t *testing.T) {
 		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
 	})
 
+	logger.Section("creating a repository in a new namespace that doesn't exist", func() {
+		repoNamespace := "carvel-test-repos-a"
+
+		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", repoNamespace, "--create-namespace"})
+
+		kubectl.Run([]string{"get", kind, pkgrName, "-n", repoNamespace})
+	})
+
+	logger.Section("creating a repository in a namespace that already exists", func() {
+		repoNamespace := "carvel-test-repos-b"
+		kubectl.Run([]string{"create", "namespace", repoNamespace})
+
+		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", repoNamespace, "--create-namespace"})
+
+		kubectl.Run([]string{"get", kind, pkgrName, "-n", repoNamespace})
+	})
+
 }

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -27,8 +27,6 @@ func TestPackageRepository(t *testing.T) {
 
 	cleanUp := func() {
 		RemoveClusterResource(t, kind, pkgrName, env.Namespace, kubectl)
-		kubectl.Run([]string{"delete", "namespace", existingRepoNamespace})
-		kubectl.Run([]string{"delete", "namespace", newRepoNamespace})
 	}
 
 	cleanUp()
@@ -136,6 +134,8 @@ func TestPackageRepository(t *testing.T) {
 		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", newRepoNamespace, "--create-namespace"})
 
 		kubectl.Run([]string{"get", kind, pkgrName, "-n", newRepoNamespace})
+
+		RemoveClusterResource(t, kind, pkgrName, newRepoNamespace, kubectl)
 	})
 
 	logger.Section("creating a repository in a namespace that already exists", func() {
@@ -144,6 +144,8 @@ func TestPackageRepository(t *testing.T) {
 		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", existingRepoNamespace, "--create-namespace"})
 
 		kubectl.Run([]string{"get", kind, pkgrName, "-n", existingRepoNamespace})
+
+		RemoveClusterResource(t, kind, pkgrName, existingRepoNamespace, kubectl)
 	})
 
 }

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -27,6 +27,8 @@ func TestPackageRepository(t *testing.T) {
 
 	cleanUp := func() {
 		RemoveClusterResource(t, kind, pkgrName, env.Namespace, kubectl)
+		RemoveClusterResource(t, kind, pkgrName, existingRepoNamespace, kubectl)
+		RemoveClusterResource(t, kind, pkgrName, newRepoNamespace, kubectl)
 	}
 
 	cleanUp()
@@ -134,8 +136,6 @@ func TestPackageRepository(t *testing.T) {
 		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", newRepoNamespace, "--create-namespace"})
 
 		kubectl.Run([]string{"get", kind, pkgrName, "-n", newRepoNamespace})
-
-		RemoveClusterResource(t, kind, pkgrName, newRepoNamespace, kubectl)
 	})
 
 	logger.Section("creating a repository in a namespace that already exists", func() {
@@ -144,8 +144,6 @@ func TestPackageRepository(t *testing.T) {
 		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL, "-n", existingRepoNamespace, "--create-namespace"})
 
 		kubectl.Run([]string{"get", kind, pkgrName, "-n", existingRepoNamespace})
-
-		RemoveClusterResource(t, kind, pkgrName, existingRepoNamespace, kubectl)
 	})
 
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

When adding a new package repository to a cluster, it's now possible to create the installation namespace automatically by specifying the "--create-namespace" flag.

#### Which issue(s) this PR fixes:

Fixes gh-1001

#### Does this PR introduce a user-facing change?

```release-note
Added a new flag `create-namespace` for creating the installation namespace when adding a new package repository to a cluster.
```

#### Additional Notes for your reviewer:

After a first review of this pull request to validate the behaviour of the new flag, I will submit a PR to update the documentation on the project website.

##### Review Checklist:

- [X] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [X] Relevant tests are added or updated
- [] Relevant docs in this repo added or updated
- [] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [X] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
