### PR TITLE
fix(reftracker): copy refs map to avoid concurrent iteration panic

### DIFF
--- a/pkg/reftracker/ref_tracker.go
+++ b/pkg/reftracker/ref_tracker.go
@@ -28,18 +28,31 @@ func (a *AppRefTracker) AppsForRef(refKey RefKey) (map[RefKey]struct{}, error) {
 		return nil, fmt.Errorf("could not find ref %s", refKey.Description())
 	}
 
-	return apps, nil
+	// Return a copy so callers can iterate without holding the lock.
+	// Returning the internal map directly races with mutations from
+	// ReconcileRefs and RemoveAppFromAllRefs and triggers the Go runtime's
+	// "concurrent map iteration and map write" fatal error.
+	return copyRefKeySet(apps), nil
 }
 
 func (a *AppRefTracker) RefsForApp(appKey RefKey) (map[RefKey]struct{}, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	if a.appsToRefs[appKey] == nil {
+	refs := a.appsToRefs[appKey]
+	if refs == nil {
 		return nil, fmt.Errorf("could not find refs for App %s", appKey.RefName())
 	}
 
-	return a.appsToRefs[appKey], nil
+	return copyRefKeySet(refs), nil
+}
+
+func copyRefKeySet(in map[RefKey]struct{}) map[RefKey]struct{} {
+	out := make(map[RefKey]struct{}, len(in))
+	for k := range in {
+		out[k] = struct{}{}
+	}
+	return out
 }
 
 func (a *AppRefTracker) RemoveRef(refKey RefKey) {

--- a/pkg/reftracker/ref_tracker.go
+++ b/pkg/reftracker/ref_tracker.go
@@ -28,10 +28,6 @@ func (a *AppRefTracker) AppsForRef(refKey RefKey) (map[RefKey]struct{}, error) {
 		return nil, fmt.Errorf("could not find ref %s", refKey.Description())
 	}
 
-	// Return a copy so callers can iterate without holding the lock.
-	// Returning the internal map directly races with mutations from
-	// ReconcileRefs and RemoveAppFromAllRefs and triggers the Go runtime's
-	// "concurrent map iteration and map write" fatal error.
 	return copyRefKeySet(apps), nil
 }
 

--- a/pkg/reftracker/ref_tracker_test.go
+++ b/pkg/reftracker/ref_tracker_test.go
@@ -61,10 +61,6 @@ func Test_RemoveAppFromAllRefs_RemovesApp(t *testing.T) {
 	}
 }
 
-// Test_AppsForRef_SafeForConcurrentIteration verifies the returned map can be
-// iterated by a caller while other goroutines mutate the tracker. Before the
-// fix, AppsForRef returned the internal map directly and triggered Go's
-// "concurrent map iteration and map write" fatal error.
 func Test_AppsForRef_SafeForConcurrentIteration(t *testing.T) {
 	appRefTracker := reftracker.NewAppRefTracker()
 
@@ -80,7 +76,6 @@ func Test_AppsForRef_SafeForConcurrentIteration(t *testing.T) {
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 
-	// Mutator: continuously reconciles refs to mutate the internal map.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -99,7 +94,6 @@ func Test_AppsForRef_SafeForConcurrentIteration(t *testing.T) {
 		}
 	}()
 
-	// Iterator: repeatedly fetches the apps map and iterates it.
 	iterDone := make(chan struct{})
 	go func() {
 		defer close(iterDone)
@@ -109,7 +103,6 @@ func Test_AppsForRef_SafeForConcurrentIteration(t *testing.T) {
 				continue
 			}
 			for range apps {
-				// Force iteration; would fatal if apps aliased the internal map.
 			}
 		}
 	}()

--- a/pkg/reftracker/ref_tracker_test.go
+++ b/pkg/reftracker/ref_tracker_test.go
@@ -4,6 +4,7 @@
 package reftracker_test
 
 import (
+	"sync"
 	"testing"
 
 	"carvel.dev/kapp-controller/pkg/reftracker"
@@ -58,4 +59,62 @@ func Test_RemoveAppFromAllRefs_RemovesApp(t *testing.T) {
 	if _, ok := apps[appKey]; ok {
 		t.Fatalf("expected app to be removed from appRefTracker after deletion")
 	}
+}
+
+// Test_AppsForRef_SafeForConcurrentIteration verifies the returned map can be
+// iterated by a caller while other goroutines mutate the tracker. Before the
+// fix, AppsForRef returned the internal map directly and triggered Go's
+// "concurrent map iteration and map write" fatal error.
+func Test_AppsForRef_SafeForConcurrentIteration(t *testing.T) {
+	appRefTracker := reftracker.NewAppRefTracker()
+
+	refKey := reftracker.NewSecretKey("secretName", "default")
+	refKeyMap := map[reftracker.RefKey]struct{}{refKey: {}}
+
+	for i := 0; i < 20; i++ {
+		appKey := reftracker.NewAppKey("seed-app", "default")
+		appKey = reftracker.NewAppKey(appKey.RefName()+string(rune('a'+i)), "default")
+		appRefTracker.ReconcileRefs(refKeyMap, appKey)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Mutator: continuously reconciles refs to mutate the internal map.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				appKey := reftracker.NewAppKey("mutator-app", "default")
+				appKey = reftracker.NewAppKey(appKey.RefName()+string(rune('a'+(i%26))), "default")
+				appRefTracker.ReconcileRefs(refKeyMap, appKey)
+				appRefTracker.RemoveAppFromAllRefs(appKey)
+				i++
+			}
+		}
+	}()
+
+	// Iterator: repeatedly fetches the apps map and iterates it.
+	iterDone := make(chan struct{})
+	go func() {
+		defer close(iterDone)
+		for i := 0; i < 200; i++ {
+			apps, err := appRefTracker.AppsForRef(refKey)
+			if err != nil {
+				continue
+			}
+			for range apps {
+				// Force iteration; would fatal if apps aliased the internal map.
+			}
+		}
+	}()
+
+	<-iterDone
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

`AppRefTracker.AppsForRef` and `RefsForApp` returned the internal map directly. Callers (`SecretHandler.enqueueAppsForUpdate`, `ConfigMapHandler.enqueueAppsForUpdate`) then iterated those maps outside the tracker lock while `ReconcileRefs` and `RemoveAppFromAllRefs` were mutating the same maps under the lock. On large clusters with high churn this triggered Go's fatal `concurrent map iteration and map write` panic, taking down the controller.

The fix is to return a shallow copy of the set; the map values are unused so a copy of the keys is sufficient. Callers can iterate the snapshot without holding the lock.

#### Which issue(s) this PR fixes:
Fixes #1812

#### Does this PR introduce a user-facing change?

```release-note
Fix a fatal "concurrent map iteration and map write" panic in kapp-controller when AppRefTracker is read by Secret/ConfigMap event handlers concurrently with ReconcileRefs or RemoveAppFromAllRefs.
```

#### Additional Notes for your reviewer:

The new test `Test_AppsForRef_SafeForConcurrentIteration` reproduces the original panic when run with `-race` against the previous implementation and passes after the fix.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```