### PR TITLE
[Do not merge] Add Workflows to test kapp-ctrl against latest k8s

### DIFF
--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -12,7 +12,7 @@ env:
   # Replace with your actual org/repo name
   # git@github.com:carvel-dev/kapp-controller.git
   # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
-  IMAGE_NAME: ${{ github.repository_owner }}/kindest-node
+  IMAGE_NAME: ${{ github.repository }}/kindest-node
 
 jobs:
   resolve-versions:
@@ -117,14 +117,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Or a PAT if GITHUB_TOKEN lacks permission
           TIMESTAMP: ${{ needs.resolve-versions.outputs.timestamp }}
           # List the branches we want to test against
-          TARGET_BRANCHES: "release-0.59 release-0.58"
+          TAGS_TO_TEST: "v0.59.1 v0.58.1"
+          WORKFLOW_BRANCH: "CodesbyUnnati:unnati/nightly-build-kind-images"
+
         run: |
-          for branch in $TARGET_BRANCHES; do
-            echo "Triggering test workflow on branch: $branch"
+          for tag in $TAGS_TO_TEST; do
+            echo "Triggering test for kapp-controller version: $tag"
             
-            # This calls the 'nightly-e2e.yml' workflow on the specific branch
-            # We pass the timestamp as an input so it knows which image to pull
             gh workflow run nightly-e2e.yml \
-              --ref $branch \
-              -f image_timestamp=$TIMESTAMP
+              --ref "$WORKFLOW_BRANCH" \
+              -f image_timestamp=$TIMESTAMP \
+              -f kapp_ctrl_ref=$tag
           done

--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -96,6 +96,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: codesbyunnati
+          password: ${{ secrets.TEST_GHCR_PAT }}
 
       - name: Build and Push Kind Node Image
         run: |

--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -12,7 +12,7 @@ env:
   # Replace with your actual org/repo name
   # git@github.com:carvel-dev/kapp-controller.git
   # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
-  IMAGE_NAME: ${{ github.actor }}/kindest-node
+  # IMAGE_NAME: ${{ github.actor }}/kindest-node
 
 jobs:
   resolve-versions:
@@ -70,6 +70,14 @@ jobs:
         run: |
           sudo rm -rf /opt/hostedtoolcache || true
           docker system prune -af || true
