### PR TITLE
chore(deps): bump kbld from v0.48.1 to v0.49.1

### DIFF
--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -12,16 +12,16 @@
   version: v0.55.1
 - checksums:
     darwin:
-      amd64: fc0909f8a77f737cc075fc2e9dbf70408e00e933015863569dbd17a020e6fc06
-      arm64: a9ed7e4fbce8fa714357458d29cea0664a00d403415f47e700fbc3b7d951f561
+      amd64: d6c6dd4af41bea5cb3c8914e9b43536fc3c606592ddaaa98dda08b8517400969
+      arm64: 8b7c93828b96065d7fcdb51989e59462af443f59c8a88beeb421c5f5ff0ef65e
     linux:
-      amd64: 9e417cb47dbf484cbf2a9f10b6a43186d2dded3597102de3f47f1d2989669884
-      arm64: 27cc0137f0b7c71e0ebe924ace785b6e25b27c809c7db8d39f880c1864c191cc
+      amd64: 437d38d3e59d01dd0d1ad75b4eb67fbd04fe51ed3de1ed55c3f7b3b7d5ec7546
+      arm64: b3f5277ff4819de189d1ebd6e455b3390308ca43b122b5bb3c40a7bb9e6f30c4
   dev: true
   name: kbld
   repo: vmware-tanzu/carvel-kbld
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.48.1
+  version: v0.49.1
 - checksums:
     darwin:
       amd64: cebb31f6b72cd94dc4e1c17b31ba6e4ac70caeb53e4b29aea1fbc1885605e9a7


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Bumps kbld dependency from v0.48.1 to v0.49.1 to pick up the SHA-1 removal fix.

kbld v0.49.1 replaces crypto/sha1 with crypto/sha256 in the e2e packaging test, eliminating a cryptographic audit finding (SHA-1 is not FIPS-approved). Although the SHA-1 usage was in test-only code (//go:build e2e), the upstream fix has been merged and this bump brings kapp-controller in sync with the latest kbld release.

Reference: carvel-dev/kbld#598

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes # (no separate issue filed — tracked via the upstream kbld PR above)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
No — this is a dependency version bump. No API or behavioral changes for kapp-controller users.
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [ ] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [ ] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs
Kbld PR: https://github.com/carvel-dev/kbld/pull/598
```

