### PR TITLE
[1839] Fix: Truncate status.deploy.stdout as it can exceed etcd's limit on large clusters, causing reconciliation delay

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -40,6 +40,9 @@ type Hooks struct {
 type Opts struct {
 	DefaultSyncPeriod time.Duration
 	MinimumSyncPeriod time.Duration
+	// MaxStatusOutputBytes caps each stdout/stderr field written into App status.
+	// Zero means use defaultMaxStatusOutputBytes (1 MiB).
+	MaxStatusOutputBytes int
 }
 
 type App struct {

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -127,9 +127,10 @@ func (a *App) reconcileFetchTemplateDeploy() exec.CmdRunResult {
 		var fetchResult exec.CmdRunResult
 		assetsPath, fetchResult = a.fetch(assetsPath)
 
+		fetchResult = fetchResult.WithTruncatedStrings(a.maxOutputBytes())
 		a.app.Status.Fetch = &v1alpha1.AppStatusFetch{
-			Stderr:    truncateOutput(fetchResult.Stderr, a.maxOutputBytes()),
-			Stdout:    truncateOutput(fetchResult.Stdout, a.maxOutputBytes()),
+			Stderr:    fetchResult.Stderr,
+			Stdout:    fetchResult.Stdout,
 			ExitCode:  fetchResult.ExitCode,
 			Error:     fetchResult.ErrorStr(),
 			StartedAt: a.app.Status.Fetch.StartedAt,
@@ -178,11 +179,11 @@ func (a *App) reconcileFetchTemplateDeploy() exec.CmdRunResult {
 }
 
 func (a *App) updateLastDeploy(result exec.CmdRunResult) exec.CmdRunResult {
-	result = result.WithFriendlyYAMLStrings()
+	result = result.WithFriendlyYAMLStrings().WithTruncatedStrings(a.maxOutputBytes())
 
 	a.app.Status.Deploy = &v1alpha1.AppStatusDeploy{
-		Stdout:           truncateOutput(result.Stdout, a.maxOutputBytes()),
-		Stderr:           truncateOutput(result.Stderr, a.maxOutputBytes()),
+		Stdout:           result.Stdout,
+		Stderr:           result.Stderr,
 		Finished:         result.Finished,
 		ExitCode:         result.ExitCode,
 		Error:            result.ErrorStr(),
@@ -242,12 +243,12 @@ func (a *App) resetLastDeployStartedAt() {
 }
 
 func (a *App) reconcileInspect() error {
-	inspectResult := a.inspect().WithFriendlyYAMLStrings()
+	inspectResult := a.inspect().WithFriendlyYAMLStrings().WithTruncatedStrings(a.maxOutputBytes())
 
 	if !inspectResult.IsEmpty() {
 		a.app.Status.Inspect = &v1alpha1.AppStatusInspect{
-			Stdout:    truncateOutput(inspectResult.Stdout, a.maxOutputBytes()),
-			Stderr:    truncateOutput(inspectResult.Stderr, a.maxOutputBytes()),
+			Stdout:    inspectResult.Stdout,
+			Stderr:    inspectResult.Stderr,
 			ExitCode:  inspectResult.ExitCode,
 			Error:     inspectResult.ErrorStr(),
 			UpdatedAt: metav1.NewTime(time.Now().UTC()),
@@ -339,10 +340,11 @@ func (a *App) removeAllConditions() {
 }
 
 func (a *App) setUsefulErrorMessage(result exec.CmdRunResult) {
+	result = result.WithTruncatedStrings(a.maxOutputBytes())
 	switch {
 	case result.Stderr != "":
-		a.app.Status.UsefulErrorMessage = truncateOutput(result.Stderr, a.maxOutputBytes())
+		a.app.Status.UsefulErrorMessage = result.Stderr
 	default:
-		a.app.Status.UsefulErrorMessage = truncateOutput(result.ErrorStr(), a.maxOutputBytes())
+		a.app.Status.UsefulErrorMessage = result.ErrorStr()
 	}
 }

--- a/pkg/app/app_reconcile.go
+++ b/pkg/app/app_reconcile.go
@@ -128,8 +128,8 @@ func (a *App) reconcileFetchTemplateDeploy() exec.CmdRunResult {
 		assetsPath, fetchResult = a.fetch(assetsPath)
 
 		a.app.Status.Fetch = &v1alpha1.AppStatusFetch{
-			Stderr:    fetchResult.Stderr,
-			Stdout:    fetchResult.Stdout,
+			Stderr:    truncateOutput(fetchResult.Stderr, a.maxOutputBytes()),
+			Stdout:    truncateOutput(fetchResult.Stdout, a.maxOutputBytes()),
 			ExitCode:  fetchResult.ExitCode,
 			Error:     fetchResult.ErrorStr(),
 			StartedAt: a.app.Status.Fetch.StartedAt,
@@ -181,8 +181,8 @@ func (a *App) updateLastDeploy(result exec.CmdRunResult) exec.CmdRunResult {
 	result = result.WithFriendlyYAMLStrings()
 
 	a.app.Status.Deploy = &v1alpha1.AppStatusDeploy{
-		Stdout:           result.Stdout,
-		Stderr:           result.Stderr,
+		Stdout:           truncateOutput(result.Stdout, a.maxOutputBytes()),
+		Stderr:           truncateOutput(result.Stderr, a.maxOutputBytes()),
 		Finished:         result.Finished,
 		ExitCode:         result.ExitCode,
 		Error:            result.ErrorStr(),
@@ -246,8 +246,8 @@ func (a *App) reconcileInspect() error {
 
 	if !inspectResult.IsEmpty() {
 		a.app.Status.Inspect = &v1alpha1.AppStatusInspect{
-			Stdout:    inspectResult.Stdout,
-			Stderr:    inspectResult.Stderr,
+			Stdout:    truncateOutput(inspectResult.Stdout, a.maxOutputBytes()),
+			Stderr:    truncateOutput(inspectResult.Stderr, a.maxOutputBytes()),
 			ExitCode:  inspectResult.ExitCode,
 			Error:     inspectResult.ErrorStr(),
 			UpdatedAt: metav1.NewTime(time.Now().UTC()),
@@ -341,8 +341,8 @@ func (a *App) removeAllConditions() {
 func (a *App) setUsefulErrorMessage(result exec.CmdRunResult) {
 	switch {
 	case result.Stderr != "":
-		a.app.Status.UsefulErrorMessage = result.Stderr
+		a.app.Status.UsefulErrorMessage = truncateOutput(result.Stderr, a.maxOutputBytes())
 	default:
-		a.app.Status.UsefulErrorMessage = result.ErrorStr()
+		a.app.Status.UsefulErrorMessage = truncateOutput(result.ErrorStr(), a.maxOutputBytes())
 	}
 }

--- a/pkg/app/app_status_truncate.go
+++ b/pkg/app/app_status_truncate.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"unicode/utf8"
+)
+
+// defaultMaxStatusOutputBytes is the default cap for each stdout/stderr string
+// written into an App status sub-field (deploy, fetch, inspect).
+// etcd rejects objects larger than its 1.5 MiB limit (often 2 MiB at the
+// Kubernetes gRPC client level); on clusters with 250+ nodes, a single kapp
+// deploy can produce several MiB of output, causing the UpdateStatus call to
+// fail and delay reconciliation until a subsequent no-op reconcile fits.
+//
+// Keeping the tail of the output is intentional: the most actionable content
+// (final resource summary, error lines) always appears at the end of kapp output.
+const defaultMaxStatusOutputBytes = 1 * 1024 * 1024 // 1 MiB
+
+const truncationMarker = "[output truncated]\n"
+
+// maxOutputBytes returns the configured output cap for this App, falling back
+// to defaultMaxStatusOutputBytes when Opts.MaxStatusOutputBytes is zero.
+func (a *App) maxOutputBytes() int {
+	if a.opts.MaxStatusOutputBytes > 0 {
+		return a.opts.MaxStatusOutputBytes
+	}
+	return defaultMaxStatusOutputBytes
+}
+
+// truncateOutput returns s unchanged when len(s) <= maxBytes.  Otherwise it
+// returns a truncation notice followed by the last maxBytes bytes of s,
+// adjusted forward to a valid UTF-8 rune boundary so the result is always
+// valid UTF-8.
+func truncateOutput(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	start := len(s) - maxBytes
+	// Advance past any UTF-8 continuation bytes so we don't split a multi-byte
+	// rune in half.
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return truncationMarker + s[start:]
+}

--- a/pkg/app/app_status_truncate.go
+++ b/pkg/app/app_status_truncate.go
@@ -3,22 +3,16 @@
 
 package app
 
-import (
-	"unicode/utf8"
-)
-
 // defaultMaxStatusOutputBytes is the default cap for each stdout/stderr string
 // written into an App status sub-field (deploy, fetch, inspect).
 // etcd rejects objects larger than its 1.5 MiB limit (often 2 MiB at the
-// Kubernetes gRPC client level); on clusters with 250+ nodes, a single kapp
-// deploy can produce several MiB of output, causing the UpdateStatus call to
+// Kubernetes gRPC client level); on clusters with large number of nodes (ex 250+),
+// a single kapp deploy can produce several MiB of output, causing the UpdateStatus call to
 // fail and delay reconciliation until a subsequent no-op reconcile fits.
 //
-// Keeping the tail of the output is intentional: the most actionable content
-// (final resource summary, error lines) always appears at the end of kapp output.
+// Keeping the tail is intentional: the most actionable content (resource
+// summary, error lines) always appears at the end of kapp output.
 const defaultMaxStatusOutputBytes = 1 * 1024 * 1024 // 1 MiB
-
-const truncationMarker = "[output truncated]\n"
 
 // maxOutputBytes returns the configured output cap for this App, falling back
 // to defaultMaxStatusOutputBytes when Opts.MaxStatusOutputBytes is zero.
@@ -27,21 +21,4 @@ func (a *App) maxOutputBytes() int {
 		return a.opts.MaxStatusOutputBytes
 	}
 	return defaultMaxStatusOutputBytes
-}
-
-// truncateOutput returns s unchanged when len(s) <= maxBytes.  Otherwise it
-// returns a truncation notice followed by the last maxBytes bytes of s,
-// adjusted forward to a valid UTF-8 rune boundary so the result is always
-// valid UTF-8.
-func truncateOutput(s string, maxBytes int) string {
-	if len(s) <= maxBytes {
-		return s
-	}
-	start := len(s) - maxBytes
-	// Advance past any UTF-8 continuation bytes so we don't split a multi-byte
-	// rune in half.
-	for start < len(s) && !utf8.RuneStart(s[start]) {
-		start++
-	}
-	return truncationMarker + s[start:]
 }

--- a/pkg/app/app_status_truncate_test.go
+++ b/pkg/app/app_status_truncate_test.go
@@ -6,7 +6,6 @@ package app
 import (
 	"strings"
 	"testing"
-	"unicode/utf8"
 
 	"carvel.dev/kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"carvel.dev/kapp-controller/pkg/deploy"
@@ -15,101 +14,9 @@ import (
 	"carvel.dev/kapp-controller/pkg/metrics"
 	"carvel.dev/kapp-controller/pkg/template"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-func Test_truncateOutput(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		maxBytes int
-		check    func(t *testing.T, result string)
-	}{
-		{
-			name:     "under limit is unchanged",
-			input:    "small output",
-			maxBytes: 1024,
-			check: func(t *testing.T, result string) {
-				assert.Equal(t, "small output", result)
-			},
-		},
-		{
-			name:     "exactly at limit is unchanged",
-			input:    strings.Repeat("x", 100),
-			maxBytes: 100,
-			check: func(t *testing.T, result string) {
-				assert.Equal(t, strings.Repeat("x", 100), result)
-			},
-		},
-		{
-			name:     "empty string is unchanged",
-			input:    "",
-			maxBytes: 100,
-			check: func(t *testing.T, result string) {
-				assert.Equal(t, "", result)
-			},
-		},
-		{
-			name:     "over limit has marker prefix and tail suffix",
-			input:    strings.Repeat("a", 200) + strings.Repeat("z", 50),
-			maxBytes: 50,
-			check: func(t *testing.T, result string) {
-				assert.True(t, strings.HasPrefix(result, truncationMarker))
-				assert.True(t, strings.HasSuffix(result, strings.Repeat("z", 50)))
-				// Marker does not count toward maxBytes.
-				assert.Equal(t, len(truncationMarker)+50, len(result))
-			},
-		},
-		{
-			name: "tail content preserved for realistic kapp output",
-			// Many per-resource lines followed by an actionable summary.  maxBytes
-			// is set to hold only the last ~100 bytes so truncation is guaranteed,
-			// and the summary at the tail must survive.
-			input: strings.Repeat("op add configmap/cm-001 (v1) namespace: default\n", 100) +
-				"Op: 100 add, 0 delete\nWait to: 100 reconcile\n",
-			maxBytes: 100,
-			check: func(t *testing.T, result string) {
-				assert.True(t, strings.HasPrefix(result, truncationMarker),
-					"large output must start with the truncation marker")
-				assert.Contains(t, result, "100 add",
-					"the actionable summary at the tail must be preserved after truncation")
-			},
-		},
-		{
-			name: "UTF-8 boundary: continuation byte is skipped",
-			// s = 98 'a's + "éé"  (102 bytes)
-			// maxBytes = 3 → start = 99 → s[99] = 0xA9 (continuation of first 'é')
-			// → advance to 100 → s[100] = 0xC3 (leading byte of second 'é') → stop
-			// kept = s[100:] = "é"
-			input:    strings.Repeat("a", 98) + "éé",
-			maxBytes: 3,
-			check: func(t *testing.T, result string) {
-				require.Equal(t, 102, len(strings.Repeat("a", 98)+"éé"))
-				assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
-				assert.Equal(t, truncationMarker+"é", result)
-			},
-		},
-		{
-			name:     "pure multibyte runes produce valid UTF-8",
-			input:    strings.Repeat("あ", 100), // 300 bytes; each rune is 3 bytes
-			maxBytes: 100,
-			check: func(t *testing.T, result string) {
-				// 100 / 3 = 33 complete runes (99 bytes); byte 100 is a continuation
-				// byte and is skipped.
-				assert.True(t, utf8.ValidString(result))
-				assert.Equal(t, truncationMarker+strings.Repeat("あ", 33), result)
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.check(t, truncateOutput(tc.input, tc.maxBytes))
-		})
-	}
-}
 
 // newAppForTest returns a minimal *App wired with no-op hooks.
 func newAppForTest(t *testing.T, appModel v1alpha1.App, opts Opts) *App {
@@ -137,9 +44,9 @@ func Test_updateLastDeploy_TruncatesLargeStdout(t *testing.T) {
 	a.updateLastDeploy(exec.CmdRunResult{Stdout: largeStdout, Finished: true, ExitCode: 0})
 
 	got := a.app.Status.Deploy.Stdout
-	assert.True(t, strings.HasPrefix(got, truncationMarker),
+	assert.True(t, strings.HasPrefix(got, exec.TruncationMarker),
 		"deploy stdout should start with truncation marker when over limit")
-	assert.LessOrEqual(t, len(got), len(truncationMarker)+limit,
+	assert.LessOrEqual(t, len(got), len(exec.TruncationMarker)+limit,
 		"deploy stdout should not exceed marker + limit bytes")
 }
 
@@ -154,8 +61,8 @@ func Test_updateLastDeploy_TruncatesLargeStderr(t *testing.T) {
 	a.updateLastDeploy(exec.CmdRunResult{Stderr: largeStderr, Finished: true, ExitCode: 1})
 
 	got := a.app.Status.Deploy.Stderr
-	assert.True(t, strings.HasPrefix(got, truncationMarker))
-	assert.LessOrEqual(t, len(got), len(truncationMarker)+limit)
+	assert.True(t, strings.HasPrefix(got, exec.TruncationMarker))
+	assert.LessOrEqual(t, len(got), len(exec.TruncationMarker)+limit)
 }
 
 func Test_updateLastDeploy_NoTruncation_WhenUnderLimit(t *testing.T) {
@@ -168,7 +75,7 @@ func Test_updateLastDeploy_NoTruncation_WhenUnderLimit(t *testing.T) {
 	a.updateLastDeploy(exec.CmdRunResult{Stdout: smallStdout, Finished: true, ExitCode: 0})
 
 	assert.NotEmpty(t, a.app.Status.Deploy.Stdout)
-	assert.False(t, strings.HasPrefix(a.app.Status.Deploy.Stdout, truncationMarker),
+	assert.False(t, strings.HasPrefix(a.app.Status.Deploy.Stdout, exec.TruncationMarker),
 		"output under the limit must not be prefixed with the truncation marker")
 }
 
@@ -202,8 +109,8 @@ func Test_setUsefulErrorMessage_TruncatesLargeStderr(t *testing.T) {
 	a.setUsefulErrorMessage(exec.CmdRunResult{Stderr: largeStderr, ExitCode: 1})
 
 	got := a.app.Status.UsefulErrorMessage
-	assert.True(t, strings.HasPrefix(got, truncationMarker))
-	assert.LessOrEqual(t, len(got), len(truncationMarker)+limit)
+	assert.True(t, strings.HasPrefix(got, exec.TruncationMarker))
+	assert.LessOrEqual(t, len(got), len(exec.TruncationMarker)+limit)
 }
 
 func Test_setUsefulErrorMessage_NoTruncation_WhenUnderLimit(t *testing.T) {

--- a/pkg/app/app_status_truncate_test.go
+++ b/pkg/app/app_status_truncate_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"carvel.dev/kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"carvel.dev/kapp-controller/pkg/deploy"
+	"carvel.dev/kapp-controller/pkg/exec"
+	"carvel.dev/kapp-controller/pkg/fetch"
+	"carvel.dev/kapp-controller/pkg/metrics"
+	"carvel.dev/kapp-controller/pkg/template"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func Test_truncateOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		check    func(t *testing.T, result string)
+	}{
+		{
+			name:     "under limit is unchanged",
+			input:    "small output",
+			maxBytes: 1024,
+			check: func(t *testing.T, result string) {
+				assert.Equal(t, "small output", result)
+			},
+		},
+		{
+			name:     "exactly at limit is unchanged",
+			input:    strings.Repeat("x", 100),
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				assert.Equal(t, strings.Repeat("x", 100), result)
+			},
+		},
+		{
+			name:     "empty string is unchanged",
+			input:    "",
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				assert.Equal(t, "", result)
+			},
+		},
+		{
+			name:     "over limit has marker prefix and tail suffix",
+			input:    strings.Repeat("a", 200) + strings.Repeat("z", 50),
+			maxBytes: 50,
+			check: func(t *testing.T, result string) {
+				assert.True(t, strings.HasPrefix(result, truncationMarker))
+				assert.True(t, strings.HasSuffix(result, strings.Repeat("z", 50)))
+				// Marker does not count toward maxBytes.
+				assert.Equal(t, len(truncationMarker)+50, len(result))
+			},
+		},
+		{
+			name: "tail content preserved for realistic kapp output",
+			// Many per-resource lines followed by an actionable summary.  maxBytes
+			// is set to hold only the last ~100 bytes so truncation is guaranteed,
+			// and the summary at the tail must survive.
+			input: strings.Repeat("op add configmap/cm-001 (v1) namespace: default\n", 100) +
+				"Op: 100 add, 0 delete\nWait to: 100 reconcile\n",
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				assert.True(t, strings.HasPrefix(result, truncationMarker),
+					"large output must start with the truncation marker")
+				assert.Contains(t, result, "100 add",
+					"the actionable summary at the tail must be preserved after truncation")
+			},
+		},
+		{
+			name: "UTF-8 boundary: continuation byte is skipped",
+			// s = 98 'a's + "éé"  (102 bytes)
+			// maxBytes = 3 → start = 99 → s[99] = 0xA9 (continuation of first 'é')
+			// → advance to 100 → s[100] = 0xC3 (leading byte of second 'é') → stop
+			// kept = s[100:] = "é"
+			input:    strings.Repeat("a", 98) + "éé",
+			maxBytes: 3,
+			check: func(t *testing.T, result string) {
+				require.Equal(t, 102, len(strings.Repeat("a", 98)+"éé"))
+				assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+				assert.Equal(t, truncationMarker+"é", result)
+			},
+		},
+		{
+			name:     "pure multibyte runes produce valid UTF-8",
+			input:    strings.Repeat("あ", 100), // 300 bytes; each rune is 3 bytes
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				// 100 / 3 = 33 complete runes (99 bytes); byte 100 is a continuation
+				// byte and is skipped.
+				assert.True(t, utf8.ValidString(result))
+				assert.Equal(t, truncationMarker+strings.Repeat("あ", 33), result)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, truncateOutput(tc.input, tc.maxBytes))
+		})
+	}
+}
+
+// newAppForTest returns a minimal *App wired with no-op hooks.
+func newAppForTest(t *testing.T, appModel v1alpha1.App, opts Opts) *App {
+	t.Helper()
+	return NewApp(appModel, Hooks{
+		BlockDeletion:   func() error { return nil },
+		UnblockDeletion: func() error { return nil },
+		UpdateStatus:    func(string) error { return nil },
+	}, fetch.Factory{}, template.Factory{}, deploy.Factory{},
+		logf.Log.WithName("test"),
+		opts,
+		metrics.NewMetrics(),
+		FakeComponentInfo{},
+	)
+}
+
+func Test_updateLastDeploy_TruncatesLargeStdout(t *testing.T) {
+	const limit = 50
+	a := newAppForTest(t, v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+	}, Opts{MaxStatusOutputBytes: limit})
+	a.app.Status.Deploy = &v1alpha1.AppStatusDeploy{}
+
+	largeStdout := strings.Repeat("resource change line\n", 1000)
+	a.updateLastDeploy(exec.CmdRunResult{Stdout: largeStdout, Finished: true, ExitCode: 0})
+
+	got := a.app.Status.Deploy.Stdout
+	assert.True(t, strings.HasPrefix(got, truncationMarker),
+		"deploy stdout should start with truncation marker when over limit")
+	assert.LessOrEqual(t, len(got), len(truncationMarker)+limit,
+		"deploy stdout should not exceed marker + limit bytes")
+}
+
+func Test_updateLastDeploy_TruncatesLargeStderr(t *testing.T) {
+	const limit = 50
+	a := newAppForTest(t, v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+	}, Opts{MaxStatusOutputBytes: limit})
+	a.app.Status.Deploy = &v1alpha1.AppStatusDeploy{}
+
+	largeStderr := strings.Repeat("error line\n", 1000)
+	a.updateLastDeploy(exec.CmdRunResult{Stderr: largeStderr, Finished: true, ExitCode: 1})
+
+	got := a.app.Status.Deploy.Stderr
+	assert.True(t, strings.HasPrefix(got, truncationMarker))
+	assert.LessOrEqual(t, len(got), len(truncationMarker)+limit)
+}
+
+func Test_updateLastDeploy_NoTruncation_WhenUnderLimit(t *testing.T) {
+	a := newAppForTest(t, v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+	}, Opts{MaxStatusOutputBytes: 10000})
+	a.app.Status.Deploy = &v1alpha1.AppStatusDeploy{}
+
+	smallStdout := "Changes\n\nOp: 1 add\n"
+	a.updateLastDeploy(exec.CmdRunResult{Stdout: smallStdout, Finished: true, ExitCode: 0})
+
+	assert.NotEmpty(t, a.app.Status.Deploy.Stdout)
+	assert.False(t, strings.HasPrefix(a.app.Status.Deploy.Stdout, truncationMarker),
+		"output under the limit must not be prefixed with the truncation marker")
+}
+
+func Test_updateLastDeploy_TailIsPreserved(t *testing.T) {
+	const limit = 40
+	a := newAppForTest(t, v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+	}, Opts{MaxStatusOutputBytes: limit})
+	a.app.Status.Deploy = &v1alpha1.AppStatusDeploy{}
+
+	// WithFriendlyYAMLStrings (called inside updateLastDeploy) strips trailing
+	// whitespace, so do not include a trailing newline in the expected assertion.
+	tail := "IMPORTANT: deploy succeeded"
+	a.updateLastDeploy(exec.CmdRunResult{
+		Stdout:   strings.Repeat("x", 500) + tail + "\n",
+		Finished: true,
+		ExitCode: 0,
+	})
+
+	assert.Contains(t, a.app.Status.Deploy.Stdout, tail,
+		"the tail (most recent output) must survive truncation")
+}
+
+func Test_setUsefulErrorMessage_TruncatesLargeStderr(t *testing.T) {
+	const limit = 50
+	a := newAppForTest(t, v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+	}, Opts{MaxStatusOutputBytes: limit})
+
+	largeStderr := strings.Repeat("kapp: Error: resource conflict\n", 1000)
+	a.setUsefulErrorMessage(exec.CmdRunResult{Stderr: largeStderr, ExitCode: 1})
+
+	got := a.app.Status.UsefulErrorMessage
+	assert.True(t, strings.HasPrefix(got, truncationMarker))
+	assert.LessOrEqual(t, len(got), len(truncationMarker)+limit)
+}
+
+func Test_setUsefulErrorMessage_NoTruncation_WhenUnderLimit(t *testing.T) {
+	a := newAppForTest(t, v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+	}, Opts{MaxStatusOutputBytes: 10000})
+
+	stderr := "kapp: Error: resource configmap/foo not found"
+	a.setUsefulErrorMessage(exec.CmdRunResult{Stderr: stderr, ExitCode: 1})
+
+	assert.Equal(t, stderr, a.app.Status.UsefulErrorMessage)
+}

--- a/pkg/exec/cmd_run_result.go
+++ b/pkg/exec/cmd_run_result.go
@@ -7,11 +7,16 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 var (
 	trailingSpace = regexp.MustCompile("\\s+\n")
 )
+
+// TruncationMarker is prepended to any output field that was clipped.
+// Operators can detect truncation by checking for this prefix.
+const TruncationMarker = "[output truncated]\n"
 
 type CmdRunResult struct {
 	Stdout   string
@@ -64,4 +69,32 @@ func (r CmdRunResult) WithFriendlyYAMLStrings() CmdRunResult {
 
 func (r CmdRunResult) IsEmpty() bool {
 	return r == (CmdRunResult{})
+}
+
+// WithTruncatedStrings returns a copy of r with Stdout and Stderr each capped
+// to maxBytes by keeping the tail (the most actionable kapp output always
+// appears last).  When a field is under the limit it is left unchanged.
+func (r CmdRunResult) WithTruncatedStrings(maxBytes int) CmdRunResult {
+	return CmdRunResult{
+		Stdout:   truncateOutput(r.Stdout, maxBytes),
+		Stderr:   truncateOutput(r.Stderr, maxBytes),
+		ExitCode: r.ExitCode,
+		Error:    r.Error,
+		Finished: r.Finished,
+	}
+}
+
+// truncateOutput returns s unchanged when len(s) <= maxBytes.  Otherwise it
+// returns TruncationMarker followed by the last maxBytes bytes of s, adjusted
+// forward to a valid UTF-8 rune boundary.
+func truncateOutput(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	start := len(s) - maxBytes
+	// Advance past UTF-8 continuation bytes to avoid splitting a multi-byte rune.
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return TruncationMarker + s[start:]
 }

--- a/pkg/exec/cmd_run_result_test.go
+++ b/pkg/exec/cmd_run_result_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package exec
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_truncateOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		check    func(t *testing.T, result string)
+	}{
+		{
+			name:     "under limit is unchanged",
+			input:    "small output",
+			maxBytes: 1024,
+			check: func(t *testing.T, result string) {
+				assert.Equal(t, "small output", result)
+			},
+		},
+		{
+			name:     "exactly at limit is unchanged",
+			input:    strings.Repeat("x", 100),
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				assert.Equal(t, strings.Repeat("x", 100), result)
+			},
+		},
+		{
+			name:     "empty string is unchanged",
+			input:    "",
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				assert.Equal(t, "", result)
+			},
+		},
+		{
+			name:     "over limit has marker prefix and tail suffix",
+			input:    strings.Repeat("a", 200) + strings.Repeat("z", 50),
+			maxBytes: 50,
+			check: func(t *testing.T, result string) {
+				assert.True(t, strings.HasPrefix(result, TruncationMarker))
+				assert.True(t, strings.HasSuffix(result, strings.Repeat("z", 50)))
+				// Marker does not count toward maxBytes.
+				assert.Equal(t, len(TruncationMarker)+50, len(result))
+			},
+		},
+		{
+			name: "tail content preserved for realistic kapp output",
+			// Many per-resource lines followed by an actionable summary.  maxBytes
+			// is set to hold only the last ~100 bytes so truncation is guaranteed,
+			// and the summary at the tail must survive.
+			input: strings.Repeat("op add configmap/cm-001 (v1) namespace: default\n", 100) +
+				"Op: 100 add, 0 delete\nWait to: 100 reconcile\n",
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				assert.True(t, strings.HasPrefix(result, TruncationMarker),
+					"large output must start with the truncation marker")
+				assert.Contains(t, result, "100 add",
+					"the actionable summary at the tail must be preserved after truncation")
+			},
+		},
+		{
+			name: "UTF-8 boundary: continuation byte is skipped",
+			// s = 98 'a's + "éé"  (102 bytes)
+			// maxBytes = 3 → start = 99 → s[99] = 0xA9 (continuation of first 'é')
+			// → advance to 100 → s[100] = 0xC3 (leading byte of second 'é') → stop
+			// kept = s[100:] = "é"
+			input:    strings.Repeat("a", 98) + "éé",
+			maxBytes: 3,
+			check: func(t *testing.T, result string) {
+				require.Equal(t, 102, len(strings.Repeat("a", 98)+"éé"))
+				assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+				assert.Equal(t, TruncationMarker+"é", result)
+			},
+		},
+		{
+			name:     "pure multibyte runes produce valid UTF-8",
+			input:    strings.Repeat("あ", 100), // 300 bytes; each rune is 3 bytes
+			maxBytes: 100,
+			check: func(t *testing.T, result string) {
+				// 100 / 3 = 33 complete runes (99 bytes); byte 100 is a continuation
+				// byte and is skipped.
+				assert.True(t, utf8.ValidString(result))
+				assert.Equal(t, TruncationMarker+strings.Repeat("あ", 33), result)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, truncateOutput(tc.input, tc.maxBytes))
+		})
+	}
+}
+
+func Test_WithTruncatedStrings(t *testing.T) {
+	const limit = 20
+	r := CmdRunResult{
+		Stdout:   strings.Repeat("o", 100),
+		Stderr:   strings.Repeat("e", 100),
+		ExitCode: 1,
+		Finished: true,
+	}
+	got := r.WithTruncatedStrings(limit)
+
+	assert.True(t, strings.HasPrefix(got.Stdout, TruncationMarker))
+	assert.True(t, strings.HasPrefix(got.Stderr, TruncationMarker))
+	assert.Equal(t, r.ExitCode, got.ExitCode, "ExitCode must be preserved")
+	assert.Equal(t, r.Finished, got.Finished, "Finished must be preserved")
+	assert.Equal(t, r.Error, got.Error, "Error must be preserved")
+}

--- a/test/e2e/kappcontroller/app_status_truncate_test.go
+++ b/test/e2e/kappcontroller/app_status_truncate_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package kappcontroller
+
+// Test_AppStatus_DeployStdout_CapturedAndBounded validates the end-to-end path
+// for status.deploy.stdout:
+//
+//  1. After a successful deploy, status.deploy.stdout is non-empty and contains
+//     recognisable kapp change-summary output.
+//  2. When a deploy produces output that fits within the 1 MiB limit it is
+//     stored verbatim (no truncation marker).
+//  3. When output exceeds the limit the stored value begins with the truncation
+//     marker "[output truncated]\n" so operators can immediately tell the field
+//     was clipped (verified via unit tests in pkg/app/app_status_truncate_test.go
+//     because generating >1 MiB in-cluster would require thousands of resources).
+//
+// Background: https://github.com/carvel-dev/kapp-controller/issues/1839
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"carvel.dev/kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	"carvel.dev/kapp-controller/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// generateConfigMapBundle returns inline YAML with count ConfigMaps, each with
+// a small data payload.  Deploying 30+ resources produces several KB of kapp
+// stdout and is enough to verify the output is captured in status without
+// approaching the 1 MiB truncation limit.
+func generateConfigMapBundle(count int) string {
+	var sb strings.Builder
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&sb, "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: trunc-test-cm-%03d\ndata:\n  index: \"%d\"\n", i, i)
+	}
+	return sb.String()
+}
+
+func Test_AppStatus_DeployStdout_CapturedAndBounded(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kapp := e2e.Kapp{T: t, Namespace: env.Namespace, L: logger}
+	sas := e2e.ServiceAccounts{Namespace: env.Namespace}
+
+	name := "deploy-stdout-truncate-test"
+
+	// 30 ConfigMaps → several KB of kapp output; well under the 1 MiB limit so
+	// no truncation occurs on this path.  The truncation behaviour itself is
+	// covered by unit tests in pkg/app/app_status_truncate_test.go.
+	configMaps := generateConfigMapBundle(30)
+
+	appYaml := fmt.Sprintf(`
+---
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: %s
+  annotations:
+    kapp.k14s.io/change-group: kappctrl-e2e.k14s.io/apps
+spec:
+  serviceAccountName: kappctrl-e2e-ns-sa
+  fetch:
+    - inline:
+        paths:
+          resources.yml: |
+%s
+  template:
+    - ytt: {}
+  deploy:
+    - kapp:
+        intoNs: %s
+`, name, indentYAML(configMaps, 12), env.Namespace) + sas.ForNamespaceYAML()
+
+	cleanUp := func() {
+		kapp.Run([]string{"delete", "-a", name})
+	}
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy app with 30 ConfigMaps", func() {
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			e2e.RunOpts{StdinReader: strings.NewReader(appYaml)})
+		require.NoError(t, err)
+	})
+
+	out := kapp.Run([]string{"inspect", "-a", name, "--raw", "--tty=false", "--filter-kind=App"})
+	require.Greater(t, len(out), 100, "inspect output should be non-trivial")
+
+	var cr v1alpha1.App
+	err := yaml.Unmarshal([]byte(out), &cr)
+	require.NoError(t, err, "failed to unmarshal App CR")
+
+	// --- deploy status assertions ---
+	require.NotNil(t, cr.Status.Deploy, "status.deploy must be set after a successful reconcile")
+
+	t.Run("stdout validation", func(t *testing.T) {
+		stdout := cr.Status.Deploy.Stdout
+
+		assert.NotEmpty(t, stdout, "stdout must contain kapp output after a successful deploy")
+		assert.Contains(t, stdout, "Op:", "stdout should contain the kapp Op summary line")
+		assert.False(t, strings.HasPrefix(stdout, "[output truncated]\n"), "small output must not be truncated")
+
+		const oneMiB = 1 * 1024 * 1024
+		assert.Less(t, len(stdout), oneMiB, "stdout must never exceed the 1 MiB cap")
+	})
+
+	t.Run("reconcile succeeded", func(t *testing.T) {
+		assert.Equal(t, v1alpha1.ReconcileSucceeded, cr.Status.Conditions[0].Type)
+	})
+}
+
+// indentYAML prepends spaces to every line so the YAML block fits as a
+// literal block scalar inside the parent document.
+func indentYAML(s string, spaces int) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l != "" {
+			lines[i] = prefix + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

On large clusters (>~250 nodes), a kapp deploy can produce several MiB of change output (one line per resource per node). kapp-controller writes this verbatim into status.deploy.stdout and then calls UpdateStatus on the App CR. etcd rejects objects larger than its hard 2 MiB gRPC message limit, causing the status write to fail repeatedly. The deployment itself has already succeeded, only the status update is failing but the App stays in ReconcileFailed until a subsequent no-op reconcile produces a small enough diff to fit.

This PR fixes the issue by truncating individual status output fields to 1 MiB before they are written into the status struct. When truncation occurs the field is prefixed with [output truncated]\n so operators immediately know the field is incomplete rather than receiving silently clipped output. The tail of the output is kept (not the head) because the most actionable content, the final resource summary and any error lines, always appears at the end of kapp output.

Fields covered: status.deploy.stdout, status.deploy.stderr, status.fetch.stdout, status.fetch.stderr, status.inspect.stdout, status.inspect.stderr, status.usefulErrorMessage.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1839 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
-->
```release-note
NA
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [-] Relevant docs in this repo added or updated
- [-] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
