### PR TITLE
Change copyright notices to Carvel Authors

### DIFF
--- a/cli/cmd/kctrl/kctrl.go
+++ b/cli/cmd/kctrl/kctrl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cli/pkg/kctrl/cmd/app/app.go
+++ b/cli/pkg/kctrl/cmd/app/app.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/app_tailer.go
+++ b/cli/pkg/kctrl/cmd/app/app_tailer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/app_tailer_test.go
+++ b/cli/pkg/kctrl/cmd/app/app_tailer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 package app
 

--- a/cli/pkg/kctrl/cmd/app/delete.go
+++ b/cli/pkg/kctrl/cmd/app/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/get.go
+++ b/cli/pkg/kctrl/cmd/app/get.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/init.go
+++ b/cli/pkg/kctrl/cmd/app/init.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/kick.go
+++ b/cli/pkg/kctrl/cmd/app/kick.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/list.go
+++ b/cli/pkg/kctrl/cmd/app/list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/pause.go
+++ b/cli/pkg/kctrl/cmd/app/pause.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/app/release/imgpkg_runner.go
+++ b/cli/pkg/kctrl/cmd/app/release/imgpkg_runner.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/app/release/release.go
+++ b/cli/pkg/kctrl/cmd/app/release/release.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/app/release/release_cmd_runner.go
+++ b/cli/pkg/kctrl/cmd/app/release/release_cmd_runner.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/app/status.go
+++ b/cli/pkg/kctrl/cmd/app/status.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/cli/pkg/kctrl/cmd/completion.go
+++ b/cli/pkg/kctrl/cmd/completion.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cli/pkg/kctrl/cmd/core/age_value.go
+++ b/cli/pkg/kctrl/cmd/core/age_value.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/config_factory.go
+++ b/cli/pkg/kctrl/cmd/core/config_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/deduping_messages_ui.go
+++ b/cli/pkg/kctrl/cmd/core/deduping_messages_ui.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/deps_factory.go
+++ b/cli/pkg/kctrl/cmd/core/deps_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/examples.go
+++ b/cli/pkg/kctrl/cmd/core/examples.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/file_sources.go
+++ b/cli/pkg/kctrl/cmd/core/file_sources.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/flags_factory.go
+++ b/cli/pkg/kctrl/cmd/core/flags_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/help_sections.go
+++ b/cli/pkg/kctrl/cmd/core/help_sections.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/kube_api_flags.go
+++ b/cli/pkg/kctrl/cmd/core/kube_api_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/kubeconfig_flags.go
+++ b/cli/pkg/kctrl/cmd/core/kubeconfig_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/messages_ui.go
+++ b/cli/pkg/kctrl/cmd/core/messages_ui.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/namespace_flags.go
+++ b/cli/pkg/kctrl/cmd/core/namespace_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/namespace_value.go
+++ b/cli/pkg/kctrl/cmd/core/namespace_value.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
+++ b/cli/pkg/kctrl/cmd/core/secure_namespace_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/semver_value.go
+++ b/cli/pkg/kctrl/cmd/core/semver_value.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/status_logging_ui.go
+++ b/cli/pkg/kctrl/cmd/core/status_logging_ui.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/strings_single_line_value.go
+++ b/cli/pkg/kctrl/cmd/core/strings_single_line_value.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/truncated_value.go
+++ b/cli/pkg/kctrl/cmd/core/truncated_value.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/unknown_bool_value.go
+++ b/cli/pkg/kctrl/cmd/core/unknown_bool_value.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/core/wait_flags.go
+++ b/cli/pkg/kctrl/cmd/core/wait_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/cli/pkg/kctrl/cmd/dev/cmd.go
+++ b/cli/pkg/kctrl/cmd/dev/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package dev

--- a/cli/pkg/kctrl/cmd/kctrl.go
+++ b/cli/pkg/kctrl/cmd/kctrl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cli/pkg/kctrl/cmd/logger_flags.go
+++ b/cli/pkg/kctrl/cmd/logger_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cli/pkg/kctrl/cmd/package/available/cmd.go
+++ b/cli/pkg/kctrl/cmd/package/available/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package available

--- a/cli/pkg/kctrl/cmd/package/available/default_values.go
+++ b/cli/pkg/kctrl/cmd/package/available/default_values.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package available

