### PR TITLE
Allow to update the packageinstall with a different packageName

### DIFF
--- a/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
+++ b/cli/pkg/kctrl/cmd/package/installed/create_or_update.go
@@ -767,11 +767,16 @@ func (o *CreateOrUpdateOptions) preparePackageInstallForUpdate(pkgInstall *kcpkg
 		return nil, fmt.Errorf("Failed to update package '%s' as no existing package reference/version was found in the package install", o.Name)
 	}
 
-	// If o.PackageName is provided by the user (via --package flag), verify that the package name in PackageInstall matches it.
-	// This will prevent the users from accidentally overwriting an installed package with another package content due to choosing a pre-existing name for the package isntall.
+	// If o.PackageName provided by the user (via --package flag) is not the same as the package name in PackageInstall
+	// Prompt user to confirm
 	// Otherwise if o.PackageName is not provided, fill it from the installed package spec
 	if o.packageName != "" && updatedPkgInstall.Spec.PackageRef.RefName != o.packageName {
-		return nil, fmt.Errorf("Installed package '%s' is already associated with package '%s'", o.Name, updatedPkgInstall.Spec.PackageRef.RefName)
+		o.ui.PrintLinef("Changing Package reference for installation '%s' from Package '%s' to Package '%s'", o.Name, updatedPkgInstall.Spec.PackageRef.RefName, o.packageName)
+		err := o.ui.AskForConfirmation()
+		if err != nil {
+			return nil, err
+		}
+		updatedPkgInstall.Spec.PackageRef.RefName = o.packageName
 	}
 	o.packageName = updatedPkgInstall.Spec.PackageRef.RefName
 


### PR DESCRIPTION
Allow to update the packageinstall with a difference packageName

1. Prompt user to confirm
2. Add e2e test for this operation

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
We need to change the package name for the installed package. However the current [code](https://github.com/carvel-dev/kapp-controller/blob/e4b4822224f7bd06e27787a013e3c3e997beb043/cli/pkg/kctrl/cmd/package/installed/create_or_update.go#L774) blocks it . 

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1651
detail check https://kubernetes.slack.com/archives/CH8KCCKA5/p1736907725646329


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
NONE

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
