### PR TITLE
Don't use a string as the OpenAPI default value for Helm values with an empty object default

### DIFF
--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen.go
@@ -180,7 +180,7 @@ func (h HelmValuesSchemaGen) calculateProperties(key *yaml3.Node, value *yaml3.N
 		if len(properties) > 0 {
 			apiKeys = append(apiKeys, &MapItem{Key: propertiesKey, Value: &Map{Items: properties}})
 		} else {
-			apiKeys = append(apiKeys, &MapItem{Key: defaultKey, Value: "{}"})
+			apiKeys = append(apiKeys, &MapItem{Key: defaultKey, Value: &Map{}})
 		}
 	case yaml3.SequenceNode:
 		apiKeys = append(apiKeys, &MapItem{Key: typeKey, Value: arrayVal})

--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
@@ -81,6 +81,8 @@ arrExample:
 floatExample: 2.3
 # Integer example
 intExample: 3
+# Object example
+objExample: {}
 `,
 			want: `properties:
   arrExample:
@@ -111,6 +113,10 @@ intExample: 3
     default: test-container
     description: Container name
     type: string
+  objExample:
+    default: {}
+    description: Object example
+    type: object
 type: object
 `},
 		{

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -260,7 +260,7 @@ spec:
         operator:
           properties:
             affinity:
-              default: '{}'
+              default: {}
               type: object
             createOperatorServiceAccount:
               default: true
@@ -281,7 +281,7 @@ spec:
                 objects like Deployment, ServiceAccount, Role etc.
               type: string
             nodeSelector:
-              default: '{}'
+              default: {}
               type: object
             operator_image_name:
               default: mongodb-enterprise-operator
@@ -817,7 +817,7 @@ spec:
           default: ""
           type: string
         podAnnotations:
-          default: '{}'
+          default: {}
           type: object
         replicaCount:
           default: 1
@@ -834,7 +834,7 @@ spec:
         serviceAccount:
           properties:
             annotations:
-              default: '{}'
+              default: {}
               description: Annotations to add to the service account
               type: object
             create:


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes the translation of empty object Helm default values into OpenAPI. Empty objects were getting the string `"{}"` as their default, which is not a valid value. We now correctly use `{}`.

#### Which issue(s) this PR fixes:

Fixes #1448

#### Does this PR introduce a user-facing change?

```release-note
`kctrl`: Helm values with an empty object as their default now get correctly defaulted in OpenAPI.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] ~~Relevant docs in this repo added or updated~~
- [ ] ~~Relevant carvel.dev docs added or updated in a separate PR and there's a link to that PR~~
- [x] Code is at least as readable and maintainable as it was before this change
