### PR TITLE
Add --build-values to package release command

### DIFF
--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -36,6 +36,7 @@ type AppSpecBuilderOpts struct {
 	BundleTag     string
 
 	BuildYttValidations bool
+	BuildValues         string
 }
 
 func NewAppSpecBuilder(depsFactory cmdcore.DepsFactory, logger logger.Logger, ui cmdcore.AuthoringUI, opts AppSpecBuilderOpts) *AppSpecBuilder {
@@ -70,6 +71,16 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 	}
 	buildConfigs := cmdlocal.Configs{
 		Apps: []kcv1alpha1.App{builderApp},
+	}
+
+	if b.opts.BuildValues != "" && len(builderApp.Spec.Template) > 0 {
+		if builderApp.Spec.Template[0].Ytt != nil {
+			builderApp.Spec.Template[0].Ytt.ValuesFrom = append(builderApp.Spec.Template[0].Ytt.ValuesFrom,
+				kcv1alpha1.AppTemplateValuesSource{Path: b.opts.BuildValues})
+		} else if builderApp.Spec.Template[0].HelmTemplate != nil {
+			builderApp.Spec.Template[0].HelmTemplate.ValuesFrom = append(builderApp.Spec.Template[0].HelmTemplate.ValuesFrom,
+				kcv1alpha1.AppTemplateValuesSource{Path: b.opts.BuildValues})
+		}
 	}
 
 	// Make lock output directory if it does not exist

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -33,6 +33,7 @@ type ReleaseOptions struct {
 	debug                 bool
 	generateOpenAPISchema bool
 	buildYttValidations   bool
+	buildValues           string
 	tag                   string
 }
 
@@ -63,6 +64,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default build-<TIMESTAMP>)")
 	cmd.Flags().BoolVar(&o.generateOpenAPISchema, "openapi-schema", true, "Generates openapi schema for ytt and helm templated files and adds it to generated package")
 	cmd.Flags().BoolVar(&o.buildYttValidations, "build-ytt-validations", true, "Ignore ytt validation errors while releasing packages")
+	cmd.Flags().StringVar(&o.buildValues, "build-values", "", "Path to values file to be used while releasing package")
 
 	return cmd
 }
