### PR TITLE
Don't fallback to automatic noopDelete if cluster is set

### DIFF
--- a/pkg/app/app_deploy.go
+++ b/pkg/app/app_deploy.go
@@ -57,10 +57,13 @@ func (a *App) delete(changedFunc func(exec.CmdRunResult)) exec.CmdRunResult {
 
 	var result exec.CmdRunResult
 
+	appResourcesInSameNs := a.app.Status.Deploy != nil && a.app.Status.Deploy.KappDeployStatus != nil &&
+		len(a.app.Status.Deploy.KappDeployStatus.AssociatedResources.Namespaces) == 1 &&
+		a.app.Status.Deploy.KappDeployStatus.AssociatedResources.Namespaces[0] == a.app.Namespace
+
 	// Use noopDelete if the namespace is terminating and app resources are in same namespace because
 	// the app resources will be automatically deleted including the kapp ServiceAccount
-	noopDelete := a.isNamespaceTerminating() && a.app.Status.Deploy != nil && a.app.Status.Deploy.KappDeployStatus != nil &&
-		len(a.app.Status.Deploy.KappDeployStatus.AssociatedResources.Namespaces) == 1
+	noopDelete := a.isNamespaceTerminating() && appResourcesInSameNs && a.app.Spec.Cluster == nil
 
 	if !a.app.Spec.NoopDelete && !noopDelete {
 		for _, dep := range a.app.Spec.Deploy {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
When namespace is terminating
- Don't fallback to automatic noopDelete if cluster is set
- Check if the number of namespaces from kapp is 1 and is also the same where the App resides

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
