### PR TITLE
Make sure array Helm values always get an `items` field in OpenAPI schema

### DIFF
--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen.go
@@ -203,6 +203,8 @@ func (h HelmValuesSchemaGen) calculateProperties(key *yaml3.Node, value *yaml3.N
 				return nil, err
 			}
 			apiKeys = append(apiKeys, &MapItem{Key: itemsKey, Value: calculatedProperties})
+		} else {
+			apiKeys = append(apiKeys, &MapItem{Key: itemsKey, Value: &Map{}})
 		}
 	case yaml3.ScalarNode:
 		defaultVal, err := h.getDefaultValue(value.Tag, value.Value)

--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
@@ -39,8 +39,13 @@ arrKeyWithIntValues:
 arrKeyWithFloatValues:
 - 1.1
 - 1.2
+arrKeyEmpty: []
 `,
 			want: `properties:
+  arrKeyEmpty:
+    default: []
+    items: {}
+    type: array
   arrKeyWithFloatValues:
     default: []
     description: default value is 1.1. 1.2 is ignored

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -252,6 +252,7 @@ spec:
           properties:
             clusters:
               default: []
+              items: {}
               type: array
             kubeConfigSecretName:
               default: mongodb-enterprise-operator-multi-cluster-kubeconfig
@@ -289,6 +290,7 @@ spec:
               type: string
             tolerations:
               default: []
+              items: {}
               type: array
             vaultSecretBackend:
               properties:
@@ -812,6 +814,7 @@ spec:
           type: object
         imagePullSecrets:
           default: []
+          items: {}
           type: array
         nameOverride:
           default: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

The `items` field in OpenAPI schema is required. This makes sure that we always add it, even if the default value is an empty array.

#### Which issue(s) this PR fixes:

Fixes #1464.

#### Does this PR introduce a user-facing change?

```release-note
`kctrl`: array Helm values now always get an `items` field in OpenAPI.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] ~~Relevant docs in this repo added or updated~~
- [ ] ~~Relevant carvel.dev docs added or updated in a separate PR and there's a link to that PR~~
- [x] Code is at least as readable and maintainable as it was before this change