### PR TITLE
fix: stop forwarding WatchList options to internal CRD watch

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -31,11 +31,13 @@ import (
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
 	genericopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	apirest "k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	apiservercompatibility "k8s.io/apiserver/pkg/util/compatibility"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -146,6 +148,10 @@ type NewAPIServerOpts struct {
 }
 
 func NewAPIServer(clientConfig *rest.Config, coreClient kubernetes.Interface, kcClient kcclient.Interface, opts NewAPIServerOpts) (*APIServer, error) { //nolint
+	if err := disableWatchListFeatureGate(); err != nil {
+		return nil, err
+	}
+
 	aggClient, err := aggregatorclient.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("building aggregation client: %v", err)
@@ -199,6 +205,29 @@ func NewAPIServer(clientConfig *rest.Config, coreClient kubernetes.Interface, kc
 	}
 
 	return &APIServer{server, make(chan struct{}), aggClient, opts.Logger}, nil
+}
+
+// disableWatchListFeatureGate turns off the WatchList feature for the packaging
+// aggregated API server. This server is a thin proxy whose storage is the host
+// cluster's InternalPackage(Metadata) CRDs, and its custom REST watch does not
+// synthesize the WatchList "initial-events-end" bookmark.
+//
+// With WatchList enabled, the embedded apiserver's SetListOptionsDefaults injects
+// sendInitialEvents + resourceVersionMatch=NotOlderThan into watch requests with
+// resourceVersion=0. Those defaulted options are then rejected with 422 by host
+// clusters that ship the WatchList feature gate disabled (e.g. Kubernetes 1.33,
+// which turned it off by default), breaking a plain "watch&resourceVersion=0".
+//
+// Disabling it here means such requests are served as a plain watch, and
+// WatchList-capable clients (e.g. client-go informers) receive a 422 for the
+// streaming request and transparently fall back to list+watch.
+func disableWatchListFeatureGate() error {
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+		string(genericfeatures.WatchList): false,
+	}); err != nil {
+		return fmt.Errorf("disabling WatchList feature gate: %v", err)
+	}
+	return nil
 }
 
 // Run spawns a go routine that exits when apiserver is stopped.

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -11,11 +11,24 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clienttesting "k8s.io/client-go/testing"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	fakeaggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 )
+
+// The packaging apiserver must run with the WatchList feature disabled so that
+// watch&resourceVersion=0 requests are not defaulted with sendInitialEvents,
+// which host clusters that ship WatchList off (e.g. K8s 1.33) reject with 422.
+func Test_disableWatchListFeatureGate(t *testing.T) {
+	err := disableWatchListFeatureGate()
+	require.NoError(t, err)
+
+	require.False(t, utilfeature.DefaultFeatureGate.Enabled(genericfeatures.WatchList),
+		"WatchList feature gate must be disabled for the packaging apiserver")
+}
 
 // fakeCAProvider implements dynamiccertificates.CAContentProvider
 type fakeCAProvider struct {


### PR DESCRIPTION
##  What this PR does / why we need it:
The packaging API server enables the `WatchList` feature by default, so it injects `sendInitialEvents` into `watch=1&resourceVersion=0` requests and forwards them to the host cluster's watch on the backing CRDs. On Kubernetes 1.33 the `WatchList` gate is disabled by default, so the host rejects those requests with 422 Unprocessable Entity ([gate default flipped off in 1.33](https://github.com/kubernetes/kubernetes/blob/v1.33.0/staging/src/k8s.io/apiserver/pkg/features/kube_features.go#L415-L420), back on in 1.34).

This disables the WatchList feature gate in the packaging API server. Raw `watch=1&resourceVersion=0` requests are then served as a plain watch (no injection), and WatchList-capable clients cleanly fall back to list+watch — consistent across all host versions.


## Manual Validation

This fix was validated by reproducing the issue and confirming the fix on two isolated `kind` clusters.

#### Environment

Both clusters run **Kubernetes v1.33.4** — the only affected version, since the `WatchList` feature gate ships **disabled by default** on 1.33 ([kube_features.go#L415-L420](https://github.com/kubernetes/kubernetes/blob/v1.33.0/staging/src/k8s.io/apiserver/pkg/features/kube_features.go#L415-L420)). Confirmed on both clusters:

    $ kubectl get --raw /metrics | grep 'kubernetes_feature_enabled{name="WatchList"'
    kubernetes_feature_enabled{name="WatchList",stage="BETA"} 0

Two kapp-controller images were built from the same Dockerfile — one from `develop` (pre-fix), one from this branch (post-fix) — and deployed one per cluster. Both pods reported `2/2 Running` with the packaging `APIService` `Available=True`, so the kapp-controller build was the only variable between the two clusters.

#### Request

    GET /apis/data.packaging.carvel.dev/v1alpha1/packages?watch=1&resourceVersion=0

#### Results

| Cluster    | kapp-controller build                 | Result                        |
|------------|----------------------------------------|--------------------------------|
| `kc-nofix` | `develop` @ `721929598` (no fix)       | ❌ `422 Unprocessable Entity`  |
| `kc-fix`   | this branch @ `e05009b71` (with fix)  | ✅ `200 OK`                    |

**Before fix:**

    $ kubectl --context kind-kc-nofix get --raw '/apis/data.packaging.carvel.dev/v1alpha1/packages?watch=1&resourceVersion=0'

    The ListOptions "" is invalid: sendInitialEvents: Forbidden: sendInitialEvents is
    forbidden for watch unless the WatchList feature gate is enabled

**After fix:**

    $ kubectl --context kind-kc-fix get --raw '/apis/data.packaging.carvel.dev/v1alpha1/packages?watch=1&resourceVersion=0' -v=8
    ...
    "Response" status="200 OK"

</details>


### Validation & Compatibility Matrix

To ensure absolute backward compatibility and stability across our support window following the `v0.36.0` library upgrades, the complete test suite (Unit, Validation, and E2E integration tests) was successfully executed against the following Kubernetes environments:

| Test | Job | Target Platform | Resolved K8s Version | Status |
| :--- | :--- | :--- | :--- | :--- |
| `test-gh / Run all tests`| [link](https://github.com/carvel-dev/kapp-controller/actions/runs/29490618115/job/87595572269?pr=1830) | Minikube (Docker) | `v1.32.13` | ✅ Passed |
| `test-gh / Run all tests`| [link](https://github.com/carvel-dev/kapp-controller/actions/runs/29490618115/job/87595572233?pr=1830) | Minikube (Docker) | `v1.33.12` | ✅ Passed |
| `test-gh / Run all tests`| [link](https://github.com/carvel-dev/kapp-controller/actions/runs/29490618115/job/87595572254?pr=1830) | Minikube (Docker) | `v1.34.8` | ✅ Passed |
| `test-gh / Run all tests`| [link](https://github.com/carvel-dev/kapp-controller/actions/runs/29490618115/job/87595572206?pr=1830) | Minikube (Docker) | `v1.35.5` | ✅ Passed |
| `test-gh / Run all tests`| [link](https://github.com/carvel-dev/kapp-controller/actions/runs/29480010860/job/87561378528) | Minikube (Docker) | `v1.36.1` | ✅ Passed |
| `Kind Cluster E2E tests`| [link](https://github.com/carvel-dev/kapp-controller/actions/runs/29490618106/job/87595572188?pr=1830) | Kind (`kinder`) | `v1.36.x` | ✅ Passed |
