### PR TITLE
Add defaults for version flag while installing packages using kctrl

### DIFF
--- a/cli/test/e2e/package_install_test.go
+++ b/cli/test/e2e/package_install_test.go
@@ -327,3 +327,14 @@ key1: value1:
 			"--values-file", "-"}, RunOpts{StdinReader: strings.NewReader(valuesFile2)})
 	})
 }
+
+func TestPackageInstallVersionDefaults(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	logger.Section("Listing with error in package install", func() {
+		out, _ := kappCtrl.RunWithOpts([]string{"package", "install", "-i", "asdf", "-p", "asdf.asdf.com", "--dry-run", "-n", "installs"}, RunOpts{})
+		require.Contains(t, out, "constraints: '>= 0.0.0'")
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Introduces a default value for version flag while installing packages using kctrl

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1587 

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
