### PR TITLE
fix: Add validation for same secret to vendir

### DIFF
--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -16,8 +16,10 @@ import (
 	// we run vendir by shelling out to it, but we create the vendir configs with help from a vendored copy of vendir.
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
 	vendirconf "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/config"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/strings/slices"
 	kyaml "sigs.k8s.io/yaml"
 )
 
@@ -236,9 +238,26 @@ func (v *Vendir) ConfigBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	finalConfig := bytes.Join(append(resourcesYaml, vendirConfBytes), []byte("---\n"))
+	finalConfig := bytes.Join(append(v.filterConfigSecrets(resourcesYaml), vendirConfBytes), []byte("---\n"))
 
 	return finalConfig, nil
+}
+
+func (v *Vendir) filterConfigSecrets(resourcesYaml [][]byte) [][]byte {
+	filteRedresourcesYaml := [][]byte{}
+	secrets := []string{}
+	for _, y := range resourcesYaml {
+		secret := &v1.Secret{}
+		if err := kyaml.Unmarshal(y, secret); err == nil && secret.APIVersion == "v1" && secret.Kind == "Secret" && secret.Name != "" {
+			if !slices.Contains(secrets, secret.GetName()) {
+				secrets = append(secrets, secret.GetName())
+				filteRedresourcesYaml = append(filteRedresourcesYaml, y)
+			}
+		} else {
+			filteRedresourcesYaml = append(filteRedresourcesYaml, y)
+		}
+	}
+	return filteRedresourcesYaml
 }
 
 func (v *Vendir) requiredResourcesYaml(contents vendirconf.DirectoryContents) ([][]byte, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

When an AppCR is provided as part of an `kapp deploy` execution, and the AppCR have in the `fetch` section multimples entries of `git` type and those entries are against a private repository and uses the same `secretRef`, kapp controller is generating the `Directory` with multiple times the secret causing the error described in the issue, for example

```yaml
spec:
  serviceAccountName: default
  fetch:
  - git:
     # creates a config map
      url: git@github.com:odinnordico/kapp-controller-private-test.git
      ref: origin/main
      secretRef:
        name: ssh-key-secret
      subPath: cm
  - git:
      # creates a secret
      url: git@github.com:odinnordico/kapp-controller-private-test.git
      ref: origin/main
      secretRef:
        name: ssh-key-secret
      subPath: secret
```

The `ssh-key-secret` is twice and the error ` Expected to find one secret 'ssh-key-secret', but found multiple` is shown.

This PR filters the `resourcesYaml` to be used in the `vendir` command by only adding one time each secret.

This can work assuming that the AppCR only supports secrets in the same namespaces as it is, then only one secret with a given name can exist within.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1002 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
User is now able to provide the same secret on multimple fetch entries under the `secretRef.name` of each
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
