### PR TITLE
Add tag cli args for pkg repo release

### DIFF
--- a/cli/pkg/kctrl/cmd/package/repository/release/release.go
+++ b/cli/pkg/kctrl/cmd/package/repository/release/release.go
@@ -27,6 +27,7 @@ type ReleaseOptions struct {
 	chdir          string
 	outputLocation string
 	debug          bool
+	tag            string
 }
 
 const (
@@ -58,6 +59,7 @@ func NewReleaseCmd(o *ReleaseOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.chdir, "chdir", "", "Location of the working directory")
 	cmd.Flags().StringVar(&o.outputLocation, "copy-to", "", "Output location for pkgrepo-build.yml")
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "Include debug output")
+	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", "Tag pushed with imgpkg bundle (default build-<TIMESTAMP>)")
 
 	return cmd
 }
@@ -157,10 +159,15 @@ func (o *ReleaseOptions) Run() error {
 
 	var bundleURL string
 
+	tag := o.pkgRepoVersion
+	if o.tag != "" {
+		tag = o.tag
+	}
+
 	switch {
 	case pkgRepoBuild.Spec.Export.ImgpkgBundle != nil:
 		imgpkgRunner := ImgpkgRunner{
-			BundlePath:        fmt.Sprintf("%s:%s", pkgRepoBuild.Spec.Export.ImgpkgBundle.Image, o.pkgRepoVersion),
+			BundlePath:        fmt.Sprintf("%s:%s", pkgRepoBuild.Spec.Export.ImgpkgBundle.Image, tag),
 			Paths:             []string{"packages"},
 			UseKbldImagesLock: true,
 			ImgLockFilepath:   tempImgpkgLockPath,

--- a/cli/test/e2e/package_repo_release_test.go
+++ b/cli/test/e2e/package_repo_release_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -49,13 +50,21 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 			promptOutput.Write(env.Image)
 		}()
 
-		kctrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir, "--version", "1.0.0"},
+		version := "1.0.0"
+		kctrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir, "--version", version},
 			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
 				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
 
 		keysToBeIgnored := []string{"creationTimestamp:", "image"}
 		verifyPackageRepoBuild(t, keysToBeIgnored)
 		verifyPackageRepository(t, keysToBeIgnored)
+
+		args := []string{"tag", "list", "-i", os.Getenv("KCTRL_E2E_IMAGE")}
+		cmd := exec.Command("imgpkg", args...)
+		output, err := cmd.Output()
+		// t.Logf("the tags are: %s", output)
+		require.Contains(t, string(output), version)
+		require.NoError(t, err, "There was an error in listing the tags")
 	})
 
 	logger.Section("Creating a package repository interactively with tags using pkg repo release", func() {
@@ -66,13 +75,22 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 			promptOutput.Write(env.Image)
 		}()
 
-		kctrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir, "--version", "1.0.0", "--tag", "build-tag-0001"},
+		version := "1.0.0"
+		tag := "build-tag-0001"
+		kctrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir, "--version", version, "--tag", tag},
 			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
 				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
 
 		keysToBeIgnored := []string{"creationTimestamp:", "image"}
 		verifyPackageRepoBuild(t, keysToBeIgnored)
 		verifyPackageRepository(t, keysToBeIgnored)
+
+		args := []string{"tag", "list", "-i", os.Getenv("KCTRL_E2E_IMAGE")}
+		cmd := exec.Command("imgpkg", args...)
+		output, err := cmd.Output()
+		// t.Logf("the tags are: %s", output)
+		require.Contains(t, string(output), tag)
+		require.NoError(t, err, "There was an error in listing the tags")
 	})
 
 	logger.Section(fmt.Sprintf("Installing package repository"), func() {

--- a/cli/test/e2e/package_repo_release_test.go
+++ b/cli/test/e2e/package_repo_release_test.go
@@ -58,6 +58,23 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 		verifyPackageRepository(t, keysToBeIgnored)
 	})
 
+	logger.Section("Creating a package repository interactively with tags using pkg repo release", func() {
+		go func() {
+			promptOutput.WaitFor("Enter the package repository name")
+			promptOutput.Write(pkgrName)
+			promptOutput.WaitFor("Enter the registry url")
+			promptOutput.Write(env.Image)
+		}()
+
+		kctrl.RunWithOpts([]string{"pkg", "repo", "release", "--tty=true", "--chdir", workingDir, "--version", "1.0.0", "--tag", "build-tag-0001"},
+			RunOpts{NoNamespace: true, StdinReader: promptOutput.StringReader(),
+				StdoutWriter: promptOutput.BufferedOutputWriter(), Interactive: true})
+
+		keysToBeIgnored := []string{"creationTimestamp:", "image"}
+		verifyPackageRepoBuild(t, keysToBeIgnored)
+		verifyPackageRepository(t, keysToBeIgnored)
+	})
+
 	logger.Section(fmt.Sprintf("Installing package repository"), func() {
 		kapp.RunWithOpts([]string{"deploy", "-a", pkgrKappAppName, "-f", filepath.Join(workingDir, pkgRepoOutputFile), "-c"},
 			RunOpts{StdinReader: promptOutput.StringReader(), StdoutWriter: promptOutput.BufferedOutputWriter()})

--- a/cli/test/e2e/package_repo_release_test.go
+++ b/cli/test/e2e/package_repo_release_test.go
@@ -62,7 +62,6 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 		args := []string{"tag", "list", "-i", os.Getenv("KCTRL_E2E_IMAGE")}
 		cmd := exec.Command("imgpkg", args...)
 		output, err := cmd.Output()
-		// t.Logf("the tags are: %s", output)
 		require.Contains(t, string(output), version)
 		require.NoError(t, err, "There was an error in listing the tags")
 	})
@@ -88,7 +87,6 @@ func TestPackageRepositoryReleaseInteractively(t *testing.T) {
 		args := []string{"tag", "list", "-i", os.Getenv("KCTRL_E2E_IMAGE")}
 		cmd := exec.Command("imgpkg", args...)
 		output, err := cmd.Output()
-		// t.Logf("the tags are: %s", output)
 		require.Contains(t, string(output), tag)
 		require.NoError(t, err, "There was an error in listing the tags")
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1639

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Allow Control of Image Tags with introduction of `--tag` flag in `kctrl package repo release`
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
