### PR TITLE
fix: update-kind-example-to-containerd_1.5

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -388,9 +388,12 @@ func (o CreateOrUpdateOptions) update(client kubernetes.Interface, kcClient kccl
 		if err != nil {
 			return err
 		}
-		err = o.waitForAppPause(kcClient)
-		if err != nil {
-			return err
+
+		if o.WaitFlags.Enabled {
+			err = o.waitForAppPause(kcClient)
+			if err != nil {
+				return err
+			}
 		}
 		reconciliationPaused = true
 

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -65,6 +65,12 @@ func NewPauseCmd(o *PauseOrKickOptions, flagsFactory cmdcore.FlagsFactory) *cobr
 		cmd.Use = "pause INSTALLED_PACKAGE_NAME"
 	}
 
+	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
+		AllowDisableWait: true,
+		DefaultInterval:  2 * time.Second,
+		DefaultTimeout:   5 * time.Minute,
+	})
+
 	return cmd
 }
 
@@ -165,9 +171,11 @@ func (o *PauseOrKickOptions) Kick(args []string) error {
 		return err
 	}
 
-	err = o.waitForAppPause(client)
-	if err != nil {
-		return err
+	if o.WaitFlags.Enabled {
+		err = o.waitForAppPause(client)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = o.unpause(client)

--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -138,6 +138,22 @@ key2: value2
 		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
 	})
 
+	logger.Section("package installed list with one package installed with wide option", func() {
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "list", "--wide", "--json"}, RunOpts{})
+		require.NoError(t, err)
+
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{{
+			"message":         "",
+			"name":            "testpkgi",
+			"package_name":    "test-pkg.carvel.dev",
+			"package_version": "1.0.0",
+			"status":          "Reconcile succeeded",
+		}}
+		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
+	})
+
 	logger.Section("package installed get", func() {
 
 		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "get", "--package-install", pkgiName, "--json"}, RunOpts{})
@@ -258,6 +274,36 @@ key2: value2
 			AllowError: true,
 		})
 		require.Contains(t, err.Error(), "not found")