+      
+      - name: Setup Environment Variables
+        run: |
+          # Convert username to lowercase
+          OWNER_LC=$(echo "${{ github.actor }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=$OWNER_LC/kindest-node" >> $GITHUB_ENV
+          echo "REGISTRY_USER=$OWNER_LC" >> $GITHUB_ENV
+
       - name: Checkout Kubernetes & Get the exact commit SHA
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -5,6 +5,7 @@ on:
     # 2:00 AM IST = 20:30 UTC (previous day)
     - cron: '30 20 * * *'
   workflow_dispatch:
+  pull_request:
 
 env:
   REGISTRY: ghcr.io
@@ -30,16 +31,30 @@ jobs:
       - name: Resolve Kubernetes Versions
         id: set-matrix
         run: |
+          # 1. Fetch branches
           git ls-remote --heads https://github.com/kubernetes/kubernetes.git \
           | awk '{print $2}' | grep 'refs/heads/release-1.[0-9]*$' | sed 's|refs/heads/||' | sort -V > branches.txt
 
-        # 2. Determine Latest Release Branch (The highest number)
+          # 2. Define variables
           LATEST_BRANCH=$(tail -n1 branches.txt)
-        # 3. Min Supported Branch (e.g., currently 1.32)
-          MIN_BRANCH="release-1.32" 
+          MIN_BRANCH="release-1.32"
 
-          echo "Latest: $LATEST_BRANCH, Min: $MIN_BRANCH"
-          echo "matrix={\"k8s_branch\":[\"$LATEST_BRANCH\", \"$MIN_BRANCH\"]}" >> $GITHUB_OUTPUT
+          # 3. Safety Check
+          if [ -z "$LATEST_BRANCH" ]; then
+            echo "Error: Could not find any release-1.xx branches!"
+            exit 1
+          fi
+
+          echo "Resolved -> Latest: $LATEST_BRANCH, Min: $MIN_BRANCH"
+
+          # 4. Generate JSON using jq
+          MATRIX_JSON=$(jq -nc \
+            --arg latest "$LATEST_BRANCH" \
+            --arg min "$MIN_BRANCH" \
+            '{"k8s_branch": [$latest, $min]}')
+
+          # 5. Output to GitHub Actions
+          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
   build-and-push:
     needs: resolve-versions
@@ -55,13 +70,13 @@ jobs:
         run: |
           sudo rm -rf /opt/hostedtoolcache || true
           docker system prune -af || true
-
       - name: Checkout Kubernetes & Get the exact commit SHA
         uses: actions/checkout@v4
         with:
           repository: kubernetes/kubernetes
           ref: ${{ matrix.k8s_branch }}
           path: kubernetes
+          fetch-depth: 0
 
       - name: Checkout Kind
         uses: actions/checkout@v4
@@ -91,7 +106,6 @@ jobs:
           # Log in and Push
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker push $FULL_IMAGE
-
   trigger-tests:
     needs: [resolve-versions, build-and-push]
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -1,0 +1,116 @@
+name: Nightly Build Kind Images
+
+on:
+  schedule:
+    # 2:00 AM IST = 20:30 UTC (previous day)
+    - cron: '30 20 * * *'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # Replace with your actual org/repo name
+  # git@github.com:carvel-dev/kapp-controller.git
+  # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
+  IMAGE_NAME: ${{ github.repository_owner }}/kindest-node
+
+jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      timestamp: ${{ steps.get-date.outputs.timestamp }}
+    steps:
+      - name: Get Date Timestamp
+        id: get-date
+        # Creates a timestamp like 20231025
+        run: echo "timestamp=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+        # 1. Fetch all remote branches from kubernetes/kubernetes
+        # We look for release-1.xx branches.
+      - name: Resolve Kubernetes Versions
+        id: set-matrix
+        run: |
+          git ls-remote --heads https://github.com/kubernetes/kubernetes.git \
+          | awk '{print $2}' | grep 'refs/heads/release-1.[0-9]*$' | sed 's|refs/heads/||' | sort -V > branches.txt
+
+        # 2. Determine Latest Release Branch (The highest number)
+          LATEST_BRANCH=$(tail -n1 branches.txt)
+        # 3. Min Supported Branch (e.g., currently 1.32)
+          MIN_BRANCH="release-1.32" 
+
+          echo "Latest: $LATEST_BRANCH, Min: $MIN_BRANCH"
+          echo "matrix={\"k8s_branch\":[\"$LATEST_BRANCH\", \"$MIN_BRANCH\"]}" >> $GITHUB_OUTPUT
+
+  build-and-push:
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-versions.outputs.matrix) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache || true
+          docker system prune -af || true
+
+      - name: Checkout Kubernetes & Get the exact commit SHA
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes/kubernetes
+          ref: ${{ matrix.k8s_branch }}
+          path: kubernetes
+
+      - name: Checkout Kind
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes-sigs/kind
+          path: kind
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Build and Push Kind Node Image
+        run: |
+          cd kind
+          go install ./...
+          
+          # Construct Tag: release-1.35-20231025
+          TIMESTAMP="${{ needs.resolve-versions.outputs.timestamp }}"
+          TAG="${{ matrix.k8s_branch }}-${TIMESTAMP}"
+          FULL_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$TAG"
+          
+          echo "Building $FULL_IMAGE..."
+          
+          kind build node-image --type=source $(pwd)/../kubernetes --image $FULL_IMAGE
+          
+          # Log in and Push
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push $FULL_IMAGE
+
+  trigger-tests:
+    needs: [resolve-versions, build-and-push]
+    runs-on: ubuntu-latest
+    # Only run if builds succeeded
+    if: success()
+    steps:
+      - name: Trigger Downstream E2E Tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Or a PAT if GITHUB_TOKEN lacks permission
+          TIMESTAMP: ${{ needs.resolve-versions.outputs.timestamp }}
+          # List the branches we want to test against
+          TARGET_BRANCHES: "release-0.59 release-0.58"
+        run: |
+          for branch in $TARGET_BRANCHES; do
+            echo "Triggering test workflow on branch: $branch"
+            
+            # This calls the 'nightly-e2e.yml' workflow on the specific branch
+            # We pass the timestamp as an input so it knows which image to pull
+            gh workflow run nightly-e2e.yml \
+              --ref $branch \
+              -f image_timestamp=$TIMESTAMP
+          done

--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -12,7 +12,7 @@ env:
   # Replace with your actual org/repo name
   # git@github.com:carvel-dev/kapp-controller.git
   # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
-  IMAGE_NAME: ${{ github.repository }}/kindest-node
+  IMAGE_NAME: ${{ github.actor }}/kindest-node
 
 jobs:
   resolve-versions:
@@ -124,8 +124,10 @@ jobs:
           for tag in $TAGS_TO_TEST; do
             echo "Triggering test for kapp-controller version: $tag"
             
+            # We pass a new flag 'registry_user' so the test knows where to pull from
             gh workflow run nightly-e2e.yml \
               --ref "$WORKFLOW_BRANCH" \
               -f image_timestamp=$TIMESTAMP \
