### PR TITLE
Fix panic reading empty args slice

### DIFF
--- a/cli/pkg/kctrl/cmd/package/available/get.go
+++ b/cli/pkg/kctrl/cmd/package/available/get.go
@@ -77,7 +77,9 @@ func (o *GetOptions) Run(args []string) error {
 	var pkgName, pkgVersion string
 
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/available/list.go
+++ b/cli/pkg/kctrl/cmd/package/available/list.go
@@ -82,7 +82,9 @@ func NewListCmd(o *ListOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 
 func (o *ListOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs && len(args) > 0 {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if o.Summary && o.Name == "" {

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -207,7 +207,9 @@ func (o *CreateOrUpdateOptions) RunCreate(args []string) error {
 	o.createdAnnotations = NewCreatedResourceAnnotations(o.Name, o.NamespaceFlags.Name)
 
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {
@@ -312,7 +314,9 @@ func (o *CreateOrUpdateOptions) create(client kubernetes.Interface, kcClient kcc
 
 func (o *CreateOrUpdateOptions) RunUpdate(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/installed/delete.go
+++ b/cli/pkg/kctrl/cmd/package/installed/delete.go
@@ -82,7 +82,9 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 
 func (o *DeleteOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/installed/get.go
+++ b/cli/pkg/kctrl/cmd/package/installed/get.go
@@ -76,7 +76,9 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 
 func (o *GetOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -103,7 +103,9 @@ func NewKickCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobra
 
 func (o *PauseOrKickOptions) Pause(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {
@@ -132,7 +134,9 @@ func (o *PauseOrKickOptions) Pause(args []string) error {
 
 func (o *PauseOrKickOptions) Kick(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -128,7 +128,9 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 
 func (o *AddOrUpdateOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -69,7 +69,9 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 
 func (o *DeleteOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {

--- a/cli/pkg/kctrl/cmd/package/repository/get.go
+++ b/cli/pkg/kctrl/cmd/package/repository/get.go
@@ -59,7 +59,9 @@ func NewGetCmd(o *GetOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Command 
 
 func (o *GetOptions) Run(args []string) error {
 	if o.pkgCmdTreeOpts.PositionalArgs {
-		o.Name = args[0]
+		if len(args) > 0 {
+			o.Name = args[0]
+		}
 	}
 
 	if len(o.Name) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR fixes a bug where slice length was not checked before accessing its members, causing panics if the slice was empty.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1160

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
