### PR TITLE
Bumping golang version to v1.20.3 and making golint happy

### DIFF
--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-go@v3 # default version of go is 1.10
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - name: Install Carvel Tools
         run: ./hack/install-deps.sh
       # Run benchmark with `go test -bench` and stores the output to a file

--- a/.github/workflows/dependency-updater.yml
+++ b/.github/workflows/dependency-updater.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - name: Update Dependencies File
         run: go run ./hack/dependencies.go update
       - name: Create Pull Request

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.50.1
+          version: v1.52.2
           args: -v

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
 
       - name: Run release script
         run: |

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.6"
+        go-version: "1.20.3"
     - name: Check out code
       uses: actions/checkout@v3.3.0
       with:

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.6"
+        go-version: "1.20.3"
     - name: Check out code
       uses: actions/checkout@v3.3.0
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - name: Build the kapp-controller artifacts
         run: |
           ./hack/install-deps.sh

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - name: Check out code
         uses: actions/checkout@v3.3.0
       - name: Install Carvel Tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.6 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.20.3 AS deps
 
 ARG TARGETOS TARGETARCH KCTRL_VER=development
 WORKDIR /workspace

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-kapp-controller/cli
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cppforlife/cobrautil v0.0.0-20221130162803-acdfead391ef

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-kapp-controller
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fatih/color v1.13.0 // indirect

--- a/pkg/app/app_reconcile_test.go
+++ b/pkg/app/app_reconcile_test.go
@@ -250,7 +250,7 @@ func (f FakeComponentInfo) KappControllerVersion() (semver.Version, error) {
 	return f.KCVersion, nil
 }
 