-              -f kapp_ctrl_ref=$tag
+              -f kapp_ctrl_ref=$tag \
+              -f registry_user=${{ github.actor }} 
           done

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1,0 +1,84 @@
+name: Nightly E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_timestamp:
+        description: 'Timestamp of the Kind image to use (YYYYMMDD)'
+        required: true
+
+env:
+  # Base for the Kind Node Image
+  # git@github.com:carvel-dev/kapp-controller.git  
+  # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
+  KIND_NODE_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/kindest-node
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [release-1.35, release-1.32] # Sync these with build workflow
+    steps:
+      - name: Checkout Kapp-Controller
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Construct Image Tag
+        id: img
+        run: |
+          TIMESTAMP="${{ inputs.image_timestamp }}"
+          TAG="${{ matrix.k8s_version }}-${TIMESTAMP}"
+          echo "full_image=${{ env.KIND_NODE_IMAGE_BASE }}:$TAG" >> $GITHUB_ENV
+
+      - name: Create Kind Cluster (Nightly)
+        uses: helm/kind-action@v1
+        with:
+          version: v0.24.0
+          node_image: ${{ env.full_image }} 
+          cluster_name: kinder
+          wait: 1m 
+
+      - name: Verify Cluster Version
+        run: |
+          kubectl version
+          kubectl get nodes -o wide
+
+      - name: Install Dependencies
+        run: ./hack/install-deps.sh
+
+      - name: Build, Load and Deploy Kapp-Controller
+        run: |
+          set -e -x
+          
+          # 1. Helper for versioning
+          source ./hack/version-util.sh
+          
+          # 2. Build the Controller Image using kbld
+          # This compiles the code from the current branch
+          ytt -f config/config -f config/values-schema.yml -f config-dev -v dev.version="$(get_kappctrl_ver)+develop" | kbld -f- > kbld.out 2> kbldmeta.out
+          
+          # 3. Load the built image into the Custom Kind Cluster
+          cat kbldmeta.out | tail -n 1 | sed 's/.*final: kapp-controller -> \(.*\)$/\1/p'  | tail -n 1 | xargs kind load docker-image --name kinder
+          
+          # 4. Deploy using kapp
+          kapp deploy -a kc -f kbld.out -c -y
+
+      - name: Install Secretgen Controller
+        run: |
+          export KAPPCTRL_E2E_SECRETGEN_CONTROLLER=true
+          source ./hack/secretgen-controller.sh
+          deploy_secretgen-controller
+
+      - name: Run E2E Tests
+        run: |
+          mkdir tmp
+          # Run the actual tests
+          KAPPCTRL_E2E_NAMESPACE=kappctrl-test eval './hack/test-e2e.sh'

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -6,12 +6,16 @@ on:
       image_timestamp:
         description: 'Timestamp of the Kind image to use (YYYYMMDD)'
         required: true
+        kapp_ctrl_ref:
+        description: 'Git ref to test (e.g., v0.59.1 or HEAD)'
+        required: true
+        default: 'HEAD'
 
 env:
   # Base for the Kind Node Image
   # git@github.com:carvel-dev/kapp-controller.git  
   # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
-  KIND_NODE_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/kindest-node
+  KIND_NODE_IMAGE_BASE: ghcr.io/${{ github.repository }}/kindest-node
 
 jobs:
   e2e-tests:
@@ -24,6 +28,7 @@ jobs:
       - name: Checkout Kapp-Controller
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.kapp_ctrl_ref }}
           fetch-depth: 0
 
       - name: Setup Go

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -47,6 +47,13 @@ jobs:
           TAG="${{ matrix.k8s_version }}-${TIMESTAMP}"
           echo "full_image=${{ env.KIND_NODE_IMAGE_BASE }}:$TAG" >> $GITHUB_ENV
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: codesbyunnati
+          password: ${{ secrets.TEST_GHCR_PAT }}
+
       - name: Create Kind Cluster (Nightly)
         uses: helm/kind-action@v1
         with:

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -6,16 +6,20 @@ on:
       image_timestamp:
         description: 'Timestamp of the Kind image to use (YYYYMMDD)'
         required: true
-        kapp_ctrl_ref:
+      kapp_ctrl_ref:
         description: 'Git ref to test (e.g., v0.59.1 or HEAD)'
         required: true
         default: 'HEAD'
+      registry_user:
+        description: 'User to pull image from (defaults to org)'
+        required: false
+        default: 'carvel-dev'
 
 env:
   # Base for the Kind Node Image
   # git@github.com:carvel-dev/kapp-controller.git  
   # docker pull ghcr.io/carvel-dev/kindest-node:v1.34.2
-  KIND_NODE_IMAGE_BASE: ghcr.io/${{ github.repository }}/kindest-node
+  KIND_NODE_IMAGE_BASE: ghcr.io/${{ inputs.registry_user || github.repository_owner }}/kindest-node
 
 jobs:
   e2e-tests:
@@ -23,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [release-1.35, release-1.32] # Sync these with build workflow
+        k8s_version: [release-1.35, release-1.32]
     steps:
       - name: Checkout Kapp-Controller
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR adds workflow files that will be used to test kapp-controller against latest k8s release and a minimum supported version release. This will be an automation which will be triggered at 2am everyday and run kapp-controller tests on the latest kubernetes kind node image generated from the latest commit of that branch.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
