### PR TITLE
Fix version of the kctrl binary that is built during release

### DIFF
--- a/cli/hack/build-binaries.sh
+++ b/cli/hack/build-binaries.sh
@@ -12,7 +12,7 @@ VERSION="${1:-`get_latest_git_tag`}"
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/version.Version=$VERSION"
+LDFLAGS="-X carvel.dev/kapp-controller/cli/pkg/kctrl/version.Version=$VERSION"
 
 GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -trimpath -o kctrl-darwin-amd64 ./cmd/kctrl/...
 GOOS=darwin GOARCH=arm64 go build -ldflags="$LDFLAGS" -trimpath -o kctrl-darwin-arm64 ./cmd/kctrl/...

--- a/cli/hack/build.sh
+++ b/cli/hack/build.sh
@@ -10,7 +10,7 @@ VERSION="${1:-`get_latest_git_tag`}"
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-kapp-controller/cli/pkg/kctrl/version.Version=$VERSION"
+LDFLAGS="-X carvel.dev/kapp-controller/cli/pkg/kctrl/version.Version=$VERSION"
 
 go mod vendor
 go mod tidy


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the release process of kctrl due to the wrong path of the version variable



#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

