### PR TITLE
Configs per step

### DIFF
--- a/config/config/crds.yml
+++ b/config/config/crds.yml
@@ -1558,6 +1558,10 @@ spec:
                         name:
                           type: string
                       type: object
+                    templateSteps:
+                      items:
+                        type: integer
+                      type: array
                   type: object
                 type: array
             type: object

--- a/examples/pkgi-with-config-and-values-per-step.yaml
+++ b/examples/pkgi-with-config-and-values-per-step.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: thingamajig.acme.corp.0.0.1
+spec:
+  refName: thingamajig.acme.corp
+  version: 0.0.1
+  template:
+    spec:
+      fetch:
+      - path: helm-chart
+        helmChart:
+          name: nginx
+          repository:
+            url: oci://registry-1.docker.io/bitnamicharts
+          version: 15.12.2
+      - path: patcher
+        inline:
+          paths:
+            schema.yaml: |
+              #@data/values-schema
+              ---
+              #! These validations would fail if we were not able to add data
+              #! values to the ytt step
+
+              #@schema/validation min_len=1
+              existingServerBlockConfigmap: ""
+              #@schema/validation min_len=1
+              customServerBlock: ""
+            server-block-cm.yaml: |
+              #@ load("@ytt:data", "data")
+              ---
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: #@ data.values.existingServerBlockConfigmap
+              data:
+                custom-server-block.conf: #@ data.values.customServerBlock
+      template:
+      - helmTemplate:
+          path: helm-chart
+      - ytt:
+          paths:
+          - "-"
+          - patcher
+      deploy:
+      - kapp: {}
+
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
+metadata:
+  name: thingamajig
+  annotations:
+    ext.packaging.carvel.dev/helm-0-template-name: foobar
+spec:
+  serviceAccountName: default-ns-sa
+  packageRef:
+    refName: thingamajig.acme.corp
+    versionSelection:
+      constraints: 0.0.1
+  values:
+  - secretRef:
+      name: thingamajig-shared-values
+    templateSteps: [ 0 , 1 ]
+  - secretRef:
+      name: thingamajig-helm-values
+    templateSteps: [ 0 ]
+  - secretRef:
+      name: thingamajig-ytt-values
+    templateSteps: [ 1 ]
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thingamajig-shared-values
+stringData:
+  values.yaml: |
+    existingServerBlockConfigmap: custom-server-block
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thingamajig-helm-values
+stringData:
+  values.yaml: |
+    service:
+      type: ClusterIP
+    replicaCount: 2
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thingamajig-ytt-values
+stringData:
+  values.yaml: |
+    customServerBlock: |
+      server {
+        listen 0.0.0.0:8080;
+        location / {
+          return 200 "hello from kapp-controller, helm, ytt and friends!";
+          add_header Content-Type text/plain;
+        }
+      }

--- a/hack/test-examples.sh
+++ b/hack/test-examples.sh
@@ -33,6 +33,9 @@ time kapp delete -y -a simple-app-http
 time kapp deploy -y -a cue -f examples/cue.yml
 time kapp delete -y -a cue
 
+time kapp deploy -y -a step-values-and-config -f examples/pkgi-with-config-and-values-per-step.yaml
+time kapp delete -y -a step-values-and-config
+
 kapp delete -y -a rbac
 
 echo EXTERNAL SUCCESS

