### PR TITLE
Fix panic calling `tanzu package installed status`

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -61,10 +61,9 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 
 func (o *StatusOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		if len(args) == 0 {
-			return fmt.Errorf("Package name not provided.")
+		if len(args) > 0 {
+			o.Name = args[0]
 		}
-		o.Name = args[0]
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -61,6 +61,9 @@ func NewStatusCmd(o *StatusOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 
 func (o *StatusOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
+		if len(args) == 0 {
+			return fmt.Errorf("Package name not provided.")
+		}
 		o.Name = args[0]
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Calling `tanzu package installed status` without any arguments causes the program to panic (see linked issue).


#### Which issue(s) this PR fixes:
Fixes #1160

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
