### PR TITLE
Fix zombie process race condition in sidecar container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # --- run image ---
 FROM photon:5.0
 
-# Install openssh for git
-RUN tdnf install -y git openssh-clients
+# Install openssh for git and tini for proper PID 1 handling
+RUN tdnf install -y git openssh-clients tini
 
 # Create the kapp-controller user in the root group, the home directory will be mounted as a volume
 RUN echo "kapp-controller:x:1000:0:/home/kapp-controller:/usr/sbin/nologin" > /etc/passwd
@@ -36,4 +36,5 @@ COPY --from=deps /workspace/out/* ./
 # Run as kapp-controller by default, will be overridden to a random uid on OpenShift
 USER 1000
 ENV PATH="/:${PATH}"
-ENTRYPOINT ["/kapp-controller"]
+# Use tini as PID 1 to properly handle zombie processes and signals
+ENTRYPOINT ["tini", "--", "/kapp-controller"]

--- a/cmd/controller/sidecarexec.go
+++ b/cmd/controller/sidecarexec.go
@@ -4,12 +4,8 @@
 package main
 
 import (
-	"syscall"
-	"time"
-
 	"carvel.dev/kapp-controller/pkg/exec"
 	"carvel.dev/kapp-controller/pkg/sidecarexec"
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -17,7 +13,7 @@ func sidecarexecMain() {
 	mainLog := zap.New(zap.UseDevMode(false)).WithName("kc-sidecarexec")
 	mainLog.Info("start sidecarexec", "version", Version)
 
-	go reapZombies(mainLog)
+	// Note: Zombie reaping is now handled by tini as PID 1
 
 	localCmdRunner := exec.NewPlainCmdRunner()
 	opts := sidecarexec.ServerOpts{
@@ -34,20 +30,5 @@ func sidecarexecMain() {
 	err := server.Serve()
 	if err != nil {
 		mainLog.Error(err, "Serving RPC")
-	}
-}
-
-func reapZombies(log logr.Logger) {
-	log.Info("starting zombie reaper")
-
-	for {
-		var status syscall.WaitStatus
-
-		pid, _ := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
-		if pid <= 0 {
-			time.Sleep(1 * time.Second)
-		} else {
-			continue
-		}
 	}
 }

--- a/config/config/deployment.yml
+++ b/config/config/deployment.yml
@@ -67,7 +67,7 @@ spec:
       - name: kapp-controller-sidecarexec
         image: kapp-controller
         args: ["--sidecarexec"]
-        # tini is already configured as ENTRYPOINT in Dockerfile
+        #! tini is already configured as ENTRYPOINT in Dockerfile
         resources:
           requests:
             cpu: 120m

--- a/config/config/deployment.yml
+++ b/config/config/deployment.yml
@@ -67,6 +67,7 @@ spec:
       - name: kapp-controller-sidecarexec
         image: kapp-controller
         args: ["--sidecarexec"]
+        # tini is already configured as ENTRYPOINT in Dockerfile
         resources:
           requests:
             cpu: 120m


### PR DESCRIPTION
## Summary

Fixes a race condition in the sidecar container that causes intermittent `"waitid: no child processes"` errors during template operations (ytt, vendir, imgpkg).

### Problem

The custom `reapZombies()` function was incorrectly implemented:
- Used `syscall.Wait4(-1, ...)` which reaps **any** child process, not just orphans
- Created race condition with normal parent-child process waiting in `CmdExec.Run`
- When `ytt`/`vendir`/`imgpkg` completed, `reapZombies` could reap them before their actual parent
- Result: `cmd.Wait()` failed with `ECHILD` ("waitid: no child processes")

### Root Cause

The `reapZombies` function violated Unix process management conventions by reaping processes that had living parents, instead of only reaping orphaned processes (whose parent died).

### Solution

- **Replace custom zombie reaper with tini**: Industry standard init system for containers
- **Remove `reapZombies()` function entirely**: Eliminates the race condition source
- **Proper PID 1 handling**: tini correctly handles only orphaned processes
- **Maintains zombie cleanup**: Without interfering with normal parent-child relationships

### Changes

- **Dockerfile**: Install `tini` package and set as entrypoint
- **sidecarexec.go**: Remove `reapZombies` function and unused imports  
- **deployment.yml**: Add documentation comment about tini configuration

### Impact

- ✅ Eliminates "waitid: no child processes" errors
- ✅ Fixes intermittent PackageRepository reconciliation failures
- ✅ Improves reliability under concurrent template operations
- ✅ Uses industry standard solution (tini)
- ✅ Backward compatible - no API changes

## Test Plan

- [ ] Build and deploy updated container image
- [ ] Verify process tree shows tini as PID 1: `ps -ef` should show `tini -- /kapp-controller`
- [ ] Test PackageRepository reconciliation under load
- [ ] Confirm no more "waitid: no child processes" errors in logs
- [ ] Validate graceful container shutdown behavior

## Related Issues

This addresses the race condition described in the error logs where template operations fail with zombie process errors during high-frequency reconciliation.


Made with [Cursor](https://cursor.com)