--- a/pkg/apis/packaging/v1alpha1/package_install.go
+++ b/pkg/apis/packaging/v1alpha1/package_install.go
@@ -91,6 +91,8 @@ type PackageRef struct {
 type PackageInstallValues struct {
 	// +optional
 	SecretRef *PackageInstallValuesSecretRef `json:"secretRef,omitempty"`
+	// +optional
+	TemplateSteps []int `json:"templateSteps,omitempty"`
 }
 
 type PackageInstallValuesSecretRef struct {

--- a/pkg/apis/packaging/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/packaging/v1alpha1/zz_generated.deepcopy.go
@@ -136,6 +136,11 @@ func (in *PackageInstallValues) DeepCopyInto(out *PackageInstallValues) {
 		*out = new(PackageInstallValuesSecretRef)
 		**out = **in
 	}
+	if in.TemplateSteps != nil {
+		in, out := &in.TemplateSteps, &out.TemplateSteps
+		*out = make([]int, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/packageinstall/app.go
+++ b/pkg/packageinstall/app.go
@@ -125,7 +125,7 @@ type (
 
 const (
 	// anything that can take values
-	stepClassValueable stepClass = "valueable"
+	stepClassTakesValues stepClass = "takesValues"
 	// only helm template steps
 	stepClassHelm stepClass = "helm"
 	// only ytt template steps
@@ -150,13 +150,13 @@ func (p *templateStepsPatcher) classifySteps() {
 		classes := stepClasses{}
 
 		if step.HelmTemplate != nil {
-			classes.Insert(stepClassHelm, stepClassValueable)
+			classes.Insert(stepClassHelm, stepClassTakesValues)
 		}
 		if step.Ytt != nil {
-			classes.Insert(stepClassYtt, stepClassValueable)
+			classes.Insert(stepClassYtt, stepClassTakesValues)
 		}
 		if step.Cue != nil {
-			classes.Insert(stepClassCue, stepClassValueable)
+			classes.Insert(stepClassCue, stepClassTakesValues)
 		}
 
 		p.classifiedSteps[i] = classes
@@ -213,11 +213,11 @@ func (p *templateStepsPatcher) patch() error {
 	return nil
 }
 
-// patchFromValues patches all 'valueable' template steps with values from the
-// packageInstall
+// patchFromValues patches all template steps that take values with values from
+// the packageInstall
 func (p *templateStepsPatcher) patchFromValues() error {
 	for _, values := range p.values {
-		stepIdxs, err := p.defaultStepIdxs(values.TemplateSteps, stepClassValueable)
+		stepIdxs, err := p.defaultStepIdxs(values.TemplateSteps, stepClassTakesValues)
 		if err != nil {
 			return err
 		}
@@ -226,7 +226,7 @@ func (p *templateStepsPatcher) patchFromValues() error {
 			if stepIdx < 0 || stepIdx >= len(p.templateSteps) {
 				return fmt.Errorf("template step %d out of range", stepIdx)
 			}
-			if !p.stepHasClass(stepIdx, stepClassValueable) {
+			if !p.stepHasClass(stepIdx, stepClassTakesValues) {
 				return fmt.Errorf("template step %d does not support values", stepIdx)
 			}
 

--- a/pkg/packageinstall/app.go
+++ b/pkg/packageinstall/app.go
@@ -21,15 +21,20 @@ import (
 const (
 	ManuallyControlledAnnKey = "ext.packaging.carvel.dev/manually-controlled"
 
-	HelmTemplateOverlayNameKey      = "ext.packaging.carvel.dev/helm-template-name"
-	HelmTemplateOverlayNameSpaceKey = "ext.packaging.carvel.dev/helm-template-namespace"
+	HelmTemplateOverlayNameKey         = "ext.packaging.carvel.dev/helm-template-name"
+	HelmTemplateOverlayNameKeyFmt      = "ext.packaging.carvel.dev/helm-%d-template-name"
+	HelmTemplateOverlayNameSpaceKey    = "ext.packaging.carvel.dev/helm-template-namespace"
+	HelmTemplateOverlayNameSpaceKeyFmt = "ext.packaging.carvel.dev/helm-%d-template-namespace"
 
 	// Resulting secret names are sorted deterministically by suffix
-	ExtYttPathsFromSecretNameAnnKey  = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
-	ExtHelmPathsFromSecretNameAnnKey = "ext.packaging.carvel.dev/helm-template-values-from-secret-name"
+	ExtYttPathsFromSecretNameAnnKey     = "ext.packaging.carvel.dev/ytt-paths-from-secret-name"
+	ExtYttPathsFromSecretNameAnnKeyFmt  = "ext.packaging.carvel.dev/ytt-%d-paths-from-secret-name"
+	ExtHelmPathsFromSecretNameAnnKey    = "ext.packaging.carvel.dev/helm-template-values-from-secret-name"
+	ExtHelmPathsFromSecretNameAnnKeyFmt = "ext.packaging.carvel.dev/helm-%d-template-values-from-secret-name"
 
 	// ExtYttDataValuesOverlaysAnnKey if set, adds the pkgi's values secrets as overlays/paths, not as values, to the app
-	ExtYttDataValuesOverlaysAnnKey = "ext.packaging.carvel.dev/ytt-data-values-overlays"
+	ExtYttDataValuesOverlaysAnnKey    = "ext.packaging.carvel.dev/ytt-data-values-overlays"
+	ExtYttDataValuesOverlaysAnnKeyFmt = "ext.packaging.carvel.dev/ytt-%d-data-values-overlays"
 
 	ExtFetchSecretNameAnnKeyFmt = "ext.packaging.carvel.dev/fetch-%d-secret-name"
 )
@@ -101,21 +106,10 @@ func NewApp(existingApp *v1alpha1.App, pkgInstall *pkgingv1alpha1.PackageInstall
 	}
 
 	templatesPatcher := templateStepsPatcher{
-		yttPatcher: &yttStepPatcher{
-			addValuesAsInlinePaths: pkgiHasAnnotation(pkgInstall, ExtYttDataValuesOverlaysAnnKey),
-			additionalPaths:        secretNamesFromAnn(pkgInstall, ExtYttPathsFromSecretNameAnnKey),
-		},
-		helmPatcher: &helmStepPatcher{
-			additionalPaths: secretNamesFromAnn(pkgInstall, ExtHelmPathsFromSecretNameAnnKey),
-			name:            pkgiAnnotationValue(pkgInstall, HelmTemplateOverlayNameKey),
-			namespace:       pkgiAnnotationValue(pkgInstall, HelmTemplateOverlayNameSpaceKey),
-		},
-		cuePatcher: &cueStepPatcher{},
-
 		templateSteps: desiredApp.Spec.Template,
 		values:        pkgInstall.Spec.Values,
+		annotations:   pkgInstall.Annotations,
 	}
-
 	if err := templatesPatcher.patch(); err != nil {
 		return &v1alpha1.App{}, err
 	}
@@ -136,63 +130,10 @@ const (
 	stepClassCue stepClass = "cue"
 )
 
-type yttStepPatcher struct {
-	addValuesAsInlinePaths bool     // TODO: support multiple ytt steps
-	additionalPaths        []string // TODO: support multiple ytt steps
-}
-
-func (yp *yttStepPatcher) addValues(yttStep *kcv1alpha1.AppTemplateYtt, value pkgingv1alpha1.PackageInstallValues) {
-	if yp.addValuesAsInlinePaths {
-		addSecretAsInlinePath(&yttStep.Inline, value.SecretRef.Name)
-	} else {
-		addSecretAsValueSource(&yttStep.ValuesFrom, value.SecretRef.Name)
-	}
-}
-
-func (yp *yttStepPatcher) addPaths(yttStep *kcv1alpha1.AppTemplateYtt) {
-	for _, secretName := range yp.additionalPaths {
-		addSecretAsInlinePath(&yttStep.Inline, secretName)
-	}
-}
-
-type helmStepPatcher struct {
-	additionalPaths []string
-	name            string // TODO: support multiple helm steps
-	namespace       string // TODO: support multiple helm steps
-}
-
-func (hp *helmStepPatcher) addValues(helmStep *kcv1alpha1.AppTemplateHelmTemplate, value pkgingv1alpha1.PackageInstallValues) {
-	addSecretAsValueSource(&helmStep.ValuesFrom, value.SecretRef.Name)
-}
-
-func (hp *helmStepPatcher) addPaths(helmStep *kcv1alpha1.AppTemplateHelmTemplate) {
-	for _, secretName := range hp.additionalPaths {
-		addSecretAsValueSource(&helmStep.ValuesFrom, secretName)
-	}
-}
-
-func (hp *helmStepPatcher) setNameAndNamespace(helmStep *kcv1alpha1.AppTemplateHelmTemplate) {
-	if hp.name != "" {
-		helmStep.Name = hp.name
-	}
-	if hp.namespace != "" {
-		helmStep.Namespace = hp.namespace
-	}
-}
-
-type cueStepPatcher struct{}
-
-func (cp *cueStepPatcher) addValues(cueStep *kcv1alpha1.AppTemplateCue, value pkgingv1alpha1.PackageInstallValues) {
-	addSecretAsValueSource(&cueStep.ValuesFrom, value.SecretRef.Name)
-}
-
 type templateStepsPatcher struct {
 	templateSteps []kcv1alpha1.AppTemplate
 	values        []pkgingv1alpha1.PackageInstallValues
-
-	yttPatcher  *yttStepPatcher
-	helmPatcher *helmStepPatcher
-	cuePatcher  *cueStepPatcher
+	annotations   map[string]string
 
 	classifiedSteps [][]stepClass
 	once            sync.Once
@@ -266,6 +207,18 @@ func (p *templateStepsPatcher) defaultStepIdxs(stepIdxs []int, class stepClass) 
 }
 
 func (p *templateStepsPatcher) patch() error {
+	if err := p.patchFromValues(); err != nil {
+		return err
+	}
+	p.patchFromYttAnnotations()
+	p.patchFromHelmAnnotations()
+
+	return nil
+}
+
+// patchFromValues patches all 'valueable' template steps with values from the
+// packageInstall
+func (p *templateStepsPatcher) patchFromValues() error {
 	for _, values := range p.values {
 		stepIdxs, err := p.defaultStepIdxs(values.TemplateSteps, stepClassValueable)
 		if err != nil {
@@ -284,36 +237,108 @@ func (p *templateStepsPatcher) patch() error {
 
 			switch {
 			case p.stepHasClass(stepIdx, stepClassYtt):
-				p.yttPatcher.addValues(templateStep.Ytt, values)
+				// ytt is a bit special: when we find the indexed annotation (or the
+				// naked one for the first ytt step) to apply the values as inline
+				// paths on the app, we do so; else, by default, we apply the pkgi's
+				// values as values on the app.
+				valuesAsPath := false
+				if firstYttStepIdx, ok := p.firstOf(stepClassYtt); ok && stepIdx == firstYttStepIdx {
+					if _, ok := p.annotations[ExtYttDataValuesOverlaysAnnKey]; ok {
+						valuesAsPath = true
+					}
+				}
+				if _, ok := p.annotations[fmt.Sprintf(ExtYttDataValuesOverlaysAnnKeyFmt, stepIdx)]; ok {
+					valuesAsPath = true
+				}
+				if valuesAsPath {
+					addSecretAsInlinePath(&templateStep.Ytt.Inline, values.SecretRef.Name)
+				} else {
+					addSecretAsValueSource(&templateStep.Ytt.ValuesFrom, values.SecretRef.Name)
+				}
 
 			case p.stepHasClass(stepIdx, stepClassHelm):
-				p.helmPatcher.addValues(templateStep.HelmTemplate, values)
+				addSecretAsValueSource(&templateStep.HelmTemplate.ValuesFrom, values.SecretRef.Name)
 
 			case p.stepHasClass(stepIdx, stepClassCue):
-				p.cuePatcher.addValues(templateStep.Cue, values)
+				addSecretAsValueSource(&templateStep.Cue.ValuesFrom, values.SecretRef.Name)
 			}
 		}
-	}
-
-	for _, stepIdx := range p.getClassifiedSteps(stepClassYtt) {
-		p.yttPatcher.addPaths(p.templateSteps[stepIdx].Ytt)
-		break // TODO: support multiple ytt steps
-	}
-	for _, stepIdx := range p.getClassifiedSteps(stepClassHelm) {
-		ts := p.templateSteps[stepIdx].HelmTemplate
-		p.helmPatcher.addPaths(ts)
-		p.helmPatcher.setNameAndNamespace(ts)
-		break // TODO: support multiple helm steps
 	}
 
 	return nil
 }
 
-func secretNamesFromAnn(installedPkg *pkgingv1alpha1.PackageInstall, annKey string) []string {
+// patchFromYttAnnotations patches ytt template steps with values from
+// annotations from the packageInstall
+func (p *templateStepsPatcher) patchFromYttAnnotations() {
+	firstYttIdx, hasYtt := p.firstOf(stepClassYtt)
+
+	if !hasYtt {
+		return
+	}
+
+	patcher := func(ts *kcv1alpha1.AppTemplateYtt, pathsAnno string) {
+		for _, secretName := range secretNamesFromAnn(p.annotations, pathsAnno) {
+			addSecretAsInlinePath(&ts.Inline, secretName)
+		}
+	}
+
+	for _, stepIdx := range p.getClassifiedSteps(stepClassYtt) {
+		ts := p.templateSteps[stepIdx].Ytt
+
+		if stepIdx == firstYttIdx {
+			// annotations that are not indexed are only applied to the first ytt
+			// step, so that we are backwards compatible
+			patcher(ts, ExtYttPathsFromSecretNameAnnKey)
+		}
+
+		patcher(ts, fmt.Sprintf(ExtYttPathsFromSecretNameAnnKeyFmt, stepIdx))
+	}
+}
+
+// patchFromHelmAnnotations patches helm template steps with values from
+// annotations from the packageInstall
+func (p *templateStepsPatcher) patchFromHelmAnnotations() {
+	firstHelmIdx, hasHelm := p.firstOf(stepClassHelm)
+
+	if !hasHelm {
+		return
+	}
+
+	patcher := func(ts *kcv1alpha1.AppTemplateHelmTemplate, nameAnno, namespaceAnno, pathsAnno string) {
+		if name, ok := p.annotations[nameAnno]; ok && name != "" {
+			ts.Name = name
+		}
+		if namespace, ok := p.annotations[namespaceAnno]; ok && namespace != "" {
+			ts.Namespace = namespace
+		}
+		for _, secretName := range secretNamesFromAnn(p.annotations, pathsAnno) {
+			addSecretAsValueSource(&ts.ValuesFrom, secretName)
+		}
+	}
+
+	for _, stepIdx := range p.getClassifiedSteps(stepClassHelm) {
+		ts := p.templateSteps[stepIdx].HelmTemplate
+
+		if stepIdx == firstHelmIdx {
+			// annotations that are not indexed are only applied to the first helm
+			// step, so that we are backwards compatible
+			patcher(ts, HelmTemplateOverlayNameKey, HelmTemplateOverlayNameSpaceKey, ExtHelmPathsFromSecretNameAnnKey)
+		}
+
+		patcher(ts,
+			fmt.Sprintf(HelmTemplateOverlayNameKeyFmt, stepIdx),
+			fmt.Sprintf(HelmTemplateOverlayNameSpaceKeyFmt, stepIdx),
+			fmt.Sprintf(ExtHelmPathsFromSecretNameAnnKeyFmt, stepIdx),
+		)
+	}
+}
+
+func secretNamesFromAnn(annotations map[string]string, annKey string) []string {
 	var suffixes []string
 	suffixToSecretName := map[string]string{}
 
-	for ann, secretName := range installedPkg.Annotations {
+	for ann, secretName := range annotations {
 		if ann == annKey {
 			suffix := ""
 			suffixToSecretName[suffix] = secretName
@@ -332,18 +357,6 @@ func secretNamesFromAnn(installedPkg *pkgingv1alpha1.PackageInstall, annKey stri
 		result = append(result, suffixToSecretName[suffix])
 	}
 	return result
-}
-
-func pkgiAnnotationValue(pkgi *pkgingv1alpha1.PackageInstall, key string) string {
-	if anno, found := pkgi.Annotations[key]; found {
-		return anno
-	}
-	return ""
-}
-
-func pkgiHasAnnotation(pkgi *pkgingv1alpha1.PackageInstall, key string) bool {
-	_, found := pkgi.Annotations[key]
-	return found
 }
 
 // addSecretAsInlinePath adds a secret as an inline path to the provided inline

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -66,22 +66,22 @@ func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
 			Template: []kcv1alpha1.AppTemplate{
 				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
 					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
-						kcv1alpha1.AppTemplateValuesSource{
+						{
 							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
 								Name: "helm-no-suffix",
 							},
 						},
-						kcv1alpha1.AppTemplateValuesSource{
+						{
 							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
 								Name: "helm-suffix-2",
 							},
 						},
-						kcv1alpha1.AppTemplateValuesSource{
+						{
 							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
 								Name: "helm-suffix-4",
 							},
 						},
-						kcv1alpha1.AppTemplateValuesSource{
+						{
 							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
 								Name: "helm-suffix-text",
 							},
@@ -94,22 +94,22 @@ func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
 				{Ytt: &kcv1alpha1.AppTemplateYtt{
 					Inline: &kcv1alpha1.AppFetchInline{
 						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
-							kcv1alpha1.AppFetchInlineSource{
+							{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
 									Name: "ytt-no-suffix",
 								},
 							},
-							kcv1alpha1.AppFetchInlineSource{
+							{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
 									Name: "ytt-suffix-2",
 								},
 							},
-							kcv1alpha1.AppFetchInlineSource{
+							{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
 									Name: "ytt-suffix-4",
 								},
 							},
-							kcv1alpha1.AppFetchInlineSource{
+							{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
 									Name: "ytt-suffix-text",
 								},
@@ -131,6 +131,7 @@ func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
 		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
 	}
 }
+
 func TestAppHelmOverlaysFromAnn(t *testing.T) {
 	ipkg := &pkgingv1alpha1.PackageInstall{
 		ObjectMeta: metav1.ObjectMeta{
@@ -180,12 +181,12 @@ func TestAppHelmOverlaysFromAnn(t *testing.T) {
 					Name:      "helm-new-name",
 					Namespace: "helm-new-namespace",
 					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
-						kcv1alpha1.AppTemplateValuesSource{
+						{
 							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
 								Name: "values1",
 							},
 						},
-						kcv1alpha1.AppTemplateValuesSource{
+						{
 							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
 								Name: "values2",
 							},
@@ -251,12 +252,12 @@ func TestAppExtYttDataValuesOverlaysAnn(t *testing.T) {
 				{Ytt: &kcv1alpha1.AppTemplateYtt{
 					Inline: &kcv1alpha1.AppFetchInline{
 						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
-							kcv1alpha1.AppFetchInlineSource{
+							{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
 									Name: "values1",
 								},
 							},
-							kcv1alpha1.AppFetchInlineSource{
+							{
 								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
 									Name: "values2",
 								},
@@ -275,144 +276,6 @@ func TestAppExtYttDataValuesOverlaysAnn(t *testing.T) {
 
 	if !reflect.DeepEqual(expectedApp, app) {
 		bs, _ := yaml.Marshal(app)
-		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
-	}
-}
-
-func TestAppYttValues(t *testing.T) {
-	ipkg := &pkgingv1alpha1.PackageInstall{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app",
-			Namespace: "default",
-		},
-		Spec: pkgingv1alpha1.PackageInstallSpec{
-			Values: []pkgingv1alpha1.PackageInstallValues{
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values1"}},
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values2"}},
-			},
-		},
-	}
-
-	pkgVersion := datapkgingv1alpha1.Package{
-		Spec: datapkgingv1alpha1.PackageSpec{
-			RefName: "expec-pkg",
-			Version: "1.5.0",
-			Template: datapkgingv1alpha1.AppTemplateSpec{
-				Spec: &kcv1alpha1.AppSpec{
-					Template: []kcv1alpha1.AppTemplate{
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-					},
-				},
-			},
-		},
-	}
-
-	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion, packageinstall.Opts{DefaultSyncPeriod: 10 * time.Minute})
-	if err != nil {
-		t.Fatalf("Expected no err, but was: %s", err)
-	}
-
-	expectedApp := &kcv1alpha1.App{
-		Spec: kcv1alpha1.AppSpec{
-			SyncPeriod: &defaultSyncPeriod,
-			Template: []kcv1alpha1.AppTemplate{
-				{Ytt: &kcv1alpha1.AppTemplateYtt{
-					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
-						kcv1alpha1.AppTemplateValuesSource{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "values1",
-							},
-						},
-						kcv1alpha1.AppTemplateValuesSource{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "values2",
-							},
-						},
-					},
-				}},
-				// Second ytt templating step is untouched
-				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-			},
-		},
-	}
-
-	// Not interesting in metadata in this test
-	app.ObjectMeta = metav1.ObjectMeta{}
-
-	if !reflect.DeepEqual(expectedApp, app) {
-		bs, _ := yaml.Marshal(app)
-		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
-	}
-}
-
-func TestAppHelmTemplateValues(t *testing.T) {
-	ipkg := &pkgingv1alpha1.PackageInstall{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app",
-			Namespace: "default",
-		},
-		Spec: pkgingv1alpha1.PackageInstallSpec{
-			Values: []pkgingv1alpha1.PackageInstallValues{
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values1"}},
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values2"}},
-			},
-		},
-	}
-
-	pkgVersion := datapkgingv1alpha1.Package{
-		Spec: datapkgingv1alpha1.PackageSpec{
-			RefName: "expec-pkg",
-			Version: "1.5.0",
-			Template: datapkgingv1alpha1.AppTemplateSpec{
-				Spec: &kcv1alpha1.AppSpec{
-					Template: []kcv1alpha1.AppTemplate{
-						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-					},
-				},
-			},
-		},
-	}
-
-	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion, packageinstall.Opts{DefaultSyncPeriod: 10 * time.Minute})
-	if err != nil {
-		t.Fatalf("Expected no err, but was: %s", err)
-	}
-
-	expectedApp := &kcv1alpha1.App{
-		Spec: kcv1alpha1.AppSpec{
-			SyncPeriod: &defaultSyncPeriod,
-			Template: []kcv1alpha1.AppTemplate{
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
-					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
-						kcv1alpha1.AppTemplateValuesSource{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "values1",
-							},
-						},
-						kcv1alpha1.AppTemplateValuesSource{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "values2",
-							},
-						},
-					},
-				}},
-				// Second helm templating step is untouched
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-				// Second ytt templating step is untouched
-				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-			},
-		},
-	}
-
-	// Not interesting in metadata in this test
-	app.ObjectMeta = metav1.ObjectMeta{}
-
-	if !reflect.DeepEqual(expectedApp, app) {
 		bs, _ := yaml.Marshal(app)
 		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
 	}
@@ -715,4 +578,154 @@ func TestAppPackageIntallDefaultNamespace(t *testing.T) {
 	app.ObjectMeta = metav1.ObjectMeta{}
 
 	require.Equal(t, expectedApp, app, "App does not match expected app")
+}
+
+func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
+	pkgi := func(values []pkgingv1alpha1.PackageInstallValues) *pkgingv1alpha1.PackageInstall {
+		return &pkgingv1alpha1.PackageInstall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app",
+				Namespace: "default",
+			},
+			Spec: pkgingv1alpha1.PackageInstallSpec{
+				Values: values,
+			},
+		}
+	}
+
+	pkg := func() datapkgingv1alpha1.Package {
+		return datapkgingv1alpha1.Package{
+			Spec: datapkgingv1alpha1.PackageSpec{
+				RefName: "expec-pkg",
+				Version: "1.5.0",
+				Template: datapkgingv1alpha1.AppTemplateSpec{
+					Spec: &kcv1alpha1.AppSpec{
+						Template: []kcv1alpha1.AppTemplate{
+							{Sops: &kcv1alpha1.AppTemplateSops{}},
+							{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+							{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+							{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+							{Kbld: &kcv1alpha1.AppTemplateKbld{}},
+							{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+							{Cue: &kcv1alpha1.AppTemplateCue{}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := map[string]struct {
+		values           []pkgingv1alpha1.PackageInstallValues
+		patchPkg         func(*datapkgingv1alpha1.Package)
+		expectedTemplate []kcv1alpha1.AppTemplate
+		exepectedErrMsg  string
+	}{
+		"no values": {
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{Sops: &kcv1alpha1.AppTemplateSops{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+				{Kbld: &kcv1alpha1.AppTemplateKbld{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{Cue: &kcv1alpha1.AppTemplateCue{}},
+			},
+		},
+		"only add to first step": {
+			values: []pkgingv1alpha1.PackageInstallValues{
+				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-first"}},
+			},
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{Sops: &kcv1alpha1.AppTemplateSops{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-first"}},
+					},
+				}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+				{Kbld: &kcv1alpha1.AppTemplateKbld{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{Cue: &kcv1alpha1.AppTemplateCue{}},
+			},
+		},
+		"invalid step index": {
+			values: []pkgingv1alpha1.PackageInstallValues{
+				{TemplateSteps: []int{100}},
+			},
+			exepectedErrMsg: "out of range",
+		},
+		"specific values, but step does not support values": {
+			values: []pkgingv1alpha1.PackageInstallValues{
+				{TemplateSteps: []int{0}, SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "foo-bar"}},
+			},
+			exepectedErrMsg: "does not support values",
+		},
+		"some values, but no valueable step": {
+			values: []pkgingv1alpha1.PackageInstallValues{
+				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "foo-bar"}},
+			},
+			patchPkg: func(pkg *datapkgingv1alpha1.Package) {
+				// pkg does define any template steps that support values
+				pkg.Spec.Template.Spec.Template = []kcv1alpha1.AppTemplate{
+					{Sops: &kcv1alpha1.AppTemplateSops{}},
+				}
+			},
+			exepectedErrMsg: "no template step of class 'valueable' found",
+		},
+		"values for specific steps": {
+			values: []pkgingv1alpha1.PackageInstallValues{
+				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-first"}},
+				{TemplateSteps: []int{6}, SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-specific-cue"}},
+				{TemplateSteps: []int{3, 6}, SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-multiple-steps"}},
+				{TemplateSteps: []int{5}, SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-specific-ytt"}},
+			},
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{Sops: &kcv1alpha1.AppTemplateSops{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-first"}},
+					},
+				}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-multiple-steps"}},
+					},
+				}},
+				{Kbld: &kcv1alpha1.AppTemplateKbld{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-specific-ytt"}},
+					},
+				}},
+				{Cue: &kcv1alpha1.AppTemplateCue{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-specific-cue"}},
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-multiple-steps"}},
+					},
+				}},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			pkg := pkg()
+			if tc.patchPkg != nil {
+				tc.patchPkg(&pkg)
+			}
+
+			app, err := packageinstall.NewApp(&kcv1alpha1.App{}, pkgi(tc.values), pkg, packageinstall.Opts{})
+
+			if errMsg := tc.exepectedErrMsg; errMsg != "" {
+				require.ErrorContains(t, err, errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedTemplate, app.Spec.Template, "App template does not match expected template")
+		})
+	}
 }

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -20,267 +20,6 @@ import (
 // several tests below have no SyncPeriod set so they'll all use the same default.
 var defaultSyncPeriod metav1.Duration = metav1.Duration{Duration: 10 * time.Minute}
 
-func TestAppExtPathsFromSecretNameAnn(t *testing.T) {
-	ipkg := &pkgingv1alpha1.PackageInstall{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name":                 "ytt-no-suffix",
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.4":               "ytt-suffix-4",
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.2":               "ytt-suffix-2",
-				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.text":            "ytt-suffix-text",
-				"ext.packaging.carvel.dev/helm-template-values-from-secret-name":      "helm-no-suffix",
-				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.4":    "helm-suffix-4",
-				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.2":    "helm-suffix-2",
-				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.text": "helm-suffix-text",
-			},
-		},
-	}
-
-	pkgVersion := datapkgingv1alpha1.Package{
-		Spec: datapkgingv1alpha1.PackageSpec{
-			RefName: "expec-pkg",
-			Version: "1.5.0",
-			Template: datapkgingv1alpha1.AppTemplateSpec{
-				Spec: &kcv1alpha1.AppSpec{
-					Template: []kcv1alpha1.AppTemplate{
-						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-					},
-				},
-			},
-		},
-	}
-
-	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion, packageinstall.Opts{DefaultSyncPeriod: 10 * time.Minute})
-	if err != nil {
-		t.Fatalf("Expected no err, but was: %s", err)
-	}
-
-	expectedApp := &kcv1alpha1.App{
-		Spec: kcv1alpha1.AppSpec{
-			SyncPeriod: &defaultSyncPeriod,
-			Template: []kcv1alpha1.AppTemplate{
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
-					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
-						{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "helm-no-suffix",
-							},
-						},
-						{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "helm-suffix-2",
-							},
-						},
-						{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "helm-suffix-4",
-							},
-						},
-						{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "helm-suffix-text",
-							},
-						},
-					},
-				}},
-				// Second Helm template step is untouched
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
-
-				{Ytt: &kcv1alpha1.AppTemplateYtt{
-					Inline: &kcv1alpha1.AppFetchInline{
-						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
-							{
-								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "ytt-no-suffix",
-								},
-							},
-							{
-								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "ytt-suffix-2",
-								},
-							},
-							{
-								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "ytt-suffix-4",
-								},
-							},
-							{
-								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "ytt-suffix-text",
-								},
-							},
-						},
-					},
-				}},
-				// Second ytt templating step is untouched
-				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-			},
-		},
-	}
-
-	// Not interesting in metadata in this test
-	app.ObjectMeta = metav1.ObjectMeta{}
-
-	if !reflect.DeepEqual(expectedApp, app) {
-		bs, _ := yaml.Marshal(app)
-		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
-	}
-}
-
-func TestAppHelmOverlaysFromAnn(t *testing.T) {
-	ipkg := &pkgingv1alpha1.PackageInstall{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"ext.packaging.carvel.dev/helm-template-name":      "helm-new-name",
-				"ext.packaging.carvel.dev/helm-template-namespace": "helm-new-namespace",
-			},
-		},
-		Spec: pkgingv1alpha1.PackageInstallSpec{
-			Values: []pkgingv1alpha1.PackageInstallValues{
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values1"}},
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values2"}},
-			},
-		},
-	}
-
-	pkgVersion := datapkgingv1alpha1.Package{
-		Spec: datapkgingv1alpha1.PackageSpec{
-			RefName: "expec-pkg",
-			Version: "1.5.0",
-			Template: datapkgingv1alpha1.AppTemplateSpec{
-				Spec: &kcv1alpha1.AppSpec{
-					Template: []kcv1alpha1.AppTemplate{
-						{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
-							Name:      "helm-default-name",
-							Namespace: "helm-default-namespace",
-						}},
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-					},
-				},
-			},
-		},
-	}
-
-	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion, packageinstall.Opts{DefaultSyncPeriod: 10 * time.Minute})
-	if err != nil {
-		t.Fatalf("Expected no err, but was: %s", err)
-	}
-
-	expectedApp := &kcv1alpha1.App{
-		Spec: kcv1alpha1.AppSpec{
-			SyncPeriod: &defaultSyncPeriod,
-			Template: []kcv1alpha1.AppTemplate{
-				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
-					Name:      "helm-new-name",
-					Namespace: "helm-new-namespace",
-					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
-						{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "values1",
-							},
-						},
-						{
-							SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{
-								Name: "values2",
-							},
-						},
-					},
-				}},
-				// Ytt template step is untouched
-				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-			},
-		},
-	}
-
-	// Not interesting in metadata in this test
-	app.ObjectMeta = metav1.ObjectMeta{}
-
-	if !reflect.DeepEqual(expectedApp, app) {
-		bs, _ := yaml.Marshal(app)
-		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
-	}
-}
-
-func TestAppExtYttDataValuesOverlaysAnn(t *testing.T) {
-	ipkg := &pkgingv1alpha1.PackageInstall{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"ext.packaging.carvel.dev/ytt-data-values-overlays": "",
-			},
-		},
-		Spec: pkgingv1alpha1.PackageInstallSpec{
-			Values: []pkgingv1alpha1.PackageInstallValues{
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values1"}},
-				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values2"}},
-			},
-		},
-	}
-
-	pkgVersion := datapkgingv1alpha1.Package{
-		Spec: datapkgingv1alpha1.PackageSpec{
-			RefName: "expec-pkg",
-			Version: "1.5.0",
-			Template: datapkgingv1alpha1.AppTemplateSpec{
-				Spec: &kcv1alpha1.AppSpec{
-					Template: []kcv1alpha1.AppTemplate{
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-						{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-					},
-				},
-			},
-		},
-	}
-
-	app, err := packageinstall.NewApp(&kcv1alpha1.App{}, ipkg, pkgVersion, packageinstall.Opts{DefaultSyncPeriod: 10 * time.Minute})
-	if err != nil {
-		t.Fatalf("Expected no err, but was: %s", err)
-	}
-
-	expectedApp := &kcv1alpha1.App{
-		Spec: kcv1alpha1.AppSpec{
-			SyncPeriod: &defaultSyncPeriod,
-			Template: []kcv1alpha1.AppTemplate{
-				{Ytt: &kcv1alpha1.AppTemplateYtt{
-					Inline: &kcv1alpha1.AppFetchInline{
-						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
-							{
-								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "values1",
-								},
-							},
-							{
-								SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{
-									Name: "values2",
-								},
-							},
-						},
-					},
-				}},
-				// Second ytt templating step is untouched
-				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
-			},
-		},
-	}
-
-	// Not interesting in metadata in this test
-	app.ObjectMeta = metav1.ObjectMeta{}
-
-	if !reflect.DeepEqual(expectedApp, app) {
-		bs, _ := yaml.Marshal(app)
-		bs, _ := yaml.Marshal(app)
-		t.Fatalf("App does not match expected app: (actual)\n%s", bs)
-	}
-}
-
 func TestAppManuallyControlled(t *testing.T) {
 	existingApp := &kcv1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
@@ -618,6 +357,7 @@ func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
 	testCases := map[string]struct {
 		values           []pkgingv1alpha1.PackageInstallValues
 		patchPkg         func(*datapkgingv1alpha1.Package)
+		patchPkgi        func(*pkgingv1alpha1.PackageInstall)
 		expectedTemplate []kcv1alpha1.AppTemplate
 		exepectedErrMsg  string
 	}{
@@ -708,6 +448,44 @@ func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
 				}},
 			},
 		},
