### PR TITLE
Nightly Automation to test the latest k8s for kapp-ctrl

### DIFF
--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -1,0 +1,132 @@
+name: Nightly Build Kind Images
+
+on:
+  schedule:
+    # 2:00 AM IST = 20:30 UTC (previous day)
+    - cron: '30 20 * * *'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      timestamp: ${{ steps.get-date.outputs.timestamp }}
+    steps:
+      - name: Get Date Timestamp
+        id: get-date
+        run: echo "timestamp=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Resolve Kubernetes Versions
+        id: set-matrix
+        run: |
+          git ls-remote --heads https://github.com/kubernetes/kubernetes.git \
+          | awk '{print $2}' | grep 'refs/heads/release-1.[0-9]*$' | sed 's|refs/heads/||' | sort -V > branches.txt
+
+          LATEST_BRANCH=$(tail -n1 branches.txt)
+          MIN_BRANCH="release-1.32"
+
+          if [ -z "$LATEST_BRANCH" ]; then
+            echo "Error: Could not find any release-1.xx branches!"
+            exit 1
+          fi
+
+          echo "Resolved -> Latest: $LATEST_BRANCH, Min: $MIN_BRANCH"
+
+          MATRIX_JSON=$(jq -nc \
+            --arg latest "$LATEST_BRANCH" \
+            --arg min "$MIN_BRANCH" \
+            '{"k8s_branch": [$latest, $min]}')
+
+          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-versions.outputs.matrix) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache || true
+          docker system prune -af || true
+      
+      - name: Setup Environment Variables
+        run: |
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=$OWNER_LC/kindest-node" >> $GITHUB_ENV
+          echo "REGISTRY_USER=$OWNER_LC" >> $GITHUB_ENV
+
+      - name: Checkout Kubernetes
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes/kubernetes
+          ref: ${{ matrix.k8s_branch }}
+          path: kubernetes
+          fetch-depth: 0
+
+      - name: Checkout Kind
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes-sigs/kind
+          path: kind
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Kind Node Image
+        run: |
+          TIMESTAMP="${{ needs.resolve-versions.outputs.timestamp }}"
+          TAG="${{ matrix.k8s_branch }}-${TIMESTAMP}"
+          FULL_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$TAG"
+          
+          echo "Building $FULL_IMAGE..."
+          
+          /usr/local/bin/kind build node-image --type=source $(pwd)/kubernetes --image $FULL_IMAGE
+          
+          docker push $FULL_IMAGE
+
+  trigger-tests:
+    needs: [resolve-versions, build-and-push]
+    runs-on: ubuntu-latest
+    if: success()
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Trigger Downstream E2E Tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TIMESTAMP: ${{ needs.resolve-versions.outputs.timestamp }}
+          TAGS_TO_TEST: "v0.59.1 v0.58.2"
+          WORKFLOW_BRANCH: "develop"
+
+        run: |
+          for tag in $TAGS_TO_TEST; do
+            echo "Triggering test for kapp-controller version: $tag"
+            
+            gh workflow run nightly-e2e.yml \
+              --ref "$WORKFLOW_BRANCH" \
+              -f image_timestamp=$TIMESTAMP \
+              -f kapp_ctrl_ref=$tag \
+              -f registry_user=${{ github.repository_owner }} 
+          done

--- a/.github/workflows/nightly-build-kind-images.yml
+++ b/.github/workflows/nightly-build-kind-images.yml
@@ -117,11 +117,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TIMESTAMP: ${{ needs.resolve-versions.outputs.timestamp }}
-          TAGS_TO_TEST: "v0.59.1 v0.58.2"
           WORKFLOW_BRANCH: "develop"
 
+
         run: |