@@ -119,6 +121,7 @@ func (o *ReleaseOptions) Run() error {
 		Debug:               o.debug,
 		BundleTag:           o.tag,
 		BuildYttValidations: o.buildYttValidations,
+		BuildValues:         o.buildValues,
 	}
 	appSpec, err := cmdapprelease.NewAppSpecBuilder(o.depsFactory, o.logger, o.ui, builderOpts).Build()
 	if err != nil {

--- a/cli/test/e2e/build_values_test.go
+++ b/cli/test/e2e/build_values_test.go
@@ -1,0 +1,317 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestYttTemplateWithBuildValues(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	configYAML := `
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pkg-cm
+  namespace: #@ data.values.namespace
+data:
+  foo: bar
+`
+	schemaYAML := `
+#@data/values-schema
+---
+#@schema/validation min_len=1
+namespace: ""
+`
+	packageBuildYAML := fmt.Sprintf(`
+apiVersion: kctrl.carvel.dev/v1alpha1
+kind: PackageBuild
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com
+spec:
+  release:
+  - resource: {}
+  template:
+    spec:
+      app:
+        spec:
+          deploy:
+          - kapp: {}
+          template:
+          - ytt:
+              paths:
+              - config
+          - kbld: {}
+      export:
+      - imgpkgBundle:
+          image: %s
+          useKbldImagesLock: true
+        includePaths:
+        - config
+`, env.Image)
+	packageResourcesYAML := `
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com.0.0.0
+spec:
+  refName: samplepackage.corp.com
+  releasedAt: null
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - git: {}
+      template:
+      - ytt:
+        paths:
+        - config
+      - kbld: {}
+  valuesSchema:
+    openAPIv3: null
+  version: 0.0.0
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com
+spec:
+  displayName: samplepackage
+  longDescription: samplepackage.corp.com
+  shortDescription: samplepackage.corp.com
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    kctrl.carvel.dev/local-fetch-0: .
+  creationTimestamp: null
+  name: samplepackage
+spec:
+  packageRef:
+  refName: samplepackage.corp.com
+  versionSelection:
+    constraints: 0.0.0
+  serviceAccountName: samplepackage-sa
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0
+`
+
+	values := `
+namespace: test
+`
+
+	cleanUp := func() {
+		os.RemoveAll(workingDir)
+	}
+	cleanUp()
+	defer cleanUp()
+
+	configDir := "config"
+	err := os.Mkdir(workingDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Mkdir(path.Join(workingDir, configDir), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, configDir, "config.yaml"), []byte(configYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, configDir, "schema.yaml"), []byte(schemaYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, "package-build.yml"), []byte(packageBuildYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, "package-resources.yml"), []byte(packageResourcesYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Section("run package release without build values", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir}, RunOpts{NoNamespace: true, AllowError: true})
+		require.Error(t, err)
+	})
+
+	logger.Section("run package release with build values", func() {
+		err = os.WriteFile(path.Join(workingDir, "build-values.yml"), []byte(values), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify that validation checks are not performed while running ytt to build packages
+		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir, "--build-values", "build-values.yml"}, RunOpts{NoNamespace: true})
+	})
+}
+
+func TestHelmTemplateWithBuildValues(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	configYAML := `
+{{- $fooVal := .Values.fooVal | required ".Values.fooVal is required." -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm-1
+data:
+  foo {{ $fooVal }}
+`
+	chartYAML := `
+apiVersion: v1
+name: test-chart
+version: 1.0.0
+`
+	packageBuildYAML := fmt.Sprintf(`
+apiVersion: kctrl.carvel.dev/v1alpha1
+kind: PackageBuild
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com
+spec:
+  release:
+  - resource: {}
+  template:
+    spec:
+      app:
+        spec:
+          deploy:
+          - kapp: {}
+          template:
+          - helmTemplate:
+              path: config
+          - kbld: {}
+      export:
+      - imgpkgBundle:
+          image: %s
+          useKbldImagesLock: true
+        includePaths:
+        - config
+`, env.Image)
+	packageResourcesYAML := `
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com.0.0.0
+spec:
+  refName: samplepackage.corp.com
+  releasedAt: null
+  template:
+    spec:
+      deploy:
+      - kapp: {}
+      fetch:
+      - git: {}
+      template:
+      - helmTemplate:
+        path: config
+      - kbld: {}
+  valuesSchema:
+    openAPIv3: null
+  version: 0.0.0
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  creationTimestamp: null
+  name: samplepackage.corp.com
+spec:
+  displayName: samplepackage
+  longDescription: samplepackage.corp.com
+  shortDescription: samplepackage.corp.com
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  annotations:
+    kctrl.carvel.dev/local-fetch-0: .
+  creationTimestamp: null
+  name: samplepackage
+spec:
+  packageRef:
+  refName: samplepackage.corp.com
+  versionSelection:
+    constraints: 0.0.0
+  serviceAccountName: samplepackage-sa
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0
+`
+
+	values := `
+fooVal: bar
+`
+
+	cleanUp := func() {
+		os.RemoveAll(workingDir)
+	}
+	cleanUp()
+	defer cleanUp()
+
+	configDir := "config"
+	err := os.Mkdir(workingDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	templateDir := "templates"
+	err = os.Mkdir(path.Join(workingDir, configDir), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Mkdir(path.Join(workingDir, configDir, templateDir), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, configDir, templateDir, "config.yaml"), []byte(configYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, configDir, "Chart.yaml"), []byte(chartYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, "package-build.yml"), []byte(packageBuildYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(workingDir, "package-resources.yml"), []byte(packageResourcesYAML), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Section("run helm templated package release without build values", func() {
+		_, err := kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir}, RunOpts{NoNamespace: true, AllowError: true})
+		require.Error(t, err)
+	})
+
+	logger.Section("run helm templated package release with build values", func() {
+		err = os.WriteFile(path.Join(workingDir, "build-values.yml"), []byte(values), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kappCtrl.RunWithOpts([]string{"package", "release", "--chdir", workingDir, "--build-values", "build-values.yml"}, RunOpts{NoNamespace: true})
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Adds a flag that allows folks to supply values while releasing packages. We need this as there might be required values without defaults or values which introduce images that need to be supplied while releasing a Package.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1213 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
- Introduced `--build-values` flag for `package release` command
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