+		"values for ytt, as inline paths": {
+			patchPkgi: func(pkgi *pkgingv1alpha1.PackageInstall) {
+				pkgi.ObjectMeta.SetAnnotations(map[string]string{
+					"ext.packaging.carvel.dev/ytt-data-values-overlays":   "",
+					"ext.packaging.carvel.dev/ytt-5-data-values-overlays": "",
+				})
+			},
+			values: []pkgingv1alpha1.PackageInstallValues{
+				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-first"}},
+				{TemplateSteps: []int{2}, SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-specific-ytt"}},
+				{TemplateSteps: []int{5}, SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "values-for-another-ytt"}},
+			},
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{Sops: &kcv1alpha1.AppTemplateSops{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					Inline: &kcv1alpha1.AppFetchInline{
+						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
+							{SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{Name: "values-for-first"}},
+						},
+					},
+				}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "values-for-specific-ytt"}},
+					},
+				}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+				{Kbld: &kcv1alpha1.AppTemplateKbld{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					Inline: &kcv1alpha1.AppFetchInline{
+						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
+							{SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{Name: "values-for-another-ytt"}},
+						},
+					},
+				}},
+				{Cue: &kcv1alpha1.AppTemplateCue{}},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {
@@ -717,7 +495,12 @@ func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
 				tc.patchPkg(&pkg)
 			}
 
