### PR TITLE
Adding os environment keys to cmd environment

### DIFF
--- a/cli/pkg/kctrl/local/detailed_cmd_runner.go
+++ b/cli/pkg/kctrl/local/detailed_cmd_runner.go
@@ -6,6 +6,7 @@ package local
 import (
 	"fmt"
 	"io"
+	"os"
 	goexec "os/exec"
 
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/exec"
@@ -27,6 +28,9 @@ func (r DetailedCmdRunner) Run(cmd *goexec.Cmd) error {
 		cmd.Stdout = io.MultiWriter(r.log, cmd.Stdout)
 		cmd.Stderr = io.MultiWriter(r.log, cmd.Stderr)
 	}
+
+	// Adding os environment keys to cmd environment
+	cmd.Env = append(os.Environ(), cmd.Env...)
 
 	fmt.Fprintf(r.log, "==> Executing %s %v\n", cmd.Path, cmd.Args)
 	defer fmt.Fprintf(r.log, "==> Finished executing %s\n\n", cmd.Path)

--- a/cli/test/e2e/dev_test.go
+++ b/cli/test/e2e/dev_test.go
@@ -19,6 +19,7 @@ func TestDev(t *testing.T) {
 	kapp := Kapp{t, env.Namespace, env.KappBinaryPath, logger}
 
 	appName := "dev-test"
+	gitAppName := "dev-gitapp-test"
 	saAppName := "dev-test"
 
 	sa := ServiceAccounts{env.Namespace}.ForNamespaceYAML()
@@ -47,8 +48,29 @@ spec:
         intoNs: kctrl-test
 `, appName)
 
+	gitAppYaml := fmt.Sprintf(`---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: %s
+  namespace: kctrl-test
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+  - git:
+      url: https://github.com/k14s/k8s-simple-app-example
+      ref: origin/develop
+      subPath: config-step-2-template
+  template:
+  - ytt: {}
+  deploy:
+  - kapp:
+      intoNs: kctrl-test
+`, gitAppName)
+
 	cleanUp := func() {
 		kapp.Run([]string{"delete", "-a", fmt.Sprintf("%s.app", appName)})
+		kapp.Run([]string{"delete", "-a", fmt.Sprintf("%s.app", gitAppName)})
 		kapp.Run([]string{"delete", "-a", saAppName})
 	}
 	cleanUp()
@@ -79,4 +101,105 @@ spec:
 		}
 		require.Exactly(t, expectedOutputRows, replaceAgeAndSinceDeployed(output.Tables[0].Rows))
 	})
+
+	logger.Section("dev deploy git app", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"dev", "-f", "-"}, RunOpts{StdinReader: strings.NewReader(gitAppYaml)})
+		fmt.Printf("\n\n Out: %s \n err: %+v ", out, err)
+	})
+
+	logger.Section("inspect gitApp app resources", func() {
+		out := kapp.Run([]string{"inspect", "-a", fmt.Sprintf("%s.app", gitAppName), "--json"})
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{
+			{
+				"age":             "<replaced>",
+				"kind":            "Deployment",
+				"name":            "simple-app",
+				"namespace":       "kctrl-test",
+				"owner":           "kapp",
+				"reconcile_info":  "",
+				"reconcile_state": "ok",
+			},
+			{
+				"age":             "<replaced>",
+				"kind":            "Endpoints",
+				"name":            "simple-app",
+				"namespace":       "kctrl-test",
+				"owner":           "cluster",
+				"reconcile_info":  "",
+				"reconcile_state": "ok",
+			},
+			{
+				"age":             "<replaced>",
+				"kind":            "Service",
+				"name":            "simple-app",
+				"namespace":       "kctrl-test",
+				"owner":           "kapp",
+				"reconcile_info":  "",
+				"reconcile_state": "ok",
+			},
+			{
+				"age":             "<replaced>",
+				"kind":            "ReplicaSet",
+				"name":            "simple-app",
+				"namespace":       "kctrl-test",
+				"owner":           "cluster",
+				"reconcile_info":  "",
+				"reconcile_state": "ok",
+			},
+			{
+				"age":             "<replaced>",
+				"kind":            "Pod",
+				"name":            "simple-app",
+				"namespace":       "kctrl-test",
+				"owner":           "cluster",
+				"reconcile_info":  "",
+				"reconcile_state": "ok",
+			},
+			{
+				"age":             "<replaced>",
+				"kind":            "EndpointSlice",
+				"name":            "simple-app",
+				"namespace":       "kctrl-test",
+				"owner":           "cluster",
+				"reconcile_info":  "",
+				"reconcile_state": "ok",
+			},
+		}
+
+		require.Len(t, output.Tables[0].Rows, 6)
+
+		deploymentItem := filterByKeyValuePair(output.Tables[0].Rows, "kind", "Deployment")
+		require.Exactly(t, expectedOutputRows[0], replaceAgeAndSinceDeployed(deploymentItem)[0])
+
+		endpointItem := filterByKeyValuePair(output.Tables[0].Rows, "kind", "Endpoints")
+		require.Exactly(t, expectedOutputRows[1], replaceAgeAndSinceDeployed(endpointItem)[0])
+
+		serviceItem := filterByKeyValuePair(output.Tables[0].Rows, "kind", "Service")
+		require.Exactly(t, expectedOutputRows[2], replaceAgeAndSinceDeployed(serviceItem)[0])
+
+		replicaSetItem := filterByKeyValuePair(output.Tables[0].Rows, "kind", "ReplicaSet")
+		replicaSetItem[0]["name"] = "simple-app"
+		require.Exactly(t, expectedOutputRows[3], replaceAgeAndSinceDeployed(replicaSetItem)[0])
+
+		podItem := filterByKeyValuePair(output.Tables[0].Rows, "kind", "Pod")
+		podItem[0]["name"] = "simple-app"
+		require.Exactly(t, expectedOutputRows[4], replaceAgeAndSinceDeployed(podItem)[0])
+
+		endpointSliceItem := filterByKeyValuePair(output.Tables[0].Rows, "kind", "EndpointSlice")
+		endpointSliceItem[0]["name"] = "simple-app"
+		require.Exactly(t, expectedOutputRows[5], replaceAgeAndSinceDeployed(endpointSliceItem)[0])
+	})
+}
+
+func filterByKeyValuePair(slice []map[string]string, key, value string) []map[string]string {
+	var filteredSlice []map[string]string
+
+	for _, item := range slice {
+		if item[key] == value {
+			filteredSlice = append(filteredSlice, item)
+		}
+	}
+	return filteredSlice
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
kctrl dev fails to install git package. The recent [change](https://github.com/carvel-dev/kapp-controller/commit/50caee3ca668c2d9cb84739174b5c8110cfc4b59) is required for running vendir inside a sidecar. But, the local reconciler running on the local machine, it requires env variables to find git binary in the path.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1339 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
NONE
```
