### PR TITLE
bump helm version from 3.18.0 to 3.19.0

### DIFF
--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -48,14 +48,14 @@
   version: v0.44.0
 - checksums:
     linux:
-      amd64: 961e587fc2c03807f8a99ac25ef063fa9e6915f1894729399cbb95d2a79af931
-      arm64: 489c9d2d3ea4e095331249d74b4407fb5ac1d338c28429d70cdedccfe6e2b029
+      amd64: 1789d9244fb2a3d3682ab1d430fed200fb0d76ae323134f7721a8c87dd9295f2
+      arm64: 3906455a70e76e6825b7cdbbd86b3a82ec5191365b2df9be630bc1fcd6a9ff3d
   dev: false
   name: helm
   repo: helm/helm
   tarballSubpath: '{{.OS}}-{{.Arch}}/helm'
   urlTemplate: https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-  version: v3.18.0
+  version: v3.19.0
 - checksums:
     linux:
       amd64: 79b0f844237bd4b0446e4dc884dbc1765fc7dedc3968f743d5949c6f2e701739


### PR DESCRIPTION
#### What this PR does / why we need it: 

This PR fixes helm upstream bug causes kapp-controller to fail to fetch oci helm chart by bumping the helm binary

#### Which issue(s) this PR fixes:

Fixes # https://github.com/carvel-dev/kapp-controller/issues/1772

#### Does this PR introduce a user-facing change?
NONE

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x ] Relevant tests are added or updated
- [x ] Relevant docs in this repo added or updated
- [ x] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

just bumping the helm binary version