-			app, err := packageinstall.NewApp(&kcv1alpha1.App{}, pkgi(tc.values), pkg, packageinstall.Opts{})
+			pkgi := pkgi(tc.values)
+			if tc.patchPkgi != nil {
+				tc.patchPkgi(pkgi)
+			}
+
+			app, err := packageinstall.NewApp(&kcv1alpha1.App{}, pkgi, pkg, packageinstall.Opts{})
 
 			if errMsg := tc.exepectedErrMsg; errMsg != "" {
 				require.ErrorContains(t, err, errMsg)
@@ -725,6 +508,140 @@ func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			require.Equal(t, tc.expectedTemplate, app.Spec.Template, "App template does not match expected template")
+		})
+	}
+}
+
+func TestAppPackageIntallAnnotationsForTemplateSteps(t *testing.T) {
+	pkgi := func(annotations map[string]string) *pkgingv1alpha1.PackageInstall {
+		pkgi := &pkgingv1alpha1.PackageInstall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app",
+				Namespace: "default",
+			},
+		}
+
+		pkgi.ObjectMeta.SetAnnotations(annotations)
+
+		return pkgi
+	}
+
+	pkg := func(templateSteps []kcv1alpha1.AppTemplate) datapkgingv1alpha1.Package {
+		return datapkgingv1alpha1.Package{
+			Spec: datapkgingv1alpha1.PackageSpec{
+				RefName: "expec-pkg",
+				Version: "1.5.0",
+				Template: datapkgingv1alpha1.AppTemplateSpec{
+					Spec: &kcv1alpha1.AppSpec{
+						Template: templateSteps,
+					},
+				},
+			},
+		}
+	}
+
+	someHelmTemplateSteps := func() []kcv1alpha1.AppTemplate {
+		return []kcv1alpha1.AppTemplate{
+			{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+			{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+			{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+		}
+	}
+	someYttTemplateSteps := func() []kcv1alpha1.AppTemplate {
+		return []kcv1alpha1.AppTemplate{
+			{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+			{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+			{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+		}
+	}
+
+	testCases := map[string]struct {
+		pkgiAnnotations  map[string]string
+		pkgTemplateSteps []kcv1alpha1.AppTemplate
+		expectedTemplate []kcv1alpha1.AppTemplate
+	}{
+		"no annotations": {
+			pkgTemplateSteps: someHelmTemplateSteps(),
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{}},
+			},
+		},
+		"helm annotations": {
+			pkgTemplateSteps: someHelmTemplateSteps(),
+			pkgiAnnotations: map[string]string{
+				"ext.packaging.carvel.dev/helm-template-name":          "some-default-helm-name",
+				"ext.packaging.carvel.dev/helm-1-template-name":        "some-specific-helm-name",
+				"ext.packaging.carvel.dev/helm-2-template-namespace":   "some-specific-helm-namespace",
+				"ext.packaging.carvel.dev/helm-100-template-namespace": "no-such-step",
+
+				"ext.packaging.carvel.dev/helm-template-values-from-secret-name":       "some-helm-secret",
+				"ext.packaging.carvel.dev/helm-template-values-from-secret-name.blipp": "some-helm-secret.blipp",
+				"ext.packaging.carvel.dev/helm-1-template-values-from-secret-name.foo": "some-helm-secret.foo",
+				"ext.packaging.carvel.dev/helm-1-template-values-from-secret-name.bar": "some-helm-secret.bar",
+			},
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+					Name: "some-default-helm-name",
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "some-helm-secret"}},
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "some-helm-secret.blipp"}},
+					},
+				}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+					Name: "some-specific-helm-name",
+					ValuesFrom: []kcv1alpha1.AppTemplateValuesSource{
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "some-helm-secret.bar"}},
+						{SecretRef: &kcv1alpha1.AppTemplateValuesSourceRef{Name: "some-helm-secret.foo"}},
+					},
+				}},
+				{HelmTemplate: &kcv1alpha1.AppTemplateHelmTemplate{
+					Namespace: "some-specific-helm-namespace",
+				}},
+			},
+		},
+		"ytt annotations": {
+			pkgTemplateSteps: someYttTemplateSteps(),
+			pkgiAnnotations: map[string]string{
+				"ext.packaging.carvel.dev/ytt-paths-from-secret-name":          "some-ytt-secret",
+				"ext.packaging.carvel.dev/ytt-paths-from-secret-name.1":        "some-other-ytt-secret",
+				"ext.packaging.carvel.dev/ytt-0-paths-from-secret-name.foobar": "some-third-ytt-secret",
+				"ext.packaging.carvel.dev/ytt-2-paths-from-secret-name":        "some-specific-ytt-secret",
+				"ext.packaging.carvel.dev/ytt-100-paths-from-secret-name":      "no such step",
+			},
+			expectedTemplate: []kcv1alpha1.AppTemplate{
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					Inline: &kcv1alpha1.AppFetchInline{
+						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
+							{SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{Name: "some-ytt-secret"}},
+							{SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{Name: "some-other-ytt-secret"}},
+							{SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{Name: "some-third-ytt-secret"}},
+						},
+					},
+				}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{}},
+				{Ytt: &kcv1alpha1.AppTemplateYtt{
+					Inline: &kcv1alpha1.AppFetchInline{
+						PathsFrom: []kcv1alpha1.AppFetchInlineSource{
+							{SecretRef: &kcv1alpha1.AppFetchInlineSourceRef{Name: "some-specific-ytt-secret"}},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			app, err := packageinstall.NewApp(
+				&kcv1alpha1.App{},
+				pkgi(tc.pkgiAnnotations),
+				pkg(tc.pkgTemplateSteps),
+				packageinstall.Opts{},
+			)
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedTemplate, app.Spec.Template, "App template does not match expected template")
 		})
 	}

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -402,7 +402,7 @@ func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
 			},
 			exepectedErrMsg: "does not support values",
 		},
