### PR TITLE
Remove options that can be manipulated downstream

### DIFF
--- a/cli/pkg/kctrl/cmd/app/delete.go
+++ b/cli/pkg/kctrl/cmd/app/delete.go
@@ -57,7 +57,6 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    true,
 	})
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/app/kick.go
+++ b/cli/pkg/kctrl/cmd/app/kick.go
@@ -50,7 +50,6 @@ func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    true,
 	})
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/core/config_factory.go
+++ b/cli/pkg/kctrl/cmd/core/config_factory.go
@@ -29,9 +29,6 @@ type ConfigFactoryImpl struct {
 
 	qps   float32
 	burst int
-
-	defaultKubeconfigOverridePath    string
-	defaultKubeconfigOverrideContext string
 }
 
 var _ ConfigFactory = &ConfigFactoryImpl{}
@@ -50,11 +47,6 @@ func (f *ConfigFactoryImpl) ConfigureContextResolver(resolverFunc func() (string
 
 func (f *ConfigFactoryImpl) ConfigureYAMLResolver(resolverFunc func() (string, error)) {
 	f.yamlResolverFunc = resolverFunc
-}
-
-func (f *ConfigFactoryImpl) ConfigureKubeconfigOverrides(defaultKubeconfigOverridePath string, defaultKubeconfigOverrideContext string) {
-	f.defaultKubeconfigOverridePath = defaultKubeconfigOverridePath
-	f.defaultKubeconfigOverrideContext = defaultKubeconfigOverrideContext
 }
 
 func (f *ConfigFactoryImpl) ConfigureClient(qps float32, burst int) {
@@ -130,11 +122,6 @@ func (f *ConfigFactoryImpl) clientConfig() (bool, clientcmd.ClientConfig, error)
 	// Based on https://github.com/kubernetes/kubernetes/blob/30c7df5cd822067016640aa267714204ac089172/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L124
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	overrides := &clientcmd.ConfigOverrides{}
-
-	if len(path) == 0 && len(context) == 0 && f.defaultKubeconfigOverrideContext != "" && f.defaultKubeconfigOverridePath != "" {
-		path = f.defaultKubeconfigOverridePath
-		context = f.defaultKubeconfigOverrideContext
-	}
 
 	if len(path) > 0 {
 		loadingRules.ExplicitPath = path

--- a/cli/pkg/kctrl/cmd/core/examples.go
+++ b/cli/pkg/kctrl/cmd/core/examples.go
@@ -15,12 +15,7 @@ type PackageCommandTreeOpts struct {
 	Color bool
 	JSON  bool
 
-	DefaultKubeconfigOverridePath    string
-	DefaultKubeconfigOverrideContext string
-
-	DefaultServiceAcccountName string
-	WaitByDefault              bool
-	AllowSharedNamespaces      bool
+	AlwaysAllowTogglingWait bool
 }
 
 type Example struct {

--- a/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
+++ b/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
@@ -18,8 +18,8 @@ type SecureNamespaceFlags struct {
 	AllowedSharedNamespaces bool
 }
 
-func (s *SecureNamespaceFlags) Set(cmd *cobra.Command, defaultVal bool) {
-	cmd.Flags().BoolVar(&s.AllowedSharedNamespaces, "dangerous-allow-use-of-shared-namespace", defaultVal, "Allow use of shared namespaces")
+func (s *SecureNamespaceFlags) Set(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&s.AllowedSharedNamespaces, "dangerous-allow-use-of-shared-namespace", false, "Allow use of shared namespaces")
 }
 
 func (s *SecureNamespaceFlags) CheckForDisallowedSharedNamespaces(namespace string) error {

--- a/cli/pkg/kctrl/cmd/core/wait_flags.go
+++ b/cli/pkg/kctrl/cmd/core/wait_flags.go
@@ -19,14 +19,13 @@ type WaitFlagsOpts struct {
 	AllowDisableWait bool
 	DefaultInterval  time.Duration
 	DefaultTimeout   time.Duration
-	WaitByDefault    bool
 }
 
 func (f *WaitFlags) Set(cmd *cobra.Command, flagsFactory FlagsFactory, opts *WaitFlagsOpts) {
-	if opts.AllowDisableWait || !opts.WaitByDefault {
-		cmd.Flags().BoolVar(&f.Enabled, "wait", opts.WaitByDefault, "Wait for reconciliation to complete")
+	if opts.AllowDisableWait {
+		cmd.Flags().BoolVar(&f.Enabled, "wait", true, "Wait for reconciliation to complete")
 	}
-	f.Enabled = opts.WaitByDefault
+	f.Enabled = true
 	cmd.Flags().DurationVar(&f.CheckInterval, "wait-check-interval", opts.DefaultInterval, "Amount of time to sleep between checks while waiting")
 	cmd.Flags().DurationVar(&f.Timeout, "wait-timeout", opts.DefaultTimeout, "Maximum amount of time to wait in wait phase")
 }

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -76,7 +76,7 @@ func NewKctrlCmd(o *KctrlOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comm
 		cmdcore.RestOfCommandsHelpGroup,
 	}))
 
-	pkgOpts := cmdcore.PackageCommandTreeOpts{BinaryName: "kctrl", Color: true, JSON: true, WaitByDefault: true}
+	pkgOpts := cmdcore.PackageCommandTreeOpts{BinaryName: "kctrl", Color: true, JSON: true}
 
 	setGlobalFlags(o, cmd, flagsFactory, pkgOpts)
 
@@ -227,7 +227,6 @@ func AttachGlobalFlags(o *KctrlOptions, cmd *cobra.Command, flagsFactory cmdcore
 
 func AttachKctrlPackageCommandTree(cmd *cobra.Command, confUI *ui.ConfUI, opts cmdcore.PackageCommandTreeOpts) {
 	configFactory := cmdcore.NewConfigFactoryImpl()
-	configFactory.ConfigureKubeconfigOverrides(opts.DefaultKubeconfigOverridePath, opts.DefaultKubeconfigOverrideContext)
 	depsFactory := cmdcore.NewDepsFactoryImpl(configFactory, confUI)
 	options := NewKctrlOptions(confUI, configFactory, depsFactory)
 	flagsFactory := cmdcore.NewFlagsFactory(configFactory, depsFactory)

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -88,7 +88,7 @@ func NewCreateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
-	o.SecureNamespaceFlags.Set(cmd, o.pkgCmdTreeOpts.AllowSharedNamespaces)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name (required)")
@@ -99,7 +99,7 @@ func NewCreateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 
 	cmd.Flags().StringVarP(&o.packageName, "package", "p", "", "Set package name (required)")
 	cmd.Flags().StringVarP(&o.version, "version", "v", "", "Set package version (required)")
-	cmd.Flags().StringVar(&o.serviceAccountName, "service-account-name", o.pkgCmdTreeOpts.DefaultServiceAcccountName, "Name of an existing service account used to install underlying package contents, optional")
+	cmd.Flags().StringVar(&o.serviceAccountName, "service-account-name", "", "Name of an existing service account used to install underlying package contents, optional")
 	cmd.Flags().StringVar(&o.valuesFile, "values-file", "", "The path to the configuration values file, optional")
 	cmd.Flags().BoolVar(&o.values, "values", true, "Add or keep values supplied to package install, optional")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print YAML for resources being applied to the cluster without applying them, optional")
@@ -108,7 +108,6 @@ func NewCreateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   30 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 	o.YttOverlayFlags.Set(cmd)
 
@@ -135,7 +134,7 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
-	o.SecureNamespaceFlags.Set(cmd, o.pkgCmdTreeOpts.AllowSharedNamespaces)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name (required)")
@@ -146,7 +145,7 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 
 	cmd.Flags().StringVarP(&o.packageName, "package", "p", "", "Set package name (required)")
 	cmd.Flags().StringVarP(&o.version, "version", "v", "", "Set package version (required)")
-	cmd.Flags().StringVar(&o.serviceAccountName, "service-account-name", o.pkgCmdTreeOpts.DefaultServiceAcccountName, "Name of an existing service account used to install underlying package contents, optional")
+	cmd.Flags().StringVar(&o.serviceAccountName, "service-account-name", "", "Name of an existing service account used to install underlying package contents, optional")
 	cmd.Flags().StringVar(&o.valuesFile, "values-file", "", "The path to the configuration values file, optional")
 	cmd.Flags().BoolVar(&o.values, "values", true, "Add or keep values supplied to package install, optional")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print YAML for resources being applied to the cluster without applying them, optional")
@@ -155,7 +154,6 @@ func NewInstallCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) 
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   30 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 	o.YttOverlayFlags.Set(cmd)
 
@@ -181,7 +179,7 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 			cmdcore.PackageManagementCommandsHelpGroup.Key: cmdcore.PackageManagementCommandsHelpGroup.Value},
 	}
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
-	o.SecureNamespaceFlags.Set(cmd, o.pkgCmdTreeOpts.AllowSharedNamespaces)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "package-install", "i", "", "Set installed package name")
@@ -199,7 +197,6 @@ func NewUpdateCmd(o *CreateOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   30 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 	o.YttOverlayFlags.Set(cmd)
 

--- a/cli/pkg/kctrl/cmd/package/installed/delete.go
+++ b/cli/pkg/kctrl/cmd/package/installed/delete.go
@@ -72,10 +72,9 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 	}
 
 	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
-		AllowDisableWait: false,
+		AllowDisableWait: false || o.pkgCmdTreeOpts.AlwaysAllowTogglingWait,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -96,7 +96,6 @@ func NewKickCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobra
 		AllowDisableWait: true,
 		DefaultInterval:  2 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -65,7 +65,7 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
-	o.SecureNamespaceFlags.Set(cmd, o.pkgCmdTreeOpts.AllowSharedNamespaces)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set package repository name (required)")
@@ -84,7 +84,6 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 
 	o.CreateRepository = true
@@ -107,7 +106,7 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 	}
 
 	o.NamespaceFlags.SetWithPackageCommandTreeOpts(cmd, flagsFactory, o.pkgCmdTreeOpts)
-	o.SecureNamespaceFlags.Set(cmd, o.pkgCmdTreeOpts.AllowSharedNamespaces)
+	o.SecureNamespaceFlags.Set(cmd)
 
 	if !o.pkgCmdTreeOpts.PositionalArgs {
 		cmd.Flags().StringVarP(&o.Name, "repository", "r", "", "Set package repository name (required)")
@@ -122,7 +121,6 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -62,7 +62,6 @@ func NewDeleteCmd(o *DeleteOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Co
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 
 	return cmd

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -65,7 +65,6 @@ func NewKickCmd(o *KickOptions, flagsFactory cmdcore.FlagsFactory) *cobra.Comman
 		AllowDisableWait: true,
 		DefaultInterval:  1 * time.Second,
 		DefaultTimeout:   5 * time.Minute,
-		WaitByDefault:    o.pkgCmdTreeOpts.WaitByDefault,
 	})
 
 	return cmd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR removes options manipulating flag defaults as these can be manipulated downstream using attached pre functions set yup while attaching the command tree

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
