### PR TITLE
Add paused to printer columns

### DIFF
--- a/config/config/crds.yml
+++ b/config/config/crds.yml
@@ -748,6 +748,10 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: Paused
+      jsonPath: .spec.paused
+      name: Paused
+      type: boolean
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -1487,6 +1491,10 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: Paused
+      jsonPath: .spec.paused
+      name: Paused
+      type: boolean
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -1641,6 +1649,10 @@ spec:
       jsonPath: .status.friendlyDescription
       name: Description
       type: string
+    - description: Paused
+      jsonPath: .spec.paused
+      name: Paused
+      type: boolean
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/apis/kappctrl/v1alpha1/types.go
+++ b/pkg/apis/kappctrl/v1alpha1/types.go
@@ -14,6 +14,7 @@ import (
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 // +kubebuilder:printcolumn:name=Since-Deploy,JSONPath=.status.deploy.startedAt,description=Last time app started being deployed. Does not mean anything was changed.,type=date
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
+// +kubebuilder:printcolumn:name=Paused,JSONPath=.spec.paused,description=Paused,type=boolean
 // +protobuf=false
 // An App is a set of Kubernetes resources. These resources could span any number of namespaces or could be cluster-wide (e.g. CRDs). An App is represented in kapp-controller using a App CR.
 // The App CR comprises of three main sections:

--- a/pkg/apis/packaging/v1alpha1/package_install.go
+++ b/pkg/apis/packaging/v1alpha1/package_install.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:printcolumn:name=Package version,JSONPath=.status.version,description=PackageMetadata version,type=string
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
+// +kubebuilder:printcolumn:name=Paused,JSONPath=.spec.paused,description=Paused,type=boolean
 // A Package Install is an actual installation of a package and its underlying resources on a Kubernetes cluster.
 // It is represented in kapp-controller by a PackageInstall CR.
 // A PackageInstall CR must reference a Package CR.

--- a/pkg/apis/packaging/v1alpha1/package_repository.go
+++ b/pkg/apis/packaging/v1alpha1/package_repository.go
@@ -14,6 +14,7 @@ import (
 // +kubebuilder:resource:shortName=pkgr,categories={carvel}
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,description=Time since creation,type=date
 // +kubebuilder:printcolumn:name=Description,JSONPath=.status.friendlyDescription,description=Friendly description,type=string
+// +kubebuilder:printcolumn:name=Paused,JSONPath=.spec.paused,description=Paused,type=boolean
 // A package repository is a collection of packages and their metadata.
 // Similar to a maven repository or a rpm repository, adding a package repository to a cluster gives users of that cluster the ability to install any of the packages from that repository.
 type PackageRepository struct {


### PR DESCRIPTION
Pausing an app or package is a common operation, and should be surfaced to operators during kubectl get.

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes: #1701 
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
Show paused fields in printer columns
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [x] Relevant docs in this repo added or updated
- [x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