--- a/cli/pkg/kctrl/cmd/package/available/get.go
+++ b/cli/pkg/kctrl/cmd/package/available/get.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package available

--- a/cli/pkg/kctrl/cmd/package/available/list.go
+++ b/cli/pkg/kctrl/cmd/package/available/list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package available

--- a/cli/pkg/kctrl/cmd/package/available/values_schema.go
+++ b/cli/pkg/kctrl/cmd/package/available/values_schema.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package available

--- a/cli/pkg/kctrl/cmd/package/init.go
+++ b/cli/pkg/kctrl/cmd/package/init.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkg

--- a/cli/pkg/kctrl/cmd/package/installed/cmd.go
+++ b/cli/pkg/kctrl/cmd/package/installed/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/created_resource_annotations.go
+++ b/cli/pkg/kctrl/cmd/package/installed/created_resource_annotations.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/created_resource_kind.go
+++ b/cli/pkg/kctrl/cmd/package/installed/created_resource_kind.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/delete.go
+++ b/cli/pkg/kctrl/cmd/package/installed/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/get.go
+++ b/cli/pkg/kctrl/cmd/package/installed/get.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/list.go
+++ b/cli/pkg/kctrl/cmd/package/installed/list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
+++ b/cli/pkg/kctrl/cmd/package/installed/pause_or_kick.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/status.go
+++ b/cli/pkg/kctrl/cmd/package/installed/status.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlay_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
+++ b/cli/pkg/kctrl/cmd/package/installed/ytt_overlays.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package installed

--- a/cli/pkg/kctrl/cmd/package/pkg.go
+++ b/cli/pkg/kctrl/cmd/package/pkg.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkg

--- a/cli/pkg/kctrl/cmd/package/release/artefact_writer.go
+++ b/cli/pkg/kctrl/cmd/package/release/artefact_writer.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package schemagenerator

--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package schemagenerator_test

--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/openapi_schema_gen.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/openapi_schema_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package schemagenerator

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/package/repository/cmd.go
+++ b/cli/pkg/kctrl/cmd/package/repository/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/package/repository/delete.go
+++ b/cli/pkg/kctrl/cmd/package/repository/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/package/repository/get.go
+++ b/cli/pkg/kctrl/cmd/package/repository/get.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/package/repository/kick.go
+++ b/cli/pkg/kctrl/cmd/package/repository/kick.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/package/repository/list.go
+++ b/cli/pkg/kctrl/cmd/package/repository/list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/package/repository/release/release_cmd_runner.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/release_cmd_runner.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package release

--- a/cli/pkg/kctrl/cmd/package/repository/repo_tailer.go
+++ b/cli/pkg/kctrl/cmd/package/repository/repo_tailer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/cli/pkg/kctrl/cmd/ui_flags.go
+++ b/cli/pkg/kctrl/cmd/ui_flags.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cli/pkg/kctrl/cmd/version.go
+++ b/cli/pkg/kctrl/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/cli/pkg/kctrl/local/buildconfigs/app_build.go
+++ b/cli/pkg/kctrl/local/buildconfigs/app_build.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package buildconfigs

--- a/cli/pkg/kctrl/local/buildconfigs/pkg_build.go
+++ b/cli/pkg/kctrl/local/buildconfigs/pkg_build.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package buildconfigs

--- a/cli/pkg/kctrl/local/config.go
+++ b/cli/pkg/kctrl/local/config.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package local

--- a/cli/pkg/kctrl/local/detailed_cmd_runner.go
+++ b/cli/pkg/kctrl/local/detailed_cmd_runner.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package local

--- a/cli/pkg/kctrl/local/local_vendir.go
+++ b/cli/pkg/kctrl/local/local_vendir.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package local

--- a/cli/pkg/kctrl/local/min_core_client.go
+++ b/cli/pkg/kctrl/local/min_core_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package local

--- a/cli/pkg/kctrl/local/reconciler.go
+++ b/cli/pkg/kctrl/local/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package local

--- a/cli/pkg/kctrl/local/sources/git.go
+++ b/cli/pkg/kctrl/local/sources/git.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sources

