### PR TITLE
Do not wait for App pause on package install pause if wait is disabled

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -388,9 +388,12 @@ func (o CreateOrUpdateOptions) update(client kubernetes.Interface, kcClient kccl
 		if err != nil {
 			return err
 		}
-		err = o.waitForAppPause(kcClient)
-		if err != nil {
-			return err
+
+		if o.WaitFlags.Enabled {
+			err = o.waitForAppPause(kcClient)
+			if err != nil {
+				return err
+			}
 		}
 		reconciliationPaused = true
 

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -65,6 +65,12 @@ func NewPauseCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobr
 		cmd.Use = "pause INSTALLED_PACKAGE_NAME"
 	}
 
+	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
+		AllowDisableWait: true,
+		DefaultInterval:  2 * time.Second,
+		DefaultTimeout:   5 * time.Minute,
+	})
+
 	return cmd
 }
 
@@ -165,9 +171,11 @@ func (o *PauseOrKickOptions) Kick(args []string) error {
 		return err
 	}
 
-	err = o.waitForAppPause(client)
-	if err != nil {
-		return err
+	if o.WaitFlags.Enabled {
+		err = o.waitForAppPause(client)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = o.unpause(client)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Allows users to update installed packages and pause and kick them even if they do not have access to App resources

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Added wait flag to pause command
```

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
Need to update docs to account for flag added to pause command
```
