### PR TITLE
fix(apiserver): register OpenAPI v2 spec for aggregation

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -231,14 +231,12 @@ func newServerConfig(aggClient aggregatorclient.Interface, opts NewAPIServerOpts
 	}
 
 	serverConfig := genericapiserver.NewRecommendedConfig(Codecs)
-	if err := recommendedOptions.ApplyTo(serverConfig); err != nil {
-		return nil, err
-	}
 
 	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(
 		openapi.GetOpenAPIDefinitions,
 		genericopenapi.NewDefinitionNamer(Scheme))
 	serverConfig.OpenAPIV3Config.Info.Title = "Kapp-controller"
+	serverConfig.OpenAPIV3Config.Info.Version = "v1alpha1"
 
 	// Register OpenAPI v2 configuration to satisfy the Kubernetes Aggregation Controller.
 	// In K8s 1.30+, the aggregator syncs both v2 and v3 specs; providing v2 prevents
@@ -248,6 +246,10 @@ func newServerConfig(aggClient aggregatorclient.Interface, opts NewAPIServerOpts
 		genericopenapi.NewDefinitionNamer(Scheme))
 	serverConfig.OpenAPIConfig.Info.Title = "Kapp-controller"
 	serverConfig.OpenAPIConfig.Info.Version = "v1alpha1"
+
+	if err := recommendedOptions.ApplyTo(serverConfig); err != nil {
+		return nil, err
+	}
 
 	return serverConfig, nil
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -239,6 +239,16 @@ func newServerConfig(aggClient aggregatorclient.Interface, opts NewAPIServerOpts
 		openapi.GetOpenAPIDefinitions,
 		genericopenapi.NewDefinitionNamer(Scheme))
 	serverConfig.OpenAPIV3Config.Info.Title = "Kapp-controller"
+
+	// Register OpenAPI v2 configuration to satisfy the Kubernetes Aggregation Controller.
+	// In K8s 1.30+, the aggregator syncs both v2 and v3 specs; providing v2 prevents
+	// "resource not found" errors in the kube-apiserver logs (Fixes #1703).
+	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
+		openapi.GetOpenAPIDefinitions,
+		genericopenapi.NewDefinitionNamer(Scheme))
+	serverConfig.OpenAPIConfig.Info.Title = "Kapp-controller"
+	serverConfig.OpenAPIConfig.Info.Version = "v1alpha1"
+
 	return serverConfig, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

In Kubernetes v1.30+, the API Aggregation Controller inside the kube-apiserver is designed to synchronize discovery information for both OpenAPI v2 and v3 to ensure compatibility with all client types. Previously, kapp-controller only registered the OpenAPIV3Config for its aggregated API server (v1alpha1.data.packaging.carvel.dev).

Because the v2 spec was missing, the main kube-apiserver failed with a resource not found (404) error when attempting to fetch it during its aggregation sync loop. Consequently, the control plane logs were flooded with continuous retry errors (failed to download v1alpha1.data.packaging.carvel.dev: resource not found), even though functional package reconciliation was unaffected.

This PR registers the OpenAPI v2 configuration using genericapiserver.DefaultOpenAPIConfig to satisfy the K8s Aggregation Controller, successfully eliminating the 404 errors in the kube-apiserver logs.

Ref: https://kubernetes.io/docs/concepts/overview/kubernetes-api/#openapi-interface-definition:~:text=Kubernetes%20serves%20both%20OpenAPI%20v2.0%20and%20OpenAPI%20v3.0.

#### Which issue(s) this PR fixes:

Fixes #1703

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where kube-apiserver logs (v1.30+) were flooded with "resource not found" errors for the v1alpha1.data.packaging.carvel.dev OpenAPI spec. The kapp-controller aggregated API server now correctly registers and serves the OpenAPI v2 specification required by the Kubernetes aggregator.
```

#### Additional Notes for your reviewer:

Testing Done:

- Spun up a fresh Minikube cluster (K8s v1.35+) and deployed kapp-controller built from this branch.

- Verified that the APIService object v1alpha1.data.packaging.carvel.dev successfully reaches the Available: True state.

❯ kubectl get apiservices v1alpha1.data.packaging.carvel.dev                                                 ○ minikube
NAME                                 SERVICE                         AVAILABLE   AGE
v1alpha1.data.packaging.carvel.dev   kapp-controller/packaging-api   True        15m
❯

- Tailed kubectl logs -n kube-system -l component=kube-apiserver and verified the failed to download... resource not found error is completely resolved.

❯ kubectl logs -n kube-system -l component=kube-apiserver --since=5m | grep "failed to download v1alpha1.data.packaging.carvel.dev"
❯


##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
N/A - This is a bug fix for API aggregation logging.
```