+	})
+
+	logger.Section("Listing with error in package install", func() {
+		incorrectValuesFile := `
+key1: value1:
+`
+		_, err := kappCtrl.RunWithOpts([]string{"package", "installed", "create", "--package-install", pkgiName,
+			"-p", packageMetadataName, "--version", packageVersion1,
+			"--values-file", "-"}, RunOpts{
+			StdinReader: strings.NewReader(incorrectValuesFile),
+			AllowError:  true,
+		})
+		require.Error(t, err)
+
+		out, err := kappCtrl.RunWithOpts([]string{"package", "installed", "list", "--wide", "--json"}, RunOpts{})
+		require.NoError(t, err)
+
+		output := uitest.JSONUIFromBytes(t, []byte(out))
+
+		expectedOutputRows := []map[string]string{{
+			"message":         "Error (see .status.usefulErrorMessage for details)",
+			"name":            "testpkgi",
+			"package_name":    "test-pkg.carvel.dev",
+			"package_version": "1.0.0",
+			"status":          "Reconcile failed",
+		}}
+		require.Exactly(t, expectedOutputRows, output.Tables[0].Rows)
+
+		_, err = kappCtrl.RunWithOpts([]string{"package", "installed", "delete", "--package-install", pkgiName}, RunOpts{})
+		require.NoError(t, err)
 	})
 
 	logger.Section("package installed update with missing old version", func() {

--- a/config/config/deployment.yml
+++ b/config/config/deployment.yml
@@ -62,6 +62,8 @@ spec:
           capabilities:
             drop:
             - ALL
+          seccompProfile:
+            type: RuntimeDefault
       - name: kapp-controller-sidecarexec
         image: kapp-controller
         args: ["--sidecarexec"]
@@ -89,6 +91,8 @@ spec:
           capabilities:
             drop:
             - ALL
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: template-fs
         emptyDir:

--- a/examples/local-kind-environment/scripts/kind-with-registry.sh
+++ b/examples/local-kind-environment/scripts/kind-with-registry.sh
@@ -2,6 +2,8 @@
 set -o errexit
 
 # create registry container unless it already exists
+# http://kind-registry.local:5000
+# curl -s -X GET kind-registry.local:5000/v2/_catalog | jq .
 reg_name='kind-registry.local'
 reg_port='5000'
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
@@ -16,9 +18,25 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${reg_name}:${reg_port}"]
     endpoint = ["http://${reg_name}:5000"]
 EOF
+
+# 3. Add the registry config to the nodes
+#
+# This is necessary because localhost resolves to loopback addresses that are
+# network-namespace local.
+# In other words: localhost in the container is not localhost on the host.
+#
+# We want a consistent name that works from both ends, so we tell containerd to
+# alias localhost:${reg_port} to the registry container when pulling images
+REGISTRY_DIR="/etc/containerd/certs.d/${reg_name}:${reg_port}"
+for node in $(sudo kind get nodes); do
+  sudo docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | sudo docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+[host."http://${reg_name}:${reg_port}"]
+EOF
+done
 
 # connect the registry to the cluster network if not already connected
 if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then

--- a/examples/local-kind-environment/scripts/kind-with-registry.sh
+++ b/examples/local-kind-environment/scripts/kind-with-registry.sh
@@ -20,7 +20,7 @@ containerdConfigPatches:
     endpoint = ["http://${reg_name}:5000"]
 EOF
 
-# 3. Add the registry config to the nodes
+# Add the registry config to the nodes
 #
 # This is necessary because localhost resolves to loopback addresses that are
 # network-namespace local.

--- a/examples/local-kind-environment/scripts/kind-with-registry.sh
+++ b/examples/local-kind-environment/scripts/kind-with-registry.sh
@@ -2,8 +2,6 @@
 set -o errexit
 
 # create registry container unless it already exists
-# http://kind-registry.local:5000
-# curl -s -X GET kind-registry.local:5000/v2/_catalog | jq .
 reg_name='kind-registry.local'
 reg_port='5000'
 if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then


### PR DESCRIPTION
#### What this PR does / why we need it:
Adjusted the example of running the `kapp-controller` in `kind` for the `containerd 1.5+`

The example supplied in this repository, [kapp-controller in kind](https://github.com/carvel-dev/kapp-controller/tree/develop/examples/local-kind-environment), **no longer works** with my `containerd://1.7.1`  - the pods are scheduled and created, but there are image pull errors as every pod tries to pull image over HTTPS instead of HTTP ( as in this [StackOverflow](https://stackoverflow.com/questions/74592879/error-deploying-image-to-kubernetes-pod-http-server-gave-http-response-to-htt) example).

I believe this change happened in [containerd v1.5](https://github.com/containerd/containerd/blob/main/docs/hosts.md#bypass-tls-verification-example) as each container needs a `hosts.toml` file.
This new requirement is also reflected in project kind: [create a local registry](https://kind.sigs.k8s.io/docs/user/local-registry/), note a new step which is missing in the 2 year old [kind-with-registry.sh](https://github.com/carvel-dev/kapp-controller/blob/develop/examples/local-kind-environment/scripts/kind-with-registry.sh) script:
```
# 3. Add the registry config to the nodes
#
# This is necessary because localhost resolves to loopback addresses that are
# network-namespace local.
# In other words: localhost in the container is not localhost on the host.
#
# We want a consistent name that works from both ends, so we tell containerd to
# alias localhost:${reg_port} to the registry container when pulling images
REGISTRY_DIR="/etc/containerd/certs.d/localhost:${reg_port}"
for node in $(kind get nodes); do
  docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
[host."http://${reg_name}:5000"]
EOF
done
```
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
NONE
-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
