### PR TITLE
Unblock app deletion when ns is terminating and resources are in the same ns only

### DIFF
--- a/pkg/app/app_reconcile_test.go
+++ b/pkg/app/app_reconcile_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/metrics"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -232,12 +233,13 @@ func Test_TemplateError_DisplayedInStatus_UsefulErrorMessageProperty(t *testing.
 }
 
 type FakeComponentInfo struct {
-	KCVersion       semver.Version
-	KCVersionCount  *int
-	K8sVersion      semver.Version
-	K8sVersionCount *int
-	K8sAPIs         []string
-	K8sAPIsCount    *int
+	KCVersion          semver.Version
+	KCVersionCount     *int
+	K8sVersion         semver.Version
+	K8sVersionCount    *int
+	K8sAPIs            []string
+	K8sAPIsCount       *int
+	AppNamespaceStatus v1.NamespaceStatus
 }
 
 func (f FakeComponentInfo) KubernetesAPIs() ([]string, error) {
@@ -253,4 +255,8 @@ func (f FakeComponentInfo) KappControllerVersion() (semver.Version, error) {
 func (f FakeComponentInfo) KubernetesVersion(_ string, _ *v1alpha1.AppCluster, _ *metav1.ObjectMeta) (semver.Version, error) {
 	*f.K8sVersionCount++
 	return f.K8sVersion, nil
+}
+
+func (f FakeComponentInfo) NamespaceStatus(_ string) (v1.NamespaceStatus, error) {
+	return f.AppNamespaceStatus, nil
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/kubeconfig"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/reftracker"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/template"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -156,9 +157,10 @@ func Test_ConfigMapRefs_RetrievesNoConfigMapRefs_WhenNonePresent(t *testing.T) {
 }
 
 type FakeComponentInfo struct {
-	KCVersion  semver.Version
-	K8sVersion semver.Version
-	K8sAPIs    []string
+	KCVersion          semver.Version
+	K8sVersion         semver.Version
+	K8sAPIs            []string
+	AppNamespaceStatus v1.NamespaceStatus
 }
 
 func (f FakeComponentInfo) KubernetesAPIs() ([]string, error) {
@@ -171,4 +173,8 @@ func (f FakeComponentInfo) KappControllerVersion() (semver.Version, error) {
 
 func (f FakeComponentInfo) KubernetesVersion(_ string, _ *v1alpha1.AppCluster, _ *metav1.ObjectMeta) (semver.Version, error) {
 	return f.K8sVersion, nil
+}
+
+func (f FakeComponentInfo) NamespaceStatus(_ string) (v1.NamespaceStatus, error) {
+	return f.AppNamespaceStatus, nil
 }

--- a/pkg/componentinfo/component_info.go
+++ b/pkg/componentinfo/component_info.go
@@ -5,11 +5,13 @@
 package componentinfo
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k14s/semver/v4"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/kubeconfig"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -81,6 +83,15 @@ func (ci *ComponentInfo) KubernetesAPIs() ([]string, error) {
 	}
 
 	return metav1.ExtractGroupVersions(groups), nil
+}
+
+// NamespaceStatus returns the status of the App namespace
+func (ci *ComponentInfo) NamespaceStatus(name string) (v1.NamespaceStatus, error) {
+	namespace, err := ci.coreClient.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return v1.NamespaceStatus{}, err
+	}
+	return namespace.Status, nil
 }
 
 // parseAndScrubVersion parses version string and removes Pre and Build from the version

--- a/test/e2e/kappcontroller/namespace_deletion_test.go
+++ b/test/e2e/kappcontroller/namespace_deletion_test.go
@@ -1,0 +1,145 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kappcontroller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
+)
+
+func Test_NamespaceDelete_AppWithResourcesInSameNamespace(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+
+	nsName := "ns-delete"
+	name := "resources-in-same-namespace"
+
+	namespaceYAML := fmt.Sprintf(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %v`, nsName)
+
+	appYAML := fmt.Sprintf(`---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: %s
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - inline:
+      paths:
+        file.yml: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+           name: configmap
+           namespace: %s
+          data:
+           key: value
+  template:
+  - ytt: {}
+  deploy:
+  - kapp: {}`, name, nsName) + e2e.ServiceAccounts{nsName}.ForNamespaceYAML()
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+		kapp.Run([]string{"delete", "-a", nsName})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("create namespace and deploy App", func() {
+		kapp.RunWithOpts([]string{"deploy", "-a", nsName, "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(namespaceYAML)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--into-ns", nsName}, e2e.RunOpts{StdinReader: strings.NewReader(appYAML)})
+	})
+
+	logger.Section("delete namespace", func() {
+		kubectl.Run([]string{"delete", "ns", nsName, "--timeout=1m"})
+	})
+}
+
+func Test_NamespaceDelete_AppWithResourcesInDifferentNamespaces(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	kubectl := e2e.Kubectl{t, env.Namespace, logger}
+
+	nsName := "ns-delete"
+	name := "resources-in-different-namespaces"
+
+	namespaceYAML := fmt.Sprintf(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %v`, nsName)
+
+	appYaml := fmt.Sprintf(`---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: %s
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - inline:
+      paths:
+        file.yml: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+           name: configmap
+           namespace: %s
+          data:
+           key: value
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+           name: configmap
+           namespace: %s
+          data:
+           key: value
+  template:
+  - ytt: {}
+  deploy:
+  - kapp: {}`, name, nsName, env.Namespace) + e2e.ServiceAccounts{nsName}.ForClusterYAML()
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+
+	cleanUpTestNamespace := func() {
+		kubectl.Run([]string{"delete", "configmap", "configmap"})
+		kubectl.RunWithOpts([]string{"patch", "App", name, "--type=json", "--patch", `[{ "op": "replace", "path": "/spec/noopDelete", "value": true}]`,
+			"-n", nsName}, e2e.RunOpts{NoNamespace: true})
+		kapp.Run([]string{"delete", "-a", nsName})
+	}
+
+	cleanUp()
+	defer cleanUp()
+	defer cleanUpTestNamespace()
+
+	logger.Section("create namespace and deploy App", func() {
+		kapp.RunWithOpts([]string{"deploy", "-a", nsName, "-f", "-"}, e2e.RunOpts{StdinReader: strings.NewReader(namespaceYAML)})
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name, "--into-ns", nsName}, e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
+	})
+
+	logger.Section("delete namespace", func() {
+		// delete SA first to reduce flakiness, sometimes SA deletion happens after app is deleted
+		kubectl.RunWithOpts([]string{"delete", "serviceaccount", "kappctrl-e2e-ns-sa", "-n", nsName},
+			e2e.RunOpts{NoNamespace: true})
+		_, err := kubectl.RunWithOpts([]string{"delete", "ns", nsName, "--timeout=30s"},
+			e2e.RunOpts{AllowError: true})
+		assert.Error(t, err, "Expected to get time out error, but did not")
+	})
+}

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -51,3 +51,36 @@ roleRef:
   name: kappctrl-e2e-ns-role
 `, sa.Namespace)
 }
+
+// ForClusterYAML can be used to get service account with cluster wide permissions
+func (sa ServiceAccounts) ForClusterYAML() string {
+	return fmt.Sprintf(`
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kappctrl-e2e-ns-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kappctrl-e2e-ns-role
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kappctrl-e2e-ns-role-binding
+subjects:
+- kind: ServiceAccount
+  name: kappctrl-e2e-ns-sa
+  namespace: %s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kappctrl-e2e-ns-role
+`, sa.Namespace)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Unblock app deletion when ns is terminating and resources are in the same ns only. This partially fixes #1132.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
