### PR TITLE
Add check for annotations field while looking for `pkg_repo_ann`

### DIFF
--- a/pkg/pkgrepository/app_template.go
+++ b/pkg/pkgrepository/app_template.go
@@ -232,10 +232,12 @@ func (a *App) yttTemplateAddIdenticalRsRebase() kcv1alpha1.AppTemplateYtt {
         #@ pkg_repo_ann = "packaging.carvel.dev/package-repository-ref"
         #@ new_owner = data.values.new.metadata.annotations[pkg_repo_ann]
         #@
-        #@ if pkg_repo_ann in data.values.existing.metadata.annotations:
-        #@   existing_owner = data.values.existing.metadata.annotations[pkg_repo_ann]
-        #@ else:
-        #@   existing_owner = new_owner
+        #@ existing_owner = new_owner
+        #@
+        #@ if hasattr(data.values.existing.metadata, "annotations"):
+        #@   if pkg_repo_ann in data.values.existing.metadata.annotations:
+        #@     existing_owner = data.values.existing.metadata.annotations[pkg_repo_ann]
+        #@   end
         #@ end
         #@
         #@ if new_owner != existing_owner:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Add check for annotations field while looking for pkg_repo_ann

Manually tested the following scenarios:
- Existing package with no annotation present (package repository was successfully created and assumed ownership of the package)
- Existing package with some annotations present (package repository was successfully created and assumed ownership of the package)
- Existing package part of another repository (package repository was created successfully without owning the package)

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1054 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
