### PR TITLE
Downgrade sops dependency to v3.9.0

### DIFF
--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -58,13 +58,13 @@
   version: v3.17.3
 - checksums:
     linux:
-      amd64: 79b0f844237bd4b0446e4dc884dbc1765fc7dedc3968f743d5949c6f2e701739
-      arm64: e91ddc04e6a78f5aed9e4fc347a279b539c43b74d99e6b8078e2f2f6f5b309f5
+      amd64: 0d65660fbe785647ff4f1764d7f69edf598f79d6d79ebbef4a501909b6ff6b82
+      arm64: 596f26de6d4f7d1cc44f9e27bfea3192ef77f810f31f3f4132a417860ab91ebc
   dev: false
   name: sops
   repo: mozilla/sops
   urlTemplate: https://github.com/mozilla/sops/releases/download/{{.Version}}/sops-{{.Version}}.{{.OS}}.{{.Arch}}
-  version: v3.10.2
+  version: v3.9.0
 - checksums:
     linux:
       amd64: 7df45a6cc87d4da11cc03a539a7470c15b1041ab2b396af088fe9990f7c79d50


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This intentionally downgrades mozilla/sops version to v3.9.0. The version v3.9.0 was built using MPL 2.0 licensed go module of hashicorp/vault, all the versions of sops greater than v3.9.0 are built using BSL 1.1 licensed go module of hashicorp/vault.

sops v3.9.0 uses [github.com/hashicorp/vault@v1.14.0](https://github.com/hashicorp/vault/blob/v1.14.0/LICENSE) which is MPL 2.0 licensed, v3.9.1 uses uses [github.com/hashicorp/vault@v1.15.0](https://github.com/hashicorp/vault/blob/v1.15.0/LICENSE) which uses BUSL 1.1 (Business Source License 1.1).

Also, I noticed that the `dependencies.yml` file is periodically update by the `carvel-bot`
https://github.com/carvel-dev/kapp-controller/pull/1663, we might need to figure out a way to check for license before upgrading the versions.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [X] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [X] Relevant tests are added or updated
- [X] Relevant docs in this repo added or updated
- [X] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [X] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