-		"some values, but no valueable step": {
+		"some values, but no steps which takes values": {
 			values: []pkgingv1alpha1.PackageInstallValues{
 				{SecretRef: &pkgingv1alpha1.PackageInstallValuesSecretRef{Name: "foo-bar"}},
 			},
@@ -412,7 +412,7 @@ func TestAppPackageIntallValuesForTemplateSteps(t *testing.T) {
 					{Sops: &kcv1alpha1.AppTemplateSops{}},
 				}
 			},
-			exepectedErrMsg: "no template step of class 'valueable' found",
+			exepectedErrMsg: "no template step of class 'takesValues' found",
 		},
 		"values for specific steps": {
 			values: []pkgingv1alpha1.PackageInstallValues{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This allows finer grained configurations of an `app`'s template steps from a `pkgi`.

- `values` in a `pkgi` can be configured to be be attached to a specific template step in the resulting `app`
- configuration of an `app`'s template step, through annotations on the `pkgi`, can be configured to apply to a specific templating step 

#### Which issue(s) this PR fixes:

Related issues / comments:
- https://github.com/carvel-dev/kapp-controller/issues/1461#issuecomment-1970271302
- https://github.com/carvel-dev/kapp-controller/issues/122

#### Does this PR introduce a user-facing change?

First off: the previous behavior regarding values and annotations should have kept the same, so this should be fully backwards compatible.

It introduces a couple of new and additional knobs:

- `pkgi.spec.values.templateSteps` is an `[]int`
  - it's optional and default to an empty list, which then behaves like before this change
  - `pkgi.spec.values.templateSteps: [ 0 , 2 ]` would attach this value secret as a value to the first and third template step
  - if a template step does not take values, or a non-existing template step is referenced, an error is produced
- In addition to the already existing annotations[^existingAnnos], new ones[^newAnnos] have been introduced, modeled after the "fetch secret annotation"[^fetchSecretAnno]:
  - e.g. in addition to `ext.packaging.carvel.dev/helm-template-name` which applies to the first helm template step, `ext.packaging.carvel.dev/helm-0-template-name` can be used to explicitly target the first template step
  - if for a referenced template step the annotation is not relevant (a "helm annotation" for a ytt template step), the annotation is ignored, i.e. no error is produced
  - the original annotations are still used (for the first relevant templating step), again keeping the current behavior

Note: A user deploying a `pkgi` would still need to understand the implementation details of the `pkg`, i.e. which template steps it consists off, which values a certain step takes, ...


[^fetchSecretAnno]: `ext.packaging.carvel.dev/fetch-%d-secret-name`

[^existingAnnos]: `ext.packaging.carvel.dev/helm-template-name` <br/> `ext.packaging.carvel.dev/helm-template-namespace` <br/> `ext.packaging.carvel.dev/ytt-paths-from-secret-name` <br/> `ext.packaging.carvel.dev/helm-template-values-from-secret-name` <br/> `ext.packaging.carvel.dev/ytt-data-values-overlays`

[^newAnnos]: `ext.packaging.carvel.dev/helm-%d-template-name` <br/> `ext.packaging.carvel.dev/helm-%d-template-namespace` <br/> `ext.packaging.carvel.dev/ytt-%d-paths-from-secret-name` <br/> `ext.packaging.carvel.dev/helm-%d-template-values-from-secret-name` <br/> `ext.packaging.carvel.dev/ytt-%d-data-values-overlays`

```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
