### PR TITLE
changed e2e Tests Retry to iteration count

### DIFF
--- a/test/e2e/kappcontroller/app_secret_configmap_reconcile_test.go
+++ b/test/e2e/kappcontroller/app_secret_configmap_reconcile_test.go
@@ -95,7 +95,7 @@ stringData:
 	})
 
 	logger.Section("check App uses new secret", func() {
-		retry(t, 10*time.Second, func() error {
+		retry(t, 10, func() error {
 			out := kubectl.Run([]string{"get", "configmap/configmap", "-o", "yaml"})
 
 			var cm corev1.ConfigMap
@@ -193,7 +193,7 @@ data:
 	})
 
 	logger.Section("check App uses new configmap", func() {
-		retry(t, 10*time.Second, func() error {
+		retry(t, 10, func() error {
 			out := kubectl.Run([]string{"get", "configmap/configmap", "-o", "yaml"})
 
 			var cm corev1.ConfigMap
@@ -210,17 +210,14 @@ data:
 	})
 }
 
-func retry(t *testing.T, timeout time.Duration, f func() error) {
+func retry(t *testing.T, maxRetries int, f func() error) {
 	var err error
-	stopTime := time.Now().Add(timeout)
-	for {
+	for i := 0; i < maxRetries; i++ {
 		err = f()
 		if err == nil {
 			return
 		}
-		if time.Now().After(stopTime) {
-			t.Fatalf("retry timed out after %s: %v", timeout.String(), err)
-		}
 		time.Sleep(1 * time.Second)
 	}
+	t.Fatalf("retry failed after %d attempts: %v", maxRetries, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
The `retry` function in e2e tests has been updated to use a counter instead of a time duration for retries
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #351

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
