### PR TITLE
fix: stop calling redundant rand.Seed

### DIFF
--- a/cli/cmd/kctrl/kctrl.go
+++ b/cli/cmd/kctrl/kctrl.go
@@ -4,9 +4,7 @@
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/cppforlife/cobrautil"
 	uierrs "github.com/cppforlife/go-cli-ui/errors"
@@ -26,8 +24,6 @@ func main() {
 
 // nonExitingMain does not use os.Exit to make sure Go runs defers
 func nonExitingMain() error {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	// TODO logs
 	// TODO log flags used
 


### PR DESCRIPTION
see: https://tip.golang.org/doc/go1.20

Signed-off-by: Max Brauer <mbrauer@vmware.com>
