### PR TITLE
Change default API port to 8443

### DIFF
--- a/config/values-schema.yml
+++ b/config/values-schema.yml
@@ -16,7 +16,7 @@ dangerousEnablePprof: false
 #@schema/desc "Comma separated list of cipher suites - empty for language defaults"
 tlsCipherSuites: ""
 #@schema/desc "API port"
-apiPort: 10350
+apiPort: 8443
 #@schema/desc "The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod"
 coreDNSIP: ""
 #@schema/desc "HostNetwork of kapp-controller deployment."


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes the default port that kapp-controller is listening at for API requests

#### Which issue(s) this PR fixes:
Fixes #1217 

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change
