### PR TITLE
Treat `null` value as any type when generating schema from Helm chart

### DIFF
--- a/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
+++ b/cli/pkg/kctrl/cmd/package/release/schemagenerator/helm_openapi_schema_gen_test.go
@@ -69,7 +69,8 @@ arrKeyEmpty: []
       type: string
     type: array
 type: object
-`},
+`,
+		},
 		{
 			name: "object with different values",
 			input: `
@@ -123,7 +124,8 @@ objExample: {}
     description: Object example
     type: object
 type: object
-`},
+`,
+		},
 		{
 			name: "nested complex object",
 			input: `
@@ -176,7 +178,8 @@ containers:
         type: string
     type: object
 type: object
-`},
+`,
+		},
 		{
 			name: "Alias Node",
 			input: `
@@ -223,7 +226,40 @@ aliasEx:
       type: object
     type: array
 type: object
-`},
+`,
+		},
+		{
+			name: "unknown type",
+			input: `
+# a field without a type
+anything: null
+`,
+			want: `properties:
+  anything:
+    description: a field without a type
+    oneOf:
+    - default: null
+      nullable: true
+      type: integer
+    - default: null
+      nullable: true
+      type: number
+    - default: null
+      nullable: true
+      type: boolean
+    - default: null
+      nullable: true
+      type: string
+    - default: null
+      nullable: true
+      type: object
+    - default: null
+      items: {}
+      nullable: true
+      type: array
+type: object
+`,
+		},
 	}
 
 	for _, test := range tests {

--- a/cli/test/e2e/package_authoring_e2e_test.go
+++ b/cli/test/e2e/package_authoring_e2e_test.go
@@ -336,8 +336,26 @@ spec:
               default: quay.io/mongodb
               type: string
             imagePullSecrets:
-              default: ""
-              type: string
+              oneOf:
+              - default: null
+                nullable: true
+                type: integer
+              - default: null
+                nullable: true
+                type: number
+              - default: null
+                nullable: true
+                type: boolean
+              - default: null
+                nullable: true
+                type: string
+              - default: null
+                nullable: true
+                type: object
+              - default: null
+                items: {}
+                nullable: true
+                type: array
             initAppDb:
               default: quay.io/mongodb
               type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This change treats `null` values in Helm chart values as _any_ type using a type union of all possible types being nullable. That is because the expected type cannot be inferred from `null`.

When releasing a `Package` from a Helm chart that has `null` values, the result looks like this:

```yaml
apiVersion: data.packaging.carvel.dev/v1alpha1
kind: Package
metadata:
  creationTimestamp: null
  name: test.mamachanko.com.0.0.0+build.1737555606
spec:
  refName: test.mamachanko.com
  releasedAt: "2025-01-22T14:20:11Z"
  template:
    spec:
      deploy:
      - kapp: {}
      fetch:
      - imgpkgBundle:
          image: index.docker.io/mamachanko/helm-test@sha256:f80aac3740c96da062f922790482c3aebe7c2c57061bdf0b4208b4833e276ac9
      template:
      - helmTemplate:
          path: helm
      - ytt:
          paths:
          - '-'
      - kbld:
          paths:
          - '-'
          - .imgpkg/images.yml
  valuesSchema:
    openAPIv3:
      properties:
        credentials:
          description: helm/values.yaml
          properties:
            password:
              oneOf:
              - default: null
                nullable: true
                type: integer
              - default: null
                nullable: true
                type: number
              - default: null
                nullable: true
                type: boolean
              - default: null
                nullable: true
                type: string
              - default: null
                nullable: true
                type: object
              - default: null
                items: {}
                nullable: true
                type: array
            username:
              oneOf:
              - default: null
                nullable: true
                type: integer
              - default: null
                nullable: true
                type: number
              - default: null
                nullable: true
                type: boolean
              - default: null
                nullable: true
                type: string
              - default: null
                nullable: true
                type: object
              - default: null
                items: {}
                nullable: true
                type: array
          type: object
      type: object
  version: 0.0.0+build.1737555606
```

as opposed to the previous:

```yaml
apiVersion: data.packaging.carvel.dev/v1alpha1
kind: Package
metadata:
  creationTimestamp: null
  name: test.mamachanko.com.0.0.0+build.1737555606
spec:
  refName: test.mamachanko.com
  releasedAt: "2025-01-22T14:20:11Z"
  template:
    spec:
      deploy:
      - kapp: {}
      fetch:
      - imgpkgBundle:
          image: index.docker.io/mamachanko/helm-test@sha256:f80aac3740c96da062f922790482c3aebe7c2c57061bdf0b4208b4833e276ac9
      template:
      - helmTemplate:
          path: helm
      - ytt:
          paths:
          - '-'
      - kbld:
          paths:
          - '-'
          - .imgpkg/images.yml
  valuesSchema:
    openAPIv3:
      properties:
        credentials:
          description: helm/values.yaml
          properties:
            password:
              default: "null"
              type: "null"
            username:
              default: "null"
              type: "null"
          type: object
      type: object
  version: 0.0.0+build.1737555606

```

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1630 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
fix: treat `null` in Helm value as _any_ when generating OpenAPI v3 schema
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ x Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
