### PR TITLE
kctrl: ensure secretRef is intact when only url is updated for pkgr

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/repository/add_or_update.go
@@ -254,12 +254,16 @@ func (o *AddOrUpdateOptions) newPackageRepository() (*kcpkg.PackageRepository, e
 }
 
 func (o *AddOrUpdateOptions) updateExistingPackageRepository(pkgr *kcpkg.PackageRepository) (*kcpkg.PackageRepository, error) {
-
 	pkgr = pkgr.DeepCopy()
 
-	pkgr.Spec.Fetch = &kcpkg.PackageRepositoryFetch{
+	fetch := &kcpkg.PackageRepositoryFetch{
 		ImgpkgBundle: &kappctrl.AppFetchImgpkgBundle{Image: o.URL},
 	}
+
+	if pkgr.Spec.Fetch != nil && pkgr.Spec.Fetch.ImgpkgBundle != nil {
+		fetch.ImgpkgBundle.SecretRef = pkgr.Spec.Fetch.ImgpkgBundle.SecretRef
+	}
+	pkgr.Spec.Fetch = fetch
 
 	// the case where a user would want to update the pkgr to remove the secretRef is not supported
 	if o.SecretRef != "" {

--- a/cli/test/e2e/package_repository_test.go
+++ b/cli/test/e2e/package_repository_test.go
@@ -214,9 +214,9 @@ func TestPackageRepository(t *testing.T) {
 		_, _ = kappCtrl.RunWithOpts([]string{"package", "repository", "add", "-r", pkgrWithSecretName, "--url", pkgrURL, "--secret-ref", pkgrSecretRef}, RunOpts{
 			AllowError: true})
 
-		pkgrYaml := kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
+		pkgrJson := kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
 		pkgr := &kcpkg.PackageRepository{}
-		err := json.Unmarshal([]byte(pkgrYaml), pkgr)
+		err := json.Unmarshal([]byte(pkgrJson), pkgr)
 		require.NoError(t, err)
 		require.Equal(t, pkgrSecretRef, pkgr.Spec.Fetch.ImgpkgBundle.SecretRef.Name)
 
@@ -233,9 +233,9 @@ func TestPackageRepository(t *testing.T) {
 		kappCtrl.RunWithOpts([]string{"package", "repository", "update", "-r", pkgrWithSecretName, "--url", pkgrURL, "--secret-ref", pkgrSecretRef}, RunOpts{
 			AllowError: true})
 
-		pkgrYaml := kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
+		pkgrJson := kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
 		pkgr := &kcpkg.PackageRepository{}
-		err = json.Unmarshal([]byte(pkgrYaml), pkgr)
+		err = json.Unmarshal([]byte(pkgrJson), pkgr)
 		require.NoError(t, err)
 		require.Equal(t, pkgrSecretRef, pkgr.Spec.Fetch.ImgpkgBundle.SecretRef.Name)
 
@@ -243,10 +243,23 @@ func TestPackageRepository(t *testing.T) {
 		kappCtrl.RunWithOpts([]string{"package", "repository", "update", "-r", pkgrWithSecretName, "--url", pkgrURL, "--secret-ref", pkgrSecretRef + "-2"}, RunOpts{
 			AllowError: true})
 
-		pkgrYaml = kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
+		pkgrJson = kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
 		pkgr = &kcpkg.PackageRepository{}
-		err = json.Unmarshal([]byte(pkgrYaml), pkgr)
+		err = json.Unmarshal([]byte(pkgrJson), pkgr)
 		require.NoError(t, err)
+		require.Equal(t, pkgrSecretRef+"-2", pkgr.Spec.Fetch.ImgpkgBundle.SecretRef.Name)
+	})
+
+	logger.Section("updating just the url of a repository with secret", func() {
+		// update just the url, secret should be intact
+		kappCtrl.RunWithOpts([]string{"package", "repository", "update", "-r", pkgrWithSecretName, "--url", pkgrURL + "-new"}, RunOpts{
+			AllowError: true})
+
+		pkgrJson := kubectl.Run([]string{"get", kind, pkgrWithSecretName, "-ojson"})
+		pkgr := &kcpkg.PackageRepository{}
+		err := json.Unmarshal([]byte(pkgrJson), pkgr)
+		require.NoError(t, err)
+		require.Equal(t, pkgrURL+"-new", pkgr.Spec.Fetch.ImgpkgBundle.Image)
 		require.Equal(t, pkgrSecretRef+"-2", pkgr.Spec.Fetch.ImgpkgBundle.SecretRef.Name)
 	})
 }


### PR DESCRIPTION
#### Additional Notes for your reviewer:
takes care of cases not covered in PR #1635

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