--- a/cli/pkg/kctrl/local/sources/github_release.go
+++ b/cli/pkg/kctrl/local/sources/github_release.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sources

--- a/cli/pkg/kctrl/local/sources/helm.go
+++ b/cli/pkg/kctrl/local/sources/helm.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sources

--- a/cli/pkg/kctrl/local/sources/source.go
+++ b/cli/pkg/kctrl/local/sources/source.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sources

--- a/cli/pkg/kctrl/local/sources/template.go
+++ b/cli/pkg/kctrl/local/sources/template.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sources

--- a/cli/pkg/kctrl/logger/interface.go
+++ b/cli/pkg/kctrl/logger/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package logger

--- a/cli/pkg/kctrl/logger/noop.go
+++ b/cli/pkg/kctrl/logger/noop.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package logger

--- a/cli/pkg/kctrl/logger/ui.go
+++ b/cli/pkg/kctrl/logger/ui.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package logger

--- a/cli/pkg/kctrl/version/version.go
+++ b/cli/pkg/kctrl/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package version

--- a/cli/test/e2e/app_commands_test.go
+++ b/cli/test/e2e/app_commands_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/cluster_resource.go
+++ b/cli/test/e2e/cluster_resource.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/controller_version_test.go
+++ b/cli/test/e2e/controller_version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/dev_test.go
+++ b/cli/test/e2e/dev_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/e2e.go
+++ b/cli/test/e2e/e2e.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/env.go
+++ b/cli/test/e2e/env.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/help_test.go
+++ b/cli/test/e2e/help_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/kapp.go
+++ b/cli/test/e2e/kapp.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/kctrl.go
+++ b/cli/test/e2e/kctrl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/kubectl.go
+++ b/cli/test/e2e/kubectl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/package_available_test.go
+++ b/cli/test/e2e/package_available_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/pkgi_values_test.go
+++ b/cli/test/e2e/pkgi_values_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/release_with_changed_spec_test.go
+++ b/cli/test/e2e/release_with_changed_spec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/service_accounts.go
+++ b/cli/test/e2e/service_accounts.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/version_test.go
+++ b/cli/test/e2e/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cli/test/e2e/ytt_overlays_test.go
+++ b/cli/test/e2e/ytt_overlays_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/cmd/controller/err_reconciler.go
+++ b/cmd/controller/err_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main provides a Reconciler implementation for simple error handling

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/controller/sidecarexec.go
+++ b/cmd/controller/sidecarexec.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/cmd/controller/unique_reconciler.go
+++ b/cmd/controller/unique_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,2 +1,2 @@
-Copyright {{copyright-year}} VMware, Inc.
+Copyright {{copyright-year}} The Carvel Authors.
 SPDX-License-Identifier: Apache-2.0

--- a/hack/dependencies.go
+++ b/hack/dependencies.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main contains a dependency tool that can read a .yml file and update the dependencies of kapp-controller

--- a/hack/dependencies_test.go
+++ b/hack/dependencies_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 // +build tools
 

--- a/pkg/apis/internalpackaging/install/install.go
+++ b/pkg/apis/internalpackaging/install/install.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package install

--- a/pkg/apis/internalpackaging/v1alpha1/doc.go
+++ b/pkg/apis/internalpackaging/v1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // +k8s:deepcopy-gen=package

--- a/pkg/apis/internalpackaging/v1alpha1/register.go
+++ b/pkg/apis/internalpackaging/v1alpha1/register.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/internalpackaging/v1alpha1/types.go
+++ b/pkg/apis/internalpackaging/v1alpha1/types.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/kappctrl/install/install.go
+++ b/pkg/apis/kappctrl/install/install.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package install

--- a/pkg/apis/kappctrl/v1alpha1/doc.go
+++ b/pkg/apis/kappctrl/v1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // +k8s:deepcopy-gen=package

--- a/pkg/apis/kappctrl/v1alpha1/register.go
+++ b/pkg/apis/kappctrl/v1alpha1/register.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/kappctrl/v1alpha1/status.go
+++ b/pkg/apis/kappctrl/v1alpha1/status.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/kappctrl/v1alpha1/types.go
+++ b/pkg/apis/kappctrl/v1alpha1/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/kappctrl/v1alpha1/types_deploy.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_deploy.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/kappctrl/v1alpha1/types_fetch.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_fetch.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/kappctrl/v1alpha1/types_template.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_template.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:revive // we're unlikely to write descriptive godoc comments in this file.

