### PR TITLE
Fix error handling in package release cli

### DIFF
--- a/cli/pkg/kctrl/cmd/package/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/release/release.go
@@ -134,7 +134,7 @@ func (o *ReleaseOptions) Run() error {
 		case release.Resource != nil:
 			err = o.releaseResources(appSpec, *pkgBuild, &pkgConfigs.Pkgs[0], &pkgConfigs.PkgMetadatas[0])
 			if err != nil {
-				return nil
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
`kctrl package release ... --repo-output ...`  command is silently ignoring errors from releaseResources function.
Say, if incompatible ytt version is installed, this command will not yield any errors but no content will be written to the destination.

The bug seems to be in a simple mistake unconditionally returning nil in case of any errors
 
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes https://github.com/carvel-dev/kapp-controller/issues/1552

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
