### PR TITLE
Downgrade helm from v4 to latest v3 patch

### DIFF
--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -49,7 +49,7 @@
 - checksums:
     linux:
       amd64: a0a5e8c592ed3f376ac110715eff214730c7422f9a44d96cf98117d2b8b0e6c0
-      arm64: 1367926ea842729b4312fbf800234d15bcaa419c92201727b776da4550078a09
+      arm64: ce02147ffee6d993bf8ae97a44a22e9e1daf0b69d2d5b69a0c8cf6706445ccf5
   dev: false
   name: helm
   repo: helm/helm

--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -48,14 +48,14 @@
   version: v0.45.2
 - checksums:
     linux:
-      amd64: 5d4c7623283e6dfb1971957f4b755468ab64917066a8567dd50464af298f4031
-      arm64: 02a5fb7742469d2d132e24cb7c3f52885894043576588c6788b6813297629edd
+      amd64: a0a5e8c592ed3f376ac110715eff214730c7422f9a44d96cf98117d2b8b0e6c0
+      arm64: 1367926ea842729b4312fbf800234d15bcaa419c92201727b776da4550078a09
   dev: false
   name: helm
   repo: helm/helm
   tarballSubpath: '{{.OS}}-{{.Arch}}/helm'
   urlTemplate: https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-  version: v4.1.1
+  version: v3.19.5
 - checksums:
     linux:
       amd64: 775f1384d55decfad228e7196a3f683791914f92a473f78fc47700531c29dfef


### PR DESCRIPTION
v4 introduces breaking changes for url scheme for registries

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
