### PR TITLE
kctrl: fix repo update bug when url is same but secret changes

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -196,7 +196,8 @@ func (o *AddOrUpdateOptions) Run(args []string) error {
 		return err
 	}
 
-	if o.URL != "" && o.URL == existingRepository.Spec.Fetch.ImgpkgBundle.Image {
+	if o.URL == existingRepository.Spec.Fetch.ImgpkgBundle.Image &&
+		(o.SecretRef == "" || (existingRepository.Spec.Fetch.ImgpkgBundle.SecretRef != nil && existingRepository.Spec.Fetch.ImgpkgBundle.SecretRef.Name == o.SecretRef)) {
 		return NewRepoTailer(o.NamespaceFlags.Name, o.Name, o.ui, client, RepoTailerOpts{PrintCurrentState: true}).TailRepoStatus()
 	}
 
@@ -260,6 +261,7 @@ func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *kcpkg.Package
 		ImgpkgBundle: &kappctrl.AppFetchImgpkgBundle{Image: o.URL},
 	}
 
+	// the case where a user would want to update the pkgr to remove the secretRef is not supported
 	if o.SecretRef != "" {
 		pkgr.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrl.AppFetchLocalRef{Name: o.SecretRef}
 	}


### PR DESCRIPTION

#### What this PR does / why we need it:
Fixes the bug in package repo update where updating a secretRef alone is not working

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
None

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
