### PR TITLE
updating default value for apply-timeout option for kapp to 5mins

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,11 +164,17 @@ func (gc *Config) KappDeployRawOptions() []string {
 	gc.dataLock.RLock()
 	defer gc.dataLock.RUnlock()
 
+	kappOptions := make([]string, 0)
+
 	// Configure kapp to keep only 5 app changes as it seems that
 	// larger number of ConfigMaps negative affects other controllers on the cluster.
 	// Eventually kapp can be smart enough to keep minimal number of app changes.
 	// Set default first so that it can be overridden by user provided options.
-	return append([]string{"--app-changes-max-to-keep=5"}, gc.data.kappDeployRawOptions...)
+	// return append([]string{"--app-changes-max-to-keep=5"}, gc.data.kappDeployRawOptions...)
+	kappOptions = append(kappOptions, "--app-changes-max-to-keep=5")
+	kappOptions = append(kappOptions, "--apply-timeout=5m")
+	kappOptions = append(kappOptions, gc.data.kappDeployRawOptions...)
+	return kappOptions
 }
 
 // AppDefaultSyncPeriod returns duration that is used by Apps

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,6 +166,9 @@ func Test_NewConfig_AppMinimumSyncPeriod(t *testing.T) {
 }
 
 func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
+	defaultRawOptions := []string{
+		"--app-changes-max-to-keep=5", "--apply-timeout=5m",
+	}
 	t.Run("with empty config value, returns just default", func(t *testing.T) {
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -176,7 +179,7 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 		}
 		config, err := kcconfig.NewConfig(k8sfake.NewSimpleClientset(secret))
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5"}, config.KappDeployRawOptions())
+		assert.Equal(t, defaultRawOptions, config.KappDeployRawOptions())
 	})
 
 	t.Run("with empty config value, returns just default", func(t *testing.T) {
@@ -191,7 +194,7 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 		}
 		config, err := kcconfig.NewConfig(k8sfake.NewSimpleClientset(secret))
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5"}, config.KappDeployRawOptions())
+		assert.Equal(t, defaultRawOptions, config.KappDeployRawOptions())
 	})
 
 	t.Run("with populated config value, returns default and user set", func(t *testing.T) {
@@ -206,7 +209,7 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 		}
 		config, err := kcconfig.NewConfig(k8sfake.NewSimpleClientset(secret))
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5", "--key=val"}, config.KappDeployRawOptions())
+		assert.Equal(t, appendNewSlice(defaultRawOptions, "--key=val"), config.KappDeployRawOptions())
 	})
 
 	t.Run("clears previously set value when secret is gone", func(t *testing.T) {
@@ -223,15 +226,21 @@ func Test_NewConfig_KappDeployRawOptions(t *testing.T) {
 
 		config, err := kcconfig.NewConfig(client)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5", "--key=val"}, config.KappDeployRawOptions())
+		assert.Equal(t, appendNewSlice(defaultRawOptions, "--key=val"), config.KappDeployRawOptions())
 
 		err = client.CoreV1().Secrets("default").Delete(
 			context.Background(), "kapp-controller-config", metav1.DeleteOptions{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, config.Reload())
-		assert.Equal(t, []string{"--app-changes-max-to-keep=5"}, config.KappDeployRawOptions())
+		assert.Equal(t, defaultRawOptions, config.KappDeployRawOptions())
 	})
+}
+
+func appendNewSlice(act []string, items ...string) []string {
+	newslice := make([]string, 0)
+	newslice = append(newslice, act...)
+	return append(newslice, items...)
 }
 
 func Test_NewConfig_ReturnsConfigMap_WhenOnlyConfigMapExists(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Existing default value for kapp apply-timeout is 15minutes.
Reducing it to a reasonable time to reduce issues where controller queue is hogged by a very slow or stuck apps (for eg. with incorrect conditions which cannot be met).  
Reduced timeout will ensure queue is freed up faster.
In rare cases, if packages need higher apply-timeout, then it can be fed in as part of Package manifests.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
