### PR TITLE
Add version annotation to APIService to prevent race conditions during rolling upgrades

### DIFF
--- a/config/config/agg-api.yml
+++ b/config/config/agg-api.yml
@@ -4,6 +4,8 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.data.packaging.carvel.dev
+  annotations:
+    kapp-controller.carvel.dev/version: v0.0.0
 spec:
   group: data.packaging.carvel.dev
   groupPriorityMinimum: 100

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -14,6 +14,9 @@ export version="$(get_kappctrl_ver)"
 sed 's/v0.0.0/'"$version"'/' config/config/deployment.yml > tmp/deployment.yml
 mv tmp/deployment.yml config/config/deployment.yml
 
+sed 's/v0.0.0/'"$version"'/' config/config/agg-api.yml > tmp/agg-api.yml
+mv tmp/agg-api.yml config/config/agg-api.yml
+
 ytt -f config/config -f config/values-schema.yml -f config-release -v dev.version="$version" --data-values-env=KCTRL | kbld --imgpkg-lock-output .imgpkg/images.yml -f- > ./tmp/release.yml
 
 # Update image url in kapp-controller package overlays


### PR DESCRIPTION
## Summary

This PR adds a version annotation to the APIService resource to prevent race conditions during kapp-controller rolling upgrades.

## Problem

During kapp-controller rolling upgrades via `kapp deploy <KC-new-release.yml>`, a race condition occurs where:
1. kapp doesn't detect any changes in the APIService resource (since it remains static)
2. kapp reports deployment success before the new APIService webhook is fully operational
3. This can lead to failed operations during the upgrade window

## Solution

Add a version annotation (`kapp-controller.carvel.dev/version`) to the APIService that:
- Gets updated with each release version (following the same pattern as the Deployment resource)
- Ensures kapp detects changes in the APIService during upgrades
- Forces kapp to properly wait for APIService readiness before reporting success

## Changes

- **config/config/agg-api.yml**: Add `kapp-controller.carvel.dev/version: v0.0.0` annotation to APIService metadata
- **hack/build-release.sh**: Add sed replacement to update version placeholder with actual release version during build

## Implementation Details

This follows the exact same pattern already used for the Deployment resource:
1. Static annotation with `v0.0.0` placeholder in source files
2. Build script replaces placeholder with actual version during release process
3. Final release.yml contains the real version annotation

## Test Plan

- [x] Verified annotation is correctly added to APIService
- [x] Tested build script properly replaces version placeholder
- [x] Confirmed ytt processing works without errors
- [x] Validated APIService structure remains valid

## Impact

- **Positive**: Eliminates race condition during kapp-controller upgrades
- **Risk**: Minimal - only adds metadata annotation, no functional changes to APIService behavior
- **Compatibility**: Fully backward compatible

Fixes race condition during kapp-controller rolling upgrades where APIService readiness validation was bypassed.

Made with [Cursor](https://cursor.com)