### PR TITLE
Add partial support for DownwardsAPI with kctrl package release

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835
 	github.com/cppforlife/go-cli-ui v0.0.0-20220520125801-e45d9169a663
 	github.com/getkin/kin-openapi v0.81.0
+	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-containerregistry v0.13.0
 	github.com/k14s/difflib v0.0.0-20201117154628-0c031775bf57
 	github.com/mitchellh/go-wordwrap v1.0.1
@@ -45,7 +46,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect

--- a/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
+++ b/cli/pkg/kctrl/cmd/app/release/app_spec_builder.go
@@ -59,6 +59,7 @@ func (b *AppSpecBuilder) Build() (kcv1alpha1.AppSpec, error) {
 			},
 		},
 		Spec: kcv1alpha1.AppSpec{
+			ServiceAccountName: "fake-sa",
 			Fetch: []kcv1alpha1.AppFetch{
 				{
 					// To be replaced by local fetch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR allows Packages using DownwardsAPI to obtain `kubernetesAPIs` or `kubernetesVersion` by feeding a false value.
However this value cannot be reliably used to introduce images in the template step for the time being. This does not block users who are not conditionally introducing images based on these parameters.
It mocks CoreV1 client calls made by [`GetServiceAccountToken`](https://github.com/carvel-dev/kapp-controller/blob/develop/pkg/satoken/token_manager.go#L69)

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Partially fixes #1523 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
We should document that using `kappControllerVersion` with DownwardAPI can lead to failures while releasing packages
```