--- a/pkg/apis/packaging/install/install.go
+++ b/pkg/apis/packaging/install/install.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package install

--- a/pkg/apis/packaging/v1alpha1/doc.go
+++ b/pkg/apis/packaging/v1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // +k8s:deepcopy-gen=package

--- a/pkg/apis/packaging/v1alpha1/package_install.go
+++ b/pkg/apis/packaging/v1alpha1/package_install.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/packaging/v1alpha1/package_repository.go
+++ b/pkg/apis/packaging/v1alpha1/package_repository.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apis/packaging/v1alpha1/register.go
+++ b/pkg/apis/packaging/v1alpha1/register.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apiserver/apis/datapackaging/doc.go
+++ b/pkg/apiserver/apis/datapackaging/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // +k8s:deepcopy-gen=package

--- a/pkg/apiserver/apis/datapackaging/install/install.go
+++ b/pkg/apiserver/apis/datapackaging/install/install.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package install

--- a/pkg/apiserver/apis/datapackaging/register.go
+++ b/pkg/apiserver/apis/datapackaging/register.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging

--- a/pkg/apiserver/apis/datapackaging/types.go
+++ b/pkg/apiserver/apis/datapackaging/types.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging

--- a/pkg/apiserver/apis/datapackaging/v1alpha1/conversion.go
+++ b/pkg/apiserver/apis/datapackaging/v1alpha1/conversion.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apiserver/apis/datapackaging/v1alpha1/doc.go
+++ b/pkg/apiserver/apis/datapackaging/v1alpha1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // +k8s:openapi-gen=true

--- a/pkg/apiserver/apis/datapackaging/v1alpha1/register.go
+++ b/pkg/apiserver/apis/datapackaging/v1alpha1/register.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apiserver/apis/datapackaging/v1alpha1/types.go
+++ b/pkg/apiserver/apis/datapackaging/v1alpha1/types.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/pkg/apiserver/apis/datapackaging/validation/validations.go
+++ b/pkg/apiserver/apis/datapackaging/validation/validations.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package validation

--- a/pkg/apiserver/apis/datapackaging/validation/validations_test.go
+++ b/pkg/apiserver/apis/datapackaging/validation/validations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package validation_test

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package apiserver

--- a/pkg/apiserver/registry/datapackaging/package_crd_rest.go
+++ b/pkg/apiserver/registry/datapackaging/package_crd_rest.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging

--- a/pkg/apiserver/registry/datapackaging/package_crd_rest_test.go
+++ b/pkg/apiserver/registry/datapackaging/package_crd_rest_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging_test

--- a/pkg/apiserver/registry/datapackaging/package_metadata_crd_rest.go
+++ b/pkg/apiserver/registry/datapackaging/package_metadata_crd_rest.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging

--- a/pkg/apiserver/registry/datapackaging/package_metadata_crd_rest_test.go
+++ b/pkg/apiserver/registry/datapackaging/package_metadata_crd_rest_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging_test

--- a/pkg/apiserver/registry/datapackaging/package_metadata_storage_client.go
+++ b/pkg/apiserver/registry/datapackaging/package_metadata_storage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging

--- a/pkg/apiserver/registry/datapackaging/package_storage_client.go
+++ b/pkg/apiserver/registry/datapackaging/package_storage_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package datapackaging

--- a/pkg/apiserver/watchers/translation_watcher.go
+++ b/pkg/apiserver/watchers/translation_watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package watchers

--- a/pkg/apiserver/watchers/translation_watcher_test.go
+++ b/pkg/apiserver/watchers/translation_watcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package watchers

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_deploy.go
+++ b/pkg/app/app_deploy.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_factory.go
+++ b/pkg/app/app_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_fetch.go
+++ b/pkg/app/app_fetch.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_reconcile_test.go
+++ b/pkg/app/app_reconcile_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_template.go
+++ b/pkg/app/app_template.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app_test