-func (f FakeComponentInfo) KubernetesVersion(serviceAccountName string, specCluster *v1alpha1.AppCluster, objMeta *metav1.ObjectMeta) (semver.Version, error) {
+func (f FakeComponentInfo) KubernetesVersion(_ string, _ *v1alpha1.AppCluster, _ *metav1.ObjectMeta) (semver.Version, error) {
 	*f.K8sVersionCount++
 	return f.K8sVersion, nil
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -169,6 +169,6 @@ func (f FakeComponentInfo) KappControllerVersion() (semver.Version, error) {
 	return f.KCVersion, nil
 }
 
-func (f FakeComponentInfo) KubernetesVersion(serviceAccountName string, specCluster *v1alpha1.AppCluster, objMeta *metav1.ObjectMeta) (semver.Version, error) {
+func (f FakeComponentInfo) KubernetesVersion(_ string, _ *v1alpha1.AppCluster, _ *metav1.ObjectMeta) (semver.Version, error) {
 	return f.K8sVersion, nil
 }

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -56,7 +56,7 @@ func (r *Reconciler) AttachWatches(controller controller.Controller, ns string) 
 }
 
 // Reconcile gets the current config from the cluster and applies any changes.
-func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *Reconciler) Reconcile(_ context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := r.log.WithValues("request", request)
 
 	err := r.config.Reload()

--- a/pkg/deploy/factory.go
+++ b/pkg/deploy/factory.go
@@ -29,7 +29,7 @@ type KappConfiguration interface {
 
 // NewFactory returns deploy factory.
 func NewFactory(coreClient kubernetes.Interface, kubeconfig *kubeconfig.Kubeconfig,
-	kappConfig KappConfiguration, cmdRunner exec.CmdRunner, log logr.Logger) Factory {
+	kappConfig KappConfiguration, cmdRunner exec.CmdRunner, _ logr.Logger) Factory {
 
 	return Factory{coreClient, kappConfig, kubeconfig, cmdRunner}
 }

--- a/pkg/packageinstall/packageinstall_deletion_test.go
+++ b/pkg/packageinstall/packageinstall_deletion_test.go
@@ -87,6 +87,6 @@ func (f FakeComponentInfo) KappControllerVersion() (semver.Version, error) {
 	return f.KCVersion, nil
 }
 
-func (f FakeComponentInfo) KubernetesVersion(serviceAccountName string, specCluster *v1alpha1.AppCluster, objMeta *metav1.ObjectMeta) (semver.Version, error) {
+func (f FakeComponentInfo) KubernetesVersion(_ string, _ *v1alpha1.AppCluster, _ *metav1.ObjectMeta) (semver.Version, error) {
 	return f.K8sVersion, nil
 }

--- a/pkg/satoken/token_manager_test.go
+++ b/pkg/satoken/token_manager_test.go
@@ -209,7 +209,7 @@ type fakeTokenGetter struct {
 	err   error
 }
 
-func (ftg *fakeTokenGetter) getToken(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+func (ftg *fakeTokenGetter) getToken(_, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
 	ftg.count++
 	return ftg.tr, ftg.err
 }

--- a/pkg/sidecarexec/os_config.go
+++ b/pkg/sidecarexec/os_config.go
@@ -44,7 +44,7 @@ func NewOSConfig(log logr.Logger) OSConfig {
 
 // ApplyCACerts atomically updates existing CA certs file
 // with additional CA certs provided.
-func (r OSConfig) ApplyCACerts(chain string, unusedResult *int) error {
+func (r OSConfig) ApplyCACerts(chain string, _ *int) error {
 	r.log.Info("Applying CA certs")
 
 	origCopyFile, err := os.Open(r.CACertsLoc.OrigCopyPath)
@@ -94,7 +94,7 @@ type ProxyInput struct {
 }
 
 // ApplyProxy sets proxy related environment variables.
-func (r OSConfig) ApplyProxy(in ProxyInput, unusedResult *int) error {
+func (r OSConfig) ApplyProxy(in ProxyInput, _ *int) error {
 	vals := map[string]string{
 		"http_proxy":  in.HTTPProxy,
 		"https_proxy": in.HTTPSProxy,

--- a/pkg/sidecarexec/os_config_test.go
+++ b/pkg/sidecarexec/os_config_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func Test_TrustedCertsCreateConfig(t *testing.T) {
-	backup, certs, close, err := createCertTempFiles(t)
+	backup, certs, closeFile, err := createCertTempFiles(t)
 	assert.NoError(t, err)
-	defer close()
+	defer closeFile()
 
 	backup.Write([]byte("existing-cert"))
 
@@ -36,9 +36,9 @@ func Test_TrustedCertsCreateConfig(t *testing.T) {
 }
 
 func Test_TrustedCertsUpdateConfig(t *testing.T) {
-	backup, certs, close, err := createCertTempFiles(t)
+	backup, certs, closeFile, err := createCertTempFiles(t)
 	assert.NoError(t, err)
-	defer close()
+	defer closeFile()
 
 	backup.Write([]byte("existing-cert"))
 
@@ -66,9 +66,9 @@ func Test_TrustedCertsUpdateConfig(t *testing.T) {
 }
 
 func Test_TrustedCertsDeleteConfig(t *testing.T) {
-	backup, certs, close, err := createCertTempFiles(t)
+	backup, certs, closeFile, err := createCertTempFiles(t)
 	assert.NoError(t, err)
-	defer close()
+	defer closeFile()
 
 	backup.Write([]byte("existing-cert"))
 
@@ -89,7 +89,7 @@ func Test_TrustedCertsDeleteConfig(t *testing.T) {
 	assert.Equal(t, string(contents), "existing-cert\n")
 }
 
-func createCertTempFiles(t *testing.T) (backup *os.File, certs *os.File, close func(), err error) {
+func createCertTempFiles(_ *testing.T) (backup *os.File, certs *os.File, close func(), err error) {
 	backup, err = os.CreateTemp("", "backup.crt")
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/template/cue.go
+++ b/pkg/template/cue.go
@@ -43,7 +43,7 @@ func (c *cue) TemplateDir(dirPath string) (exec.CmdRunResult, bool) {
 
 // TemplateStream works on a stream returning templating result.
 // dirPath is provided for context from which to reference additional inputs.
-func (c *cue) TemplateStream(stream io.Reader, dirPath string) exec.CmdRunResult {
+func (c *cue) TemplateStream(_ io.Reader, _ string) exec.CmdRunResult {
 	return exec.NewCmdRunResultWithErr(fmt.Errorf("Templating stream is not supported")) // TODO: Implement
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Bumping go to 1.20.3 from 1.19.6 to fix the CVE's in go 1.19.6

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
