### PR TITLE
Fixing the test case TestConfig_TrustCACerts ( ssl on is removed)

### DIFF
--- a/test/e2e/assets/https-server/server.yml
+++ b/test/e2e/assets/https-server/server.yml
@@ -80,9 +80,7 @@ data:
 
     http {
       server {
-        listen 443;
-
-        ssl on;
+        listen 443 ssl;
         ssl_certificate /etc/ssl/https-server.crt;
         ssl_certificate_key /etc/ssl/https-server.key;
         server_name https-svc.default.svc.cluster.local;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Removed `ssl on` from nginx.conf as this configuration is not supported anymore by nginx.
Replaced it with `listen 443 ssl`
#### Which issue(s) this PR fixes:
Fixing the test case TestConfig_TrustCACerts
Fixes #

#### Does this PR introduce a user-facing change?
None


#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