--- a/pkg/app/crd_app.go
+++ b/pkg/app/crd_app.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/crd_app_watcher.go
+++ b/pkg/app/crd_app_watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/finalizer.go
+++ b/pkg/app/finalizer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/reconcile_timer.go
+++ b/pkg/app/reconcile_timer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/reconcile_timer_test.go
+++ b/pkg/app/reconcile_timer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/reconciler.go
+++ b/pkg/app/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app

--- a/pkg/app/reconciler_test.go
+++ b/pkg/app/reconciler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package app_test

--- a/pkg/componentinfo/component_info.go
+++ b/pkg/componentinfo/component_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package componentinfo provides access to version and configuration information about components of the system.

--- a/pkg/componentinfo/component_info_test.go
+++ b/pkg/componentinfo/component_info_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package componentinfo_test

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/pkg/config/os_config.go
+++ b/pkg/config/os_config.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/reconciler.go
+++ b/pkg/config/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/config/scheme.go
+++ b/pkg/config/scheme.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/pkg/deploy/cmd_run_result_buf.go
+++ b/pkg/deploy/cmd_run_result_buf.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package deploy

--- a/pkg/deploy/factory.go
+++ b/pkg/deploy/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package deploy

--- a/pkg/deploy/interfaces.go
+++ b/pkg/deploy/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package deploy

--- a/pkg/deploy/kapp.go
+++ b/pkg/deploy/kapp.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package deploy

--- a/pkg/deploy/kapp_restrict.go
+++ b/pkg/deploy/kapp_restrict.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package deploy

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package exec

--- a/pkg/exec/cmd_runner.go
+++ b/pkg/exec/cmd_runner.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package exec

--- a/pkg/exec/doc.go
+++ b/pkg/exec/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package exec wraps os/exec to add a little error sanitization and standardization around process return codes and a channel-based cancel mechanism

--- a/pkg/exec/flag.go
+++ b/pkg/exec/flag.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package exec

--- a/pkg/exec/flag_test.go
+++ b/pkg/exec/flag_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package exec_test

--- a/pkg/fetch/doc.go
+++ b/pkg/fetch/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package fetch provides information retrieval, mostly by wrapping vendir.

--- a/pkg/fetch/factory.go
+++ b/pkg/fetch/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package fetch

--- a/pkg/fetch/inline.go
+++ b/pkg/fetch/inline.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package fetch

--- a/pkg/fetch/vendir.go
+++ b/pkg/fetch/vendir.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package fetch

--- a/pkg/fetch/vendir_test.go
+++ b/pkg/fetch/vendir_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package fetch_test

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package kubeconfig provides access to the cluster for kapp-controller

--- a/pkg/kubeconfig/kubeconfig_restricted.go
+++ b/pkg/kubeconfig/kubeconfig_restricted.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kubeconfig

--- a/pkg/kubeconfig/kubeconfig_secrets.go
+++ b/pkg/kubeconfig/kubeconfig_secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kubeconfig

--- a/pkg/kubeconfig/service_accounts.go
+++ b/pkg/kubeconfig/service_accounts.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kubeconfig

--- a/pkg/memdir/doc.go
+++ b/pkg/memdir/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package memdir is used to create temporary directories while writing to the filesystem to handle security and concurrency issues.

--- a/pkg/memdir/scoped.go
+++ b/pkg/memdir/scoped.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package memdir

--- a/pkg/memdir/subpath.go
+++ b/pkg/memdir/subpath.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package memdir

--- a/pkg/memdir/tmp_dir.go
+++ b/pkg/memdir/tmp_dir.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package memdir

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/reconcile_count_metrics.go
+++ b/pkg/metrics/reconcile_count_metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/pkg/metrics/reconcile_time_metrics.go
+++ b/pkg/metrics/reconcile_time_metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package metrics to define all prometheus metric methods

--- a/pkg/packageinstall/app.go
+++ b/pkg/packageinstall/app.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/app_test.go
+++ b/pkg/packageinstall/app_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall_test

--- a/pkg/packageinstall/finalizer.go
+++ b/pkg/packageinstall/finalizer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/packageinstall.go
+++ b/pkg/packageinstall/packageinstall.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/packageinstall_deletion_test.go
+++ b/pkg/packageinstall/packageinstall_deletion_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/packageinstall_downgrade_test.go
+++ b/pkg/packageinstall/packageinstall_downgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/packageinstall_test.go
+++ b/pkg/packageinstall/packageinstall_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/packageinstall_version_handler.go
+++ b/pkg/packageinstall/packageinstall_version_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/packageinstall/packageinstall_version_handler_test.go
+++ b/pkg/packageinstall/packageinstall_version_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall_test

