### PR TITLE
Bumping Go version to 1.20.4

### DIFF
--- a/.github/workflows/benchmark-action.yaml
+++ b/.github/workflows/benchmark-action.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
       - uses: actions/setup-go@v4 # default version of go is 1.10
         with:
-          go-version: "1.20.3"
+          go-version: 1.20.4
       - name: Install Carvel Tools
         run: ./hack/install-deps.sh
       # Run benchmark with `go test -bench` and stores the output to a file

--- a/.github/workflows/dependency-updater.yml
+++ b/.github/workflows/dependency-updater.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.3"
+          go-version: 1.20.4
       - name: Update Dependencies File
         run: go run ./hack/dependencies.go update
       - name: Create Pull Request

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.3"
+          go-version: 1.20.4
       - uses: actions/checkout@v3.5.2
         with:
           fetch-depth: '0'

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.3"
+          go-version: 1.20.4
 
       - name: Run release script
         run: |

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: "1.20.3"
+        go-version: 1.20.4
     - name: Check out code
       uses: actions/checkout@v3.5.2
       with:

--- a/.github/workflows/test-kctrl-gh.yml
+++ b/.github/workflows/test-kctrl-gh.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: "1.20.3"
+        go-version: 1.20.4
     - name: Check out code
       uses: actions/checkout@v3.5.2
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.3"
+          go-version: 1.20.4
       - name: Build the kapp-controller artifacts
         run: |
           ./hack/install-deps.sh

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.3"
+          go-version: 1.20.4
       - name: Check out code
         uses: actions/checkout@v3.5.2
       - name: Install Carvel Tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.3 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.20.4 AS deps
 
 ARG TARGETOS TARGETARCH KCTRL_VER=development
 WORKDIR /workspace


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Bumping Go version to 1.20.4 to fix CVE's in go runtime 1.20.4

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
