### PR TITLE
Add --bundle flag for cosign blob sign and verify commands

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -135,8 +135,7 @@ jobs:
 
           ### Verify the checksums file
           cosign verify-blob checksums.txt \
-          --certificate checksums.txt.pem \
-          --signature checksums.txt.sig \
+          --bundle release/checksums.json \
           --certificate-identity-regexp=https://github.com/${{ github.repository_owner }} \
           --certificate-oidc-issuer=https://token.actions.githubusercontent.com 
           \`\`\`
@@ -209,13 +208,12 @@ jobs:
 
       - name: Sign checksums.txt
         run: |
-          cosign sign-blob --yes ./tmp/checksums.txt --output-certificate release/checksums.txt.pem  --output-signature release/checksums.txt.sig
+          cosign sign-blob --yes ./tmp/checksums.txt --bundle release/checksums.json
 
       - name: Verify checksums signature
         run: |
           cosign verify-blob \
-            --cert release/checksums.txt.pem \
-            --signature release/checksums.txt.sig \
+            --bundle release/checksums.json \
             --certificate-identity-regexp=https://github.com/${{ github.repository_owner }} \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com ./tmp/checksums.txt
 


### PR DESCRIPTION
for cosign v4 changes

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
This PR is a fix for cosign sign and verification step for blobs.
v4 introduces a --bundle flag instaed of --output-certificate and --output-signature flags.
This PR adds --bundle flag for cosign blob sign and verify commands for cosign v4 changes
#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #
Fixes the cosign sign-blob and verify-blob command failures in release-process workflow
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note

```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