--- a/pkg/packageinstall/reconciler.go
+++ b/pkg/packageinstall/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package packageinstall

--- a/pkg/pkgrepository/app.go
+++ b/pkg/pkgrepository/app.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_deploy.go
+++ b/pkg/pkgrepository/app_deploy.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_factory.go
+++ b/pkg/pkgrepository/app_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_fetch.go
+++ b/pkg/pkgrepository/app_fetch.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_reconcile.go
+++ b/pkg/pkgrepository/app_reconcile.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_reconcile_test.go
+++ b/pkg/pkgrepository/app_reconcile_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_template.go
+++ b/pkg/pkgrepository/app_template.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/app_template_test.go
+++ b/pkg/pkgrepository/app_template_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository_test

--- a/pkg/pkgrepository/crd_app.go
+++ b/pkg/pkgrepository/crd_app.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/finalizer.go
+++ b/pkg/pkgrepository/finalizer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/package_repo_app.go
+++ b/pkg/pkgrepository/package_repo_app.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/package_repo_app_test.go
+++ b/pkg/pkgrepository/package_repo_app_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/reconcile_timer.go
+++ b/pkg/pkgrepository/reconcile_timer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/reconcile_timer_test.go
+++ b/pkg/pkgrepository/reconcile_timer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/reconciler.go
+++ b/pkg/pkgrepository/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository

--- a/pkg/pkgrepository/reconciler_test.go
+++ b/pkg/pkgrepository/reconciler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkgrepository_test

--- a/pkg/reconciler/configmap_handler.go
+++ b/pkg/reconciler/configmap_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reconciler

--- a/pkg/reconciler/secret_handler.go
+++ b/pkg/reconciler/secret_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reconciler

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reconciler

--- a/pkg/reftracker/app_update_status.go
+++ b/pkg/reftracker/app_update_status.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reftracker

--- a/pkg/reftracker/doc.go
+++ b/pkg/reftracker/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package reftracker contains structs used for tracking secret and configmap referenced by the app.

--- a/pkg/reftracker/ref_key.go
+++ b/pkg/reftracker/ref_key.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reftracker

--- a/pkg/reftracker/ref_tracker.go
+++ b/pkg/reftracker/ref_tracker.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reftracker

--- a/pkg/reftracker/ref_tracker_test.go
+++ b/pkg/reftracker/ref_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package reftracker_test

--- a/pkg/satoken/token_manager.go
+++ b/pkg/satoken/token_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // This file is a modified version of

--- a/pkg/satoken/token_manager_test.go
+++ b/pkg/satoken/token_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // This file is a modified version of

--- a/pkg/sidecarexec/client.go
+++ b/pkg/sidecarexec/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package sidecarexec provides an implementation of a sidecar container in kapp-controller which

--- a/pkg/sidecarexec/cmd_exec.go
+++ b/pkg/sidecarexec/cmd_exec.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sidecarexec

--- a/pkg/sidecarexec/cmd_exec_client.go
+++ b/pkg/sidecarexec/cmd_exec_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sidecarexec

--- a/pkg/sidecarexec/os_config.go
+++ b/pkg/sidecarexec/os_config.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sidecarexec

--- a/pkg/sidecarexec/os_config_client.go
+++ b/pkg/sidecarexec/os_config_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sidecarexec

--- a/pkg/sidecarexec/os_config_test.go
+++ b/pkg/sidecarexec/os_config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sidecarexec_test

--- a/pkg/sidecarexec/server.go
+++ b/pkg/sidecarexec/server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package sidecarexec

--- a/pkg/template/cue.go
+++ b/pkg/template/cue.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package template provides a factory pattern design of instantiating a new "templater" in kapp-controller

