### PR TITLE
kctrl: Add secret flag for package repo add/update

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -37,7 +37,7 @@ type AddOrUpdateOptions struct {
 	URL                  string
 	SemverTagConstraints string
 	CreateNamespace      bool
-	Secret               string
+	SecretRef            string
 
 	DryRun bool
 
@@ -79,7 +79,7 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 	// TODO consider how to support other repository types
 	cmd.Flags().StringVar(&o.URL, "url", "", "OCI registry url for package repository bundle (required)")
 	cmd.Flags().StringVar(&o.SemverTagConstraints, "semver-tag-constraints", "", "tag/semver constraint when tag is not present in URL (If both tags and semver are present, then tag gets precedence)")
-	cmd.Flags().StringVar(&o.Secret, "secret", "", "SecretRef name for imgpkgbundle, optional")
+	cmd.Flags().StringVarP(&o.SecretRef, "secretref", "s", "", "SecretRef name for imgpkgbundle, optional")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print YAML for resources being applied to the cluster without applying them, optional")
 
 	cmd.Flags().BoolVar(&o.CreateNamespace, "create-namespace", false, "Create the package repository namespace if not present (default false)")
@@ -121,7 +121,7 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 
 	cmd.Flags().StringVarP(&o.URL, "url", "", "", "OCI registry url for package repository bundle (required)")
 	cmd.Flags().StringVarP(&o.SemverTagConstraints, "semver-tag-constraints", "", "", "tag/semver constraint when tag is not present in URL (If both tags and semver are present, then tag gets precedence)")
-	cmd.Flags().StringVarP(&o.Secret, "secret", "", "", "SecretRef name for imgpkgbundle, optional")
+	cmd.Flags().StringVarP(&o.SecretRef, "secretref", "s", "", "SecretRef name for imgpkgbundle, optional")
 
 	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
 		AllowDisableWait: true,
@@ -260,8 +260,8 @@ func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *kcpkg.Package
 		ImgpkgBundle: &kappctrl.AppFetchImgpkgBundle{Image: o.URL},
 	}
 
-	if o.Secret != "" {
-		pkgr.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.Secret}
+	if o.SecretRef != "" {
+		pkgr.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.SecretRef}
 	}
 
 	ref, err := name.ParseReference(o.URL, name.WeakValidation)
@@ -323,8 +323,8 @@ func (o AddOrUpdateOptions) dryRun() error {
 		},
 	}
 
-	if o.Secret != "" {
-		packageRepo.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.Secret}
+	if o.SecretRef != "" {
+		packageRepo.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.SecretRef}
 	}
 
 	ref, err := name.ParseReference(o.URL, name.WeakValidation)

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -79,7 +79,7 @@ func NewAddCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cobra.
 	// TODO consider how to support other repository types
 	cmd.Flags().StringVar(&o.URL, "url", "", "OCI registry url for package repository bundle (required)")
 	cmd.Flags().StringVar(&o.SemverTagConstraints, "semver-tag-constraints", "", "tag/semver constraint when tag is not present in URL (If both tags and semver are present, then tag gets precedence)")
-	cmd.Flags().StringVarP(&o.SecretRef, "secretref", "s", "", "SecretRef name for imgpkgbundle, optional")
+	cmd.Flags().StringVar(&o.SecretRef, "secret-ref", "", "SecretRef name for imgpkgbundle, optional")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print YAML for resources being applied to the cluster without applying them, optional")
 
 	cmd.Flags().BoolVar(&o.CreateNamespace, "create-namespace", false, "Create the package repository namespace if not present (default false)")
@@ -121,7 +121,7 @@ func NewUpdateCmd(o *AddOrUpdateOptions, flagsFactory cmdcore.FlagsFactory) *cob
 
 	cmd.Flags().StringVarP(&o.URL, "url", "", "", "OCI registry url for package repository bundle (required)")
 	cmd.Flags().StringVarP(&o.SemverTagConstraints, "semver-tag-constraints", "", "", "tag/semver constraint when tag is not present in URL (If both tags and semver are present, then tag gets precedence)")
-	cmd.Flags().StringVarP(&o.SecretRef, "secretref", "s", "", "SecretRef name for imgpkgbundle, optional")
+	cmd.Flags().StringVarP(&o.SecretRef, "secret-ref", "", "", "SecretRef name for imgpkgbundle, optional")
 
 	o.WaitFlags.Set(cmd, flagsFactory, &cmdcore.WaitFlagsOpts{
 		AllowDisableWait: true,

--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -260,7 +260,7 @@ func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *kcpkg.Package
 		ImgpkgBundle: &kappctrl.AppFetchImgpkgBundle{Image: o.URL},
 	}
 
-	if strings.TrimSpace(o.Secret) != "" {
+	if o.Secret != "" {
 		pkgr.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.Secret}
 	}
 
@@ -323,7 +323,7 @@ func (o AddOrUpdateOptions) dryRun() error {
 		},
 	}
 
-	if strings.TrimSpace(o.Secret) != "" {
+	if o.Secret != "" {
 		packageRepo.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.Secret}
 	}
 

--- a/cli/test/e2e/package_repo_dry_run_test.go
+++ b/cli/test/e2e/package_repo_dry_run_test.go
@@ -71,3 +71,32 @@ status:
 		require.Contains(t, tagSemverOutput, tagSemverExpectedOutput)
 	})
 }
+
+func TestPackageRepoSecretRefDryRun(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kappCtrl := Kctrl{t, env.Namespace, env.KctrlBinaryPath, logger}
+
+	logger.Section("dry-run package repo add", func() {
+		expectedOutput := `apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  creationTimestamp: null
+  name: test-repo
+  namespace: kctrl-test
+spec:
+  fetch:
+    imgpkgBundle:
+      image: registry.carvel.dev/project/repo:1.0.0
+      secretRef:
+        name: regcred
+status:
+  conditions: null
+  friendlyDescription: ""
+  observedGeneration: 0`
+
+		output := kappCtrl.Run([]string{"package", "repo", "add", "-r", "test-repo", "--url",
+			"registry.carvel.dev/project/repo:1.0.0", "--semver-tag-constraints", "1.0.0", "--secret-ref", "regcred", "--dry-run"})
+		require.Contains(t, output, expectedOutput)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #
1. Add a package repository with secret:
Given I have a custom package repository,
And it is hosted on authenticated registry,
When I add a package repository 
Then I should be able to specify a secret for registry
`kctrl package repository add -r sample-repo --namespace ns --url projects.repo.com/example:1.0.0 --secret repo-secret`
And I execute:
`kubectl get pkgr sample-repo -oyaml`
And I see:
```
apiVersion: packaging.carvel.dev/v1alpha1
kind: PackageRepository
metadata: 
  name: sample-repo
  namespace: ns
spec: 
  fetch: 
    imgpkgBundle: 
      image: projects.repo.com/example:1.0.0
      - secretRef: 
          name: repo-secret
```

2. Update a package repository with secret:
Given I have a package repository created,
When I update the secret for repository
`kctrl package repository update sample-repo --secret repo-secret-2`
And I run
`kubectl get pkgr sample-repo -oyaml`
Then I see:
```
apiVersion: packaging.carvel.dev/v1alpha1
kind: PackageRepository
metadata: 
  name: sample-repo
  namespace: ns
spec: 
  fetch: 
    imgpkgBundle: 
      image: projects.repo.com/example:1.0.0
      - secretRef:   
          name: repo-secret-2
 ```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Update upstream kctrl CLI to refer to a secret while adding or updating package repository
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
