### PR TITLE
Fix flaky tests

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -23,6 +23,7 @@ jobs:
         uses: carvel-dev/setup-action@v1
         with:
           only: imgpkg
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           only: kctrl
           kctrl: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           kctrl version
           version=`kctrl version`

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -33,6 +33,7 @@ jobs:
       uses: carvel-dev/setup-action@v1
       with:
         only: ytt, kbld, imgpkg, vendir, kapp
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Tests
       run: |
         set -e -x

--- a/hack/dependencies_test.go
+++ b/hack/dependencies_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 func init() {
-	client = http.DefaultClient
+	client = &http.Client{
+		// try to use a Github API token from the environment to avoid rate-limiting
+		Transport: newGithubTransport(),
+	}
 }
 
 func TestDependencyDownload(t *testing.T) {
-	client = http.DefaultClient
 	for _, tc := range []struct {
 		name string
 		dep  dependency

--- a/test/e2e/assets/https-server/server.yml
+++ b/test/e2e/assets/https-server/server.yml
@@ -9,8 +9,6 @@ kind: Service
 metadata:
   namespace: https-server
   name: https-svc
-  annotations:
-    kapp.k14s.io/change-group: server
 spec:
   selector:
     app: self-signed-https-server
@@ -23,8 +21,6 @@ kind: Deployment
 metadata:
   name: self-signed-https-server
   namespace: https-server
-  annotations:
-    kapp.k14s.io/change-group: server
 spec:
   replicas: 1
   selector:
@@ -131,30 +127,3 @@ binaryData:
   #         deploy:
   #         - kapp: {}
   packages.tar: "H4sIAHczxmIAA+2SS2rEMAyGZ51T6AL22KmTQg5RuupetZVJyGOM4wRC6d0bx5M+oAylDJRCvo0sS/+PjGVRN3ii4Wjjgc9de7gxQohcKQjxPs/WKNKYr2QiA6nSXKo7makUhFSZzA4gbj3Id4yDR7eMYprrfUtbWV6px6fAe/wnMMYStPUTuaE+9wUY9MjjLtT9iWt0E7Xc0HScJLa2Qpk0dW8KeIz7knTkMYiKBKDHjgq4bBJ7pmrpZBqZJuc/WXHJBRfJYEkHlaPy4WfCpXnaBo0eAJ4626Kn4ASweQZK8rraEgaV93bLAqNrCxj7cSBzuf1qFTSz9wW8vF5yQ7Y9zx/VBq1dy3/9iTs7Ozu/4A1GdDfIAAgAAA=="
-
-# TODO should we make vendir's http retry within App CR, to avoid
-# transient failure when Service=>Deployment networking is not ready?
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: check-nginx-conn
-  namespace: default
-  annotations:
-    kapp.k14s.io/update-strategy: always-replace
-    kapp.k14s.io/change-rule: upsert after upserting server
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: check-nginx-conn
-    spec:
-      containers:
-      - name: check
-        image: busybox
-        command:
-        - /bin/sh
-        - "-c"
-        - |
-          wget --tries=10 --no-check-certificate https://https-svc.https-server.svc.cluster.local/deployment.yml
-      restartPolicy: Never


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
* Use token with setup-action in kctrl tests as we were experiencing rate limiting.
* Use token in `dependencies_test.go` to avoid rate limiting. Currently we only use it to download the dependencies, but not while testing dependency download.
* Remove Job from the resources used in `TrustConfig_TrustCACerts`, we have readinessProbe defined for the deployment which should make sure that the service is ready to accept request.  
  - For some reason the Job which is supposed to make sure the same doesn't work. For now, removing the Job seems to have resolved the flakiness (tried running the tests ~10 times with these changes), but even if we face the same issue again we should be able to look at the error from the App CR and try to have a fix for that.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