--- a/pkg/template/downward_api_values.go
+++ b/pkg/template/downward_api_values.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/factory.go
+++ b/pkg/template/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/helm_template.go
+++ b/pkg/template/helm_template.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/interfaces.go
+++ b/pkg/template/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/kbld.go
+++ b/pkg/template/kbld.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/sops.go
+++ b/pkg/template/sops.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/values.go
+++ b/pkg/template/values.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/values_test.go
+++ b/pkg/template/values_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/pkg/template/ytt.go
+++ b/pkg/template/ytt.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package template

--- a/test/bench/pkgr_test.go
+++ b/test/bench/pkgr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package bench

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/test/e2e/env.go
+++ b/test/e2e/env.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/test/e2e/kapp.go
+++ b/test/e2e/kapp.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/test/e2e/kappcontroller/apiserver_protobuf_test.go
+++ b/test/e2e/kappcontroller/apiserver_protobuf_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/app_secret_configmap_reconcile_test.go
+++ b/test/e2e/kappcontroller/app_secret_configmap_reconcile_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/app_status_test.go
+++ b/test/e2e/kappcontroller/app_status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/cancel_test.go
+++ b/test/e2e/kappcontroller/cancel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/config_test.go
+++ b/test/e2e/kappcontroller/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/default_namespace_test.go
+++ b/test/e2e/kappcontroller/default_namespace_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/delete_test.go
+++ b/test/e2e/kappcontroller/delete_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/fetch_test.go
+++ b/test/e2e/kappcontroller/fetch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/git_test.go
+++ b/test/e2e/kappcontroller/git_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/helm_test.go
+++ b/test/e2e/kappcontroller/helm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/http_test.go
+++ b/test/e2e/kappcontroller/http_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/imgpkg_bundle_test.go
+++ b/test/e2e/kappcontroller/imgpkg_bundle_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/metrics_test.go
+++ b/test/e2e/kappcontroller/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/carvel-kapp-controller/test/e2e"
 )
-
 
 func TestPrometheusMetrics(t *testing.T) {
 	env := e2e.BuildEnv(t)

--- a/test/e2e/kappcontroller/migrate_managed_name_test.go
+++ b/test/e2e/kappcontroller/migrate_managed_name_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/multi_fetch_test.go
+++ b/test/e2e/kappcontroller/multi_fetch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/namespace_deletion_test.go
+++ b/test/e2e/kappcontroller/namespace_deletion_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/noopdelete_test.go
+++ b/test/e2e/kappcontroller/noopdelete_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/package_repo_test.go
+++ b/test/e2e/kappcontroller/package_repo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/package_test.go
+++ b/test/e2e/kappcontroller/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/packageinstall_test.go
+++ b/test/e2e/kappcontroller/packageinstall_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/packagemetadata_test.go
+++ b/test/e2e/kappcontroller/packagemetadata_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/pause_test.go
+++ b/test/e2e/kappcontroller/pause_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/service_account_test.go
+++ b/test/e2e/kappcontroller/service_account_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/sops_age_test.go
+++ b/test/e2e/kappcontroller/sops_age_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/sops_test.go
+++ b/test/e2e/kappcontroller/sops_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller

--- a/test/e2e/kappcontroller/template_test.go
+++ b/test/e2e/kappcontroller/template_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package kappcontroller
@@ -326,9 +326,9 @@ stringData:
 
 	logger.Section("deploy", func() {
 		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name}, e2e.RunOpts{
-      StdinReader: strings.NewReader(appYaml),
-      OnErrKubectl: []string{"get", "app", name, "-oyaml"},
-    })
+			StdinReader:  strings.NewReader(appYaml),
+			OnErrKubectl: []string{"get", "app", name, "-oyaml"},
+		})
 	})
 
 	logger.Section("check ConfigMap exists", func() {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/test/e2e/secretgencontroller/private_registry_auth_test.go
+++ b/test/e2e/secretgencontroller/private_registry_auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package secretgencontroller

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2023 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright 2024 The Carvel Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package e2e


### PR DESCRIPTION
#### What this PR does / why we need it:

Change copyright notices to Carvel Authors in every file there was already a copyright header.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1503

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
None
```
I created a script with logging to make these changes. The log for all the Carvel repo changes is here: https://gist.github.com/bentito/c39c38282dd4c856a79f8adb7394180e
NB: `vendor` dirs are all ignored as are any non go, py, js, cpp, or c files, though I think in practice there were only copyright headers on .go files.