### PR TITLE
Make kctrl to exit smoothly on adding the package registry with no changes

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -190,6 +190,15 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 		return err
 	}
 
+	if o.URL == existingRepository.Spec.Fetch.ImgpkgBundle.Image {
+		repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{
+			PrintCurrentState: true,
+		})
+		err = repoWatcher.TailRepoStatus()
+		return err
+
+	}
+
 	pkgRepository, err := o.updateExistingPackageRepository(existingRepository)
 	if err != nil {
 		return err
@@ -271,7 +280,7 @@ func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *kcpkg.Package
 
 func (o *AddOrUpdateOptions) waitForPackageRepositoryInstallation(client kcclient.Interface) error {
 	o.statusUI.PrintMessagef("Waiting for package repository reconciliation for '%s'", o.Name)
-	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client)
+	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{})
 
 	err := repoWatcher.TailRepoStatus()
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -190,13 +190,8 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 		return err
 	}
 
-	if o.URL == existingRepository.Spec.Fetch.ImgpkgBundle.Image {
-		repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{
-			PrintCurrentState: true,
-		})
-		err = repoWatcher.TailRepoStatus()
-		return err
-
+	if o.URL != "" && o.URL == existingRepository.Spec.Fetch.ImgpkgBundle.Image {
+		return NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{PrintCurrentState: true}).TailRepoStatus()
 	}
 
 	pkgRepository, err := o.updateExistingPackageRepository(existingRepository)

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -104,7 +104,7 @@ func (o *DeleteOptions) Run(args []string) error {
 
 func (o *DeleteOptions) waitForDeletion(client versioned.Interface) error {
 	o.statusUI.PrintMessagef("Waiting for package repository reconciliation for '%s'", o.Name)
-	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client)
+	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{})
 
 	err := repoWatcher.TailRepoStatus()
 	if err != nil {

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -152,7 +152,7 @@ func (o *KickOptions) triggerReconciliation(client kcclient.Interface) error {
 
 func (o *KickOptions) waitForReconciliation(client kcclient.Interface) error {
 	o.statusUI.PrintMessagef("Waiting for package repository reconciliation for '%s'", o.Name)
-	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client)
+	repoWatcher := NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{})
 
 	err := repoWatcher.TailRepoStatus()
 	if err != nil {

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	uitest "github.com/cppforlife/go-cli-ui/ui/test"
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,14 @@ func TestPackageRepository(t *testing.T) {
 	})
 
 	logger.Section("adding of existing repository", func() {
-		kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL})
+		start := time.Now()
+		out := kappCtrl.Run([]string{"package", "repository", "add", "-r", pkgrName, "--url", pkgrURL})
+		elapsed := time.Since(start).Seconds()
+		require.Equal(t, elapsed < 5, true, "Adding of existing package repository takes more than 5 seconds")
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+		require.Contains(t, out, "Succeeded")
 	})
 
 	logger.Section("adding of existing repository with new url", func() {
@@ -161,7 +169,15 @@ func TestPackageRepository(t *testing.T) {
 	})
 
 	logger.Section("updating a repository with no change in url", func() {
-		kappCtrl.Run([]string{"package", "repository", "update", "-r", pkgrName, "--url", pkgrURL})
+		start := time.Now()
+		out := kappCtrl.Run([]string{"package", "repository", "update", "-r", pkgrName, "--url", pkgrURL})
+		elapsed := time.Since(start).Seconds()
+		require.Equal(t, elapsed < 5, true, "Adding of existing package repository takes more than 5 seconds")
+		require.Contains(t, out, "Fetch succeeded")
+		require.Contains(t, out, "Template succeeded")
+		require.Contains(t, out, "Deploy succeeded")
+		require.Contains(t, out, "Succeeded")
+
 	})
 
 	logger.Section("creating a repository in a new namespace that doesn't exist", func() {


### PR DESCRIPTION
Currently adding an existing package registry with no changes in url waits the kctrl until the reconciliation.
Made changes to kctrl to exit immediately with success response if there are no changes and reconciliation was successful last time and throw useful error message if the reconciliation was failed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1270 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