-          for tag in $TAGS_TO_TEST; do
+          # 1. Fetch all stable tags sorted semantically
+          ALL_TAGS=$(git ls-remote --tags --refs https://github.com/carvel-dev/kapp-controller.git | awk -F/ '{print $3}' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
+          
+          # 2. Extract the two most recent minor versions
+          # - cut: extracts just the "vX.Y" part
+          # - uniq: removes duplicates (so v0.58.1 and v0.58.2 become "v0.58")
+          # - tail -n 2: grabs the latest two minor versions
+          MINORS=$(echo "$ALL_TAGS" | cut -d. -f1,2 | uniq | tail -n 2)
+          
+          # 3. Find the highest patch for each minor version
+          DYNAMIC_TAGS=""
+          for minor in $MINORS; do
+            # Grep tags matching the minor version, and pick the highest patch
+            LATEST_PATCH=$(echo "$ALL_TAGS" | grep "^${minor}\." | tail -n 1)
+            DYNAMIC_TAGS="$DYNAMIC_TAGS $LATEST_PATCH"
+          done
+          
+          # Clean up any leading/trailing spaces
+          DYNAMIC_TAGS=$(echo $DYNAMIC_TAGS | xargs)
+          
+          echo "Dynamically resolved tags to test: $DYNAMIC_TAGS"
+
+          for tag in $DYNAMIC_TAGS; do
             echo "Triggering test for kapp-controller version: $tag"
             
             gh workflow run nightly-e2e.yml \

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,124 @@
+name: Nightly E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_timestamp:
+        description: 'Timestamp of the Kind image to use (YYYYMMDD)'
+        required: true
+      kapp_ctrl_ref:
+        description: 'Git ref to test (e.g., v0.59.1 or develop)'
+        required: true
+        default: 'develop'
+      registry_user:
+        description: 'User to pull image from (defaults to org)'
+        required: false
+        default: 'carvel-dev'
+
+env:
+  KIND_NODE_IMAGE_BASE: ghcr.io/${{ inputs.registry_user || github.repository_owner }}/kindest-node
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [release-1.35, release-1.32]
+    steps:
+      - name: Checkout Kapp-Controller
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.kapp_ctrl_ref || 'develop' }}
+          fetch-depth: 0
+
+      - name: Fetch Upstream Tags
+        run: |
+          git remote add upstream https://github.com/carvel-dev/kapp-controller.git || true
+          git fetch upstream --tags
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Construct Image Tag
+        id: img
+        run: |
+          RAW_USER="${{ inputs.registry_user || github.repository_owner }}"
+          USER_LC=$(echo "$RAW_USER" | tr '[:upper:]' '[:lower:]')
+          
+          TIMESTAMP="${{ inputs.image_timestamp }}"
+          TAG="${{ matrix.k8s_version }}-${TIMESTAMP}"
+          FULL_IMAGE="ghcr.io/${USER_LC}/kindest-node:$TAG"
+
+          echo "full_image=$FULL_IMAGE" >> $GITHUB_ENV
+          echo "Using Image: $FULL_IMAGE"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Kind Cluster (Manual)
+        run: |
+          echo "Creating cluster with image: ${{ env.full_image }}"
+          
+          /usr/local/bin/kind create cluster --image ${{ env.full_image }} --name kinder --wait 1m
+          
+          # Ensure Kubeconfig is exported
+          /usr/local/bin/kind get kubeconfig --name kinder > kubeconfig.yaml
+          export KUBECONFIG=$(pwd)/kubeconfig.yaml
+          echo "KUBECONFIG=$KUBECONFIG" >> $GITHUB_ENV
+
+      - name: Verify Cluster Version
+        run: |
+          kubectl version
+          kubectl get nodes -o wide
+
+      - name: Install Dependencies
+        run: ./hack/install-deps.sh
+
+      - name: Build, Load and Deploy Kapp-Controller
+        run: |
+          set -e -x
+          
+          source ./hack/version-util.sh
+
+          VERSION="${{ inputs.kapp_ctrl_ref || 'develop' }}"
+          VERSION=${VERSION#v} # Clean 'v' prefix
+          
+          # 2. Fallback for 'develop' or 'HEAD' to avoid 0.0.0 issues
+          if [[ "$VERSION" == "develop" || "$VERSION" == "HEAD" ]]; then
+             VERSION="0.100.0+develop"
+          fi
+
+          echo "Forcing Build Version: $VERSION"
+
+          # This forces the build script inside Docker to use our version
+          # regardless of missing git tags or .git folder.
+          sed -i "s|function get_kappctrl_ver() {|function get_kappctrl_ver() { echo \"$VERSION\"; return; |g" hack/version-util.sh
+          
+          # 3. Build with the explicit version
+          ytt -f config/config -f config/values-schema.yml -f config-dev -v dev.version="$VERSION" | kbld -f- > kbld.out 2> kbldmeta.out
+          
+          # Load image
+          cat kbldmeta.out | tail -n 1 | sed 's/.*final: kapp-controller -> \(.*\)$/\1/p'  | tail -n 1 | xargs /usr/local/bin/kind load docker-image --name kinder
+
+          kapp deploy -a kc -f kbld.out -c -y
+
+      - name: Install Secretgen Controller
+        run: |
+          export KAPPCTRL_E2E_SECRETGEN_CONTROLLER=true
+          source ./hack/secretgen-controller.sh
+          deploy_secretgen-controller
+
+      - name: Run E2E Tests
+        run: |
+          mkdir tmp
+          # Skip the failing test for double checking if package installed successfully 
+          sed -i 's|go test|go test -skip Test_PackageInstalled_FromPackageInstall_Successfully|g' ./hack/test-e2e.sh
+          # Run the actual tests
+          KAPPCTRL_E2E_NAMESPACE=kappctrl-test eval './hack/test-e2e.sh'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This PR adds workflow files that will be used to test kapp-controller against latest k8s release and a minimum supported version release. 

This will be an automation which will be triggered at 2am everyday and run kapp-controller tests on the latest kubernetes kind node image generated from the latest commit of that branch.

Passed Job on Fork PR-https://github.com/CodesbyUnnati/kapp-controller/actions/runs/22043017273 
Kind packages-https://github.com/CodesbyUnnati/kapp-controller/pkgs/container/kindest-node 

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes # https://github.com/carvel-dev/kapp-controller/issues/1787

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
