### PR TITLE
Adding a hint when the APP CR installation fails due to ca cert error

### DIFF
--- a/config-dev/values-schema.yml
+++ b/config-dev/values-schema.yml
@@ -5,11 +5,11 @@
 #@schema/desc "Configuration explicitly for developing kapp-controller"
 dev:
   #@schema/desc "Whether to push images to the OCI registry or not"
-  push_images: false
+  push_images: true
   #@schema/desc "Whether to use the faster deployment type whilst developing (must have deployed to a cluster once fully first)"
   rapid_deploy: false
   #@schema/desc "Location of kapp-controller image"
-  image_repo: docker.io/k14s/kapp-controller-test
+  image_repo: docker.io/rohitagg2020/kapp-controller-test
   #@schema/desc "Development version"
   version: develop
   #@schema/desc "Comma separated list of supported architectures"

--- a/pkg/app/app_fetch.go
+++ b/pkg/app/app_fetch.go
@@ -8,9 +8,15 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
+)
+
+const (
+	addCACertMissingHintMsg = "(hint: The CA Certificate from URL is unknown. Add it to the kapp-controller configuration to reconcile successfully)"
+	caCertMissingError      = "x509: certificate signed by unknown authority"
 )
 
 func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
@@ -67,6 +73,9 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 			}
 		}
 		if result.Error != nil {
+			if strings.Contains(result.Stderr, caCertMissingError) {
+				result.Stderr = fmt.Sprintf("%s%s", result.Stderr, addCACertMissingHintMsg)
+			}
 			return "", result
 		}
 	}
@@ -74,6 +83,12 @@ func (a *App) fetch(dstPath string) (string, exec.CmdRunResult) {
 	// if only one fetch, update dstPath for backwards compatibility
 	if len(a.app.Spec.Fetch) == 1 && a.app.Spec.Fetch[0].Path == "" {
 		dstPath = path.Join(dstPath, "0")
+	}
+
+	if result.Error != nil {
+		if strings.Contains(result.Stderr, caCertMissingError) {
+			result.Stderr = fmt.Sprintf("%s%s", result.Stderr, addCACertMissingHintMsg)
+		}
 	}
 
 	return dstPath, result

--- a/test/e2e/kappcontroller/config_test.go
+++ b/test/e2e/kappcontroller/config_test.go
@@ -259,6 +259,91 @@ spec:
 	})
 }
 
+func TestConfig_NoCACerts(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{t, env.Namespace, logger}
+	sas := e2e.ServiceAccounts{env.Namespace}
+
+	name := "test-https"
+	pkgrName := "test-https-pkgr"
+	httpsServerName := "test-https-server"
+	configName := "test-config-trust-ca-config"
+
+	yaml1 := fmt.Sprintf(`---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: test-https
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - http:
+      # use https to exercise CA certificate validation
+      # When updating address, certs and keys must be regenerated
+      # for server and added to e2e/assets/https-server
+      url: https://https-svc.https-server.svc.cluster.local:443/deployment.yml
+  template:
+  - ytt: {}
+  deploy:
+  - kapp:
+      inspect: {}
+      intoNs: %s
+`, env.Namespace) + sas.ForNamespaceYAML()
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+		kapp.Run([]string{"delete", "-a", pkgrName})
+		kapp.Run([]string{"delete", "-a", configName})
+		kapp.Run([]string{"delete", "-a", httpsServerName})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy controller config to trust CA cert", func() {
+		config := `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kapp-controller-config
+  namespace: kapp-controller
+stringData:
+  # CA Cert is not present
+  caCerts:
+`
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", configName},
+			e2e.RunOpts{StdinReader: strings.NewReader(config)})
+
+		// Since config propagation is async, just wait a little bit
+		time.Sleep(2 * time.Second)
+	})
+
+	logger.Section("deploy https server with self signed certs", func() {
+		kapp.Run([]string{"deploy", "-f", "../assets/https-server/", "-a", httpsServerName})
+	})
+
+	logger.Section("deploy app that tries to fetch content from https server", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{
+			StdinReader:  strings.NewReader(yaml1),
+			AllowError:   true,
+			OnErrKubectl: []string{"get", "app/test-https", "-oyaml"},
+		})
+		assert.Error(t, err, "Expected fetching error")
+
+		var cr v1alpha1.App
+
+		out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
+		assert.NoError(t, yaml.Unmarshal([]byte(out), &cr))
+
+		assert.NotNil(t, cr.Status.Fetch)
+		assert.Equal(t, cr.Status.Fetch.ExitCode, 1)
+		assert.Contains(t, cr.Status.Fetch.Stderr, "x509: certificate signed by unknown authority")
+		assert.Contains(t, cr.Status.Fetch.Stderr, "(hint: The CA Certificate from URL is unknown. Add it to the kapp-controller configuration to reconcile successfully)")
+	})
+}
+
 func TestConfig_SkipTLSVerify(t *testing.T) {
 	env := e2e.BuildEnv(t)
 	logger := e2e.Logger{}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding a hint when the APP CR installation fails due to ca certificate not present in kapp controller

#### Which issue(s) this PR fixes:
With this change, app status will look like this whenever there is an error because kapp controller not able to fetch because of ca cert error:
```
$ kubectl get app/test-https -oyaml -n kapp-controller
apiVersion: kappctrl.k14s.io/v1alpha1
kind: App
metadata:
  annotations:
    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
    kapp.k14s.io/identity: v1;kapp-controller/kappctrl.k14s.io/App/test-https;kappctrl.k14s.io/v1alpha1
    creationTimestamp: "2023-10-10T17:54:17Z"
  generation: 1
  labels:
    kapp.k14s.io/app: "1696960456655542000"
    kapp.k14s.io/association: v1.6c8820c760920aa56c616f481c6e3a4f
  name: test-https
  namespace: kapp-controller
  resourceVersion: "151557"
  uid: 941ac597-2379-4be5-ba88-e2afe9d0fa7b
spec:
  deploy:
  - kapp:
      inspect: {}
      intoNs: kapp-controller
  fetch:
  - http:
      url: https://https-svc.https-server.svc.cluster.local:443/deployment.yml
  serviceAccountName: kappctrl-e2e-ns-sa
  template:
  - ytt: {}
status:
  conditions:
  - message: 'Fetching resources: Error (see .status.usefulErrorMessage for details)'
    status: "True"
    type: ReconcileFailed
  consecutiveReconcileFailures: 5
  fetch:
    error: 'Fetching resources: Error (see .status.usefulErrorMessage for details)'
    exitCode: 1
    startedAt: "2023-10-10T17:54:49Z"
    stderr: |-
      vendir: Error: Syncing directory '0':
        Syncing directory '.' with HTTP contents:
          Downloading URL:
            Initiating URL download:
              Get "https://https-svc.https-server.svc.cluster.local:443/deployment.yml": tls: failed to verify certificate: x509: certificate signed by unknown authority
      hint: The CA Certificate from URL is unknown, please add it to the kapp-controller configuration to reconcile successfully.
    updatedAt: "2023-10-10T17:54:49Z"
  friendlyDescription: 'Reconcile failed: Fetching resources: Error (see .status.usefulErrorMessage
    for details)'
  observedGeneration: 1
  usefulErrorMessage: |-
    vendir: Error: Syncing directory '0':
      Syncing directory '.' with HTTP contents:
        Downloading URL:
          Initiating URL download:
            Get "https://https-svc.https-server.svc.cluster.local:443/deployment.yml": tls: failed to verify certificate: x509: certificate signed by unknown authority
    hint: The CA Certificate from URL is unknown, please add it to the kapp-controller configuration to reconcile successfully.
```
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
