### PR TITLE
Updating default value for kube-api-qps, kube-api-burst, apply-concurrency and wait-concurrency for kapp

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,11 +164,16 @@ func (gc *Config) KappDeployRawOptions() []string {
 	gc.dataLock.RLock()
 	defer gc.dataLock.RUnlock()
 
+	kappOptions := make([]string, 0)
 	// Configure kapp to keep only 5 app changes as it seems that
 	// larger number of ConfigMaps negative affects other controllers on the cluster.
 	// Eventually kapp can be smart enough to keep minimal number of app changes.
 	// Set default first so that it can be overridden by user provided options.
-	return append([]string{"--app-changes-max-to-keep=5"}, gc.data.kappDeployRawOptions...)
+	kappOptions = append(kappOptions, "--app-changes-max-to-keep=5")
+	kappOptions = append(kappOptions, "--kube-api-qps=50", "--kube-api-burst=100")
+	kappOptions = append(kappOptions, gc.data.kappDeployRawOptions...)
+
+	return kappOptions
 }
 
 // AppDefaultSyncPeriod returns duration that is used by Apps

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -171,6 +171,7 @@ func (gc *Config) KappDeployRawOptions() []string {
 	// Set default first so that it can be overridden by user provided options.
 	kappOptions = append(kappOptions, "--app-changes-max-to-keep=5")
 	kappOptions = append(kappOptions, "--kube-api-qps=50", "--kube-api-burst=100")
+	kappOptions = append(kappOptions, "--apply-concurrency=10", "--wait-concurrency=10")
 	kappOptions = append(kappOptions, gc.data.kappDeployRawOptions...)
 
 	return kappOptions

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,6 +166,7 @@ func Test_NewConfig_AppMinimumSyncPeriod(t *testing.T) {
 }
 
 func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
+	defaultRawOptions := []string{"--app-changes-max-to-keep=5", "--kube-api-qps=50", "--kube-api-burst=100"}
 	t.Run("with empty config value, returns just default", func(t *testing.T) {
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -176,7 +177,7 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 		}
 		config, err := kcconfig.NewConfig(k8sfake.NewSimpleClientset(secret))
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5"}, config.KappDeployRawOptions())
+		assert.Equal(t, defaultRawOptions, config.KappDeployRawOptions())
 	})
 
 	t.Run("with empty config value, returns just default", func(t *testing.T) {
@@ -206,7 +207,10 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 		}
 		config, err := kcconfig.NewConfig(k8sfake.NewSimpleClientset(secret))
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5", "--key=val"}, config.KappDeployRawOptions())
+		var expRawOptions []string
+		expRawOptions = append(expRawOptions, defaultRawOptions...)
+		expRawOptions = append(expRawOptions, "--key=val")
+		assert.Equal(t, expRawOptions, config.KappDeployRawOptions())
 	})
 
 	t.Run("clears previously set value when secret is gone", func(t *testing.T) {
@@ -223,14 +227,17 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 
 		config, err := kcconfig.NewConfig(client)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5", "--key=val"}, config.KappDeployRawOptions())
+		var expRawOptions []string
+		expRawOptions = append(expRawOptions, defaultRawOptions...)
+		expRawOptions = append(expRawOptions, "--key=val")
+		assert.Equal(t, expRawOptions, config.KappDeployRawOptions())
 
 		err = client.CoreV1().Secrets("default").Delete(
 			context.Background(), "kapp-controller-config", metav1.DeleteOptions{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, config.Reload())
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5"}, config.KappDeployRawOptions())
+		assert.Equal(t, defaultRawOptions, config.KappDeployRawOptions())
 	})
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -192,7 +192,7 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 		}
 		config, err := kcconfig.NewConfig(k8sfake.NewSimpleClientset(secret))
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5"}, config.KappDeployRawOptions())
+		assert.Equal(t, defaultRawOptions, config.KappDeployRawOptions())
 	})
 
 	t.Run("with populated config value, returns default and user set", func(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,7 +166,10 @@ func Test_NewConfig_AppMinimumSyncPeriod(t *testing.T) {
 }
 
 func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
-	defaultRawOptions := []string{"--app-changes-max-to-keep=5", "--kube-api-qps=50", "--kube-api-burst=100"}
+	defaultRawOptions := []string{
+		"--app-changes-max-to-keep=5", "--kube-api-qps=50", "--kube-api-burst=100",
+		"--apply-concurrency=10", "--wait-concurrency=10",
+	}
 	t.Run("with empty config value, returns just default", func(t *testing.T) {
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR is changing the default values kapp parameters when invoked from kapp-controller. Below table proposed the default values for kapp and proposed values for bigger packages.

| -- | Current Default | Proposed Default | Values for large Package |
|--------|--------|--------|--------|
| kube-api-qps | 1000 | 50 | 200 |
| kube-api-burst | 1000 | 100 | 400 |
| apply-concurrency | 5 | 10 | 15 |
| wait-concurrency | 5 | 10 | 15 | 

Reasoning behind changes:
- for kube-api-qps and kube-api-burst
   - Kapp client is used in kapp-controller for App reconciliation. kapp-controller has by default App CR concurrency of 10. so total api-qps is 10k (1000 qps x 10 App CR concurrency) and burst-qps is 10k. This high qps can overload apiserver and cause slowness in cluster (not just for kapp-controller but other user of apiserver in cluster).
   - With lower default values of 50 for qps and 100 for burst, we limit the total api-qps to 500 and 1000 when AppCR concurrency = 10.
   - Also for any small to medium App (having less than 100 resources), the api-qps of 50 and burst of 100 are sufficient and don't cause slowness in reconcile time. 
   - Any large Package/App (having more than 100 resources), the default values can be changed in the Package itself.
   
- for apply concurrency and wait concurrency
  - With increased concurrency to 10, reconcile times will be reduced.
  - With a large app, this effect is clearly seen (see below results).
  - With a small to medium app, the effect is not seen much.


- Test results with different apps.
  - Test with varying qps
 
| QPS vs Reconcile time | qps=5 burst=5 | qps=50 burst=100 | qps=1000 burst=1000 |
|--------|--------|--------|--------|
| 500 inst of simple App with 1 job sleeping for 30s | 32min | 30min 30s | 30mins 15s |
| 500 inst of kapp-controller deployed on other cluster | 10min 45s | 9min 45s | 9min 45s |
| 1 inst of App having 500 namespace, configmap,secrets,roles, rolebind,serviceaccount | -- | 6min 30s | 2min |

  - Test with varying qps and concurrency
  
  - Test with kapp-controller app deployed in other cluster.

| App: | kapp-controller | 500 instances |   |  
| -- | -- | -- | -- | --
| pkgs in global ns | 600 | 500 + 100 |   |  
|  |   |   |   |  
| apply concurrency | wait concurrency | kube-api-qps | kube-burst-qps | reconcile time(avg)|
| 5 | 5 | 1000 | 1000 | 9mins |
| 5 | 5 | 50 | 100 | 9mins | 
| 10 | 10 | 50 | 100 | 9mins 15s |
| 10 | 10 | 1000 | 1000 | 9mins |

  -  Test with kube-prometheus-stack helm chart deployed as an app (medium sized app)

| App | kube-prometheus-stack |  |   |   |   |   |   |   |  
| -- | -- | -- | -- | -- | -- | -- | -- | -- | --
|   |   |   |   |   |   |   |   |   |  
| apply concurrency | wait concurrency | kube-api-qps | kube-burst-qps | reconcile time(avg) |   | run1 | run2 | run3 | run4
| 5 | 5 | 1000 | 1000 | 29.5s |   | 28s | 33s | 24s | 33s
| 10 | 10 | 50 | 100 | 30.7s |   | 24s | 34s | 36s | 29s
| 10 | 10 | 100 | 200 | 25.2s |   | 23s | 33s | 23s | 22s
| 10 | 10 | 1000 | 1000 | 26.0s |   | 32s | 21s | 30s | 21s


  - Test with large app deploying 4k resources
  
| App | kapp-meta-app |   |   |  
| -- | -- | -- | -- | --
| App contents | 500 nos of each - ns, sa, role, rolebind, 3 secrets, 1 configmap | around 4k resources in total |   |  
|  |   |   |   |  
| apply concurrency | wait concurrency | kube-api-qps | kube-burst-qps | reconcile time (avg)
| 5(Default) | 5(default) | 1000(default) | 1000 (default) | 2 mins
| 5(Default) | 5(default) | 50 | 100 | 6 min 30s
| 10 | 10 | 50 | 100 | 6min 40s
| 10 | 10 | 1000(default) | 1000 (default) | 1min 30s
| 10 | 10 | 100 | 200 | 3 mins 10s
| 10 | 10 | 200 | 400 | 1 min 30s


#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
None
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
