### PR TITLE
Fix usage of `--dangerous-allow-use-of-shared-namespace` in hint

### DIFF
--- a/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
+++ b/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
@@ -30,7 +30,7 @@ func (s *SecureNamespaceFlags) CheckForDisallowedSharedNamespaces(namespace stri
 		if namespace == ns {
 			return fmt.Errorf("Creating sensitive resources in a shared namespace (%s)"+
 				"(hint: Specify a namespace using the '-n' flag or use kubeconfig to change default namespace 'kubectl config set-context --current --namespace=private-namespace'."+
-				"Or use '--dangerous-allow-use-of-shared-namespace=%s' to allow use of shared namespace)", namespace, namespace)
+				"Or use '--dangerous-allow-use-of-shared-namespace' to allow use of shared namespace)", namespace)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

The example usage of `--dangerous-allow-use-of-shared-namespace` in the hint is wrong:

```
❯ kctrl package install --namespace default --package stuff --version 1.19.3 --package-install stuff
kctrl: Error: Creating sensitive resources in a shared namespace (default)(hint: Specify a namespace using the '-n' flag or use kubeconfig to change default namespace 'kubectl config set-context --current --namespace=private-namespace'.Or use '--dangerous-allow-use-of-shared-namespace=default' to allow use of shared namespace)
```

The issue in detail
```
use '--dangerous-allow-use-of-shared-namespace=default' to allow use of shared namespace
                                              ↑ this is wrong                         
```

Instead, simply show to toggle the dangerous flag:

```
❯ kctrl package install --namespace default --package gateway.ossistio.tanzu.vmware.com --version 1.19.3 --package-install gateway-ossistio
kctrl: Error: Creating sensitive resources in a shared namespace (default)(hint: Specify a namespace using the '-n' flag or use kubeconfig to change default namespace 'kubectl config set-context --current --namespace=private-namespace'.Or use '--dangerous-allow-use-of-shared-namespace' to allow use of shared namespace)
```

The new hint in detail
```
use '--dangerous-allow-use-of-shared-namespace' to allow use of shared namespace
                                             ↑ this is better
```


#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
