### PR TITLE
adding new column message in kctrl pkg installed list command

### DIFF
--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -138,6 +138,22 @@ key2: value2
 		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
 	})
 
+	logger.Section("package installed list with one package installed with wide option", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "list", "--wide", "--json"}, RunOpts{})
+		require.NoError(t, err)
+
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{{
+			"message":         "",
+			"name":            "testpkgi",
+			"package_name":    "test-pkg.carvel.dev",
+			"package_version": "1.0.0",
+			"status":          "Reconcile succeeded",
+		}}
+		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
+	})
+
 	logger.Section("package installed get", func() {
 
 		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "get", "--package-install", pkgiName, "--json"}, RunOpts{})
@@ -258,6 +274,36 @@ key2: value2
 			AllowError: true,
 		})
 		require.Contains(t, err.Error(), "not found")
+	})
+
+	logger.Section("Listing with error in package install", func() {
+		incorrectValuesFile := `
+key1: value1:
+`
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "create", "--package-install", pkgiName,
+			"-p", packageMetadataName, "--version", packageVersion1,
+			"--values-file", "-"}, RunOpts{
+			StdinReader: strings.NewReader(incorrectValuesFile),
+			AllowError:  true,
+		})
+		require.Error(t, err)
+
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "list", "--wide", "--json"}, RunOpts{})
+		require.NoError(t, err)
+
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{{
+			"message":         "Error (see .status.usefulErrorMessage for details)",
+			"name":            "testpkgi",
+			"package_name":    "test-pkg.carvel.dev",
+			"package_version": "1.0.0",
+			"status":          "Reconcile failed",
+		}}
+		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
+
+		_, err = kappCtrl.RunWithOpts([]string{"package", "installed", "delete", "--package-install", pkgiName}, RunOpts{})
+		require.NoError(t, err)
 	})
 
 	logger.Section("package installed update with missing old version", func() {


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding a new column 'Message' in the output of command `kctrl package installed list`, which will show the message from last condition from the status of each package install when --wide flag is provided.

The sample output from testing.

```
 % /tmp/kctrl package installed list
Target cluster 'https://127.0.0.1:50874' (nodes: local-test-control-plane)

Installed packages in namespace 'default'

Name          Package Name         Package Version  Status  
pkg-demo      simple-app.corp.com  1.0.0            Reconcile succeeded  
pkg-demo-err  simple-app.corp.com  1.0.0            Reconcile failed  

Succeeded
 % /tmp/kctrl package installed list --wide
Target cluster 'https://127.0.0.1:50874' (nodes: local-test-control-plane)

Installed packages in namespace 'default'

Name          Package Name         Package Version  Status               Message  
pkg-demo      simple-app.corp.com  1.0.0            Reconcile succeeded  -  
pkg-demo-err  simple-app.corp.com  1.0.0            Reconcile failed     Error (see .status.usefulErrorMessage for details)  

Succeeded


```

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Adds a new column 'Message' in the output of command `kctrl package installed list`, which will show the message from last condition from the status of each package install when --wide flag is provided
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
