### PR TITLE
Bump go to v1.26.5 & Update dependencies.yml with latest carvel releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS deps
 
 ARG TARGETOS TARGETARCH KCTRL_VER=development
 WORKDIR /workspace

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,10 +1,10 @@
 module carvel.dev/kapp-controller/cli
 
-go 1.26.3
+go 1.26.5
 
 require (
 	carvel.dev/kapp-controller v0.60.1-0.20260601134914-cb4fbdccc76a
-	carvel.dev/vendir v0.45.4
+	carvel.dev/vendir v0.46.1
 	github.com/cppforlife/cobrautil v0.0.0-20221130162803-acdfead391ef
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835
 	github.com/cppforlife/go-cli-ui v0.0.0-20220520125801-e45d9169a663

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,7 +1,7 @@
 carvel.dev/kapp-controller v0.60.1-0.20260601134914-cb4fbdccc76a h1:8Xl5k4FZUV7rhQKRmTG8mU4h3X6TH49AfczkdhvaAY4=
 carvel.dev/kapp-controller v0.60.1-0.20260601134914-cb4fbdccc76a/go.mod h1:KO+hw0vgiGPtcUuPt1XTBeTUSegTi9YM58/KwauiqYg=
-carvel.dev/vendir v0.45.4 h1:FO6JVnr0aA0Qd8Ews2baIjYRAejyBSxVvLMuSqVvwTk=
-carvel.dev/vendir v0.45.4/go.mod h1:ArnuY2g3wXtY4okBnJ4PpU7GyJGTot0w9hsuwXP0Rvw=
+carvel.dev/vendir v0.46.1 h1:bDYTvudX28aJ73KMSvwooaukl+474rEjKIjBy+a3Gus=
+carvel.dev/vendir v0.46.1/go.mod h1:CgF41YRwJcvCBbiMoppsrA/Jw3TUssH4b/ZKWX3t7kY=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/cli/vendor/carvel.dev/vendir/pkg/vendir/config/data.go
+++ b/cli/vendor/carvel.dev/vendir/pkg/vendir/config/data.go
@@ -6,6 +6,7 @@ package config
 const (
 	SecretK8sCorev1BasicAuthUsernameKey = "username"
 	SecretK8sCorev1BasicAuthPasswordKey = "password"
+	SecretK8sCorev1HTTPBearerTokenKey   = "token"
 
 	SecretK8sCoreV1SSHAuthPrivateKey = "ssh-privatekey"
 	SecretSSHAuthKnownHosts          = "ssh-knownhosts" // not part of k8s

--- a/cli/vendor/carvel.dev/vendir/pkg/vendir/config/directory.go
+++ b/cli/vendor/carvel.dev/vendir/pkg/vendir/config/directory.go
@@ -77,6 +77,11 @@ type DirectoryContentsGit struct {
 
 type DirectoryContentsGitVerification struct {
 	PublicKeysSecretRef *DirectoryContentsLocalRef `json:"publicKeysSecretRef,omitempty"`
+	// AllowLegacySignatures, under GODEBUG=fips140=only, downgrades a
+	// non-FIPS-approved signature algorithm (SHA-1, MD5, DSA) from an
+	// error to a warning instead of rejecting it.
+	// +optional
+	AllowLegacySignatures bool `json:"allowLegacySignatures,omitempty"`
 }
 
 type DirectoryContentsHg struct {

--- a/cli/vendor/modules.txt
+++ b/cli/vendor/modules.txt
@@ -48,8 +48,8 @@ carvel.dev/kapp-controller/pkg/reconciler
 carvel.dev/kapp-controller/pkg/reftracker
 carvel.dev/kapp-controller/pkg/satoken
 carvel.dev/kapp-controller/pkg/template
-# carvel.dev/vendir v0.45.4
-## explicit; go 1.25.7
+# carvel.dev/vendir v0.46.1
+## explicit; go 1.26.5
 carvel.dev/vendir/pkg/vendir/config
 carvel.dev/vendir/pkg/vendir/version
 carvel.dev/vendir/pkg/vendir/versions

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module carvel.dev/kapp-controller
 
-go 1.26.3
+go 1.26.5
 
 require (
-	carvel.dev/vendir v0.45.4
+	carvel.dev/vendir v0.46.1
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/gogo/protobuf v1.3.2
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-carvel.dev/vendir v0.45.4 h1:FO6JVnr0aA0Qd8Ews2baIjYRAejyBSxVvLMuSqVvwTk=
-carvel.dev/vendir v0.45.4/go.mod h1:ArnuY2g3wXtY4okBnJ4PpU7GyJGTot0w9hsuwXP0Rvw=
+carvel.dev/vendir v0.46.1 h1:bDYTvudX28aJ73KMSvwooaukl+474rEjKIjBy+a3Gus=
+carvel.dev/vendir v0.46.1/go.mod h1:CgF41YRwJcvCBbiMoppsrA/Jw3TUssH4b/ZKWX3t7kY=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=

--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -1,15 +1,15 @@
 - checksums:
     darwin:
-      amd64: b6a946878b74883c093bcc3e93960c68a6058a7e2be6ee2c78f1ba5f80fe3c02
-      arm64: cf4d4afcf32e5cab1ba55a74f436c7e4bd04326c168a11be17078162629100e9
+      amd64: b7b8435cd5cca719b933b0bc846a0f872bd2ed0c68fa9b74ec8369bef2ac0987
+      arm64: 4a61ebc3cace9ed6c1f2d4cc7285589e85c58869d96bc36cb0d09987ec14fcd1
     linux:
-      amd64: 3a2c925ed222f8db4956946d40279688edd6ceb3e919f03f919a8fc8b8532eda
-      arm64: ce61f7aee3f66f9b78d5781ef8528b7c8e199a2747796ef17a954118d3e65724
+      amd64: 512cc21193d3b0ce307b6e8db6ba8d40831f16e02526e1c753416456ea4319af
+      arm64: 6b09566cd9cbe90050c8685889aa1eef050c3f1168809df2486062e8a3ed1ec0
   dev: true
   name: ytt
   repo: vmware-tanzu/carvel-ytt
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.55.1
+  version: v0.55.2
 - checksums:
     darwin:
       amd64: d6c6dd4af41bea5cb3c8914e9b43536fc3c606592ddaaa98dda08b8517400969
@@ -24,28 +24,28 @@
   version: v0.49.1
 - checksums:
     darwin:
-      amd64: cebb31f6b72cd94dc4e1c17b31ba6e4ac70caeb53e4b29aea1fbc1885605e9a7
-      arm64: 75c1c9809d3d3c618480be6ffaa00a4650e9792a86c8e561d63d8927828fc0e1
+      amd64: d2f6a45c09703f2aff01422cc130f00f702094757c17804ab18de4dda2249ada
+      arm64: a7ecd6a2ac62fdce02bb40784f2701e2421539e4bae6c3cd58dc8e943170c666
     linux:
-      amd64: 1724da4b62982285b1da696fb0354738e33913b33e59f3787b5c2b5ac7030327
-      arm64: 485eb76508c33365780a91831ebbf030b1be93b02d6011935abdaa751328d719
+      amd64: bf7df0647d7645572d45185bb8bf6a40dd1e631ff4ee1522bc8ce56db53bd243
+      arm64: e41693ac3d69e1143c7e5fe870712ca05ed810e1e0bc5b00f77ca22ba0f18ae1
   dev: true
   name: kapp
   repo: vmware-tanzu/carvel-kapp
   urlTemplate: https://github.com/vmware-tanzu/carvel-{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.65.3
+  version: v0.65.4
 - checksums:
     darwin:
-      amd64: 5b417c837b0134fabf2c4a322db054eacb8cfbe8d0e8cbbb86afc7e4f0d625fd
-      arm64: e136160aa642231c6eb1df25cbe3e57e5f3848ac0a7e7de57bbc3249fdbd800f
+      amd64: 133871a31862e2ea14c55e7162d5227b3b9b54774376faf2aea3f8802dd5bf2b
+      arm64: b0ed7ffa337b4964e5a0b865b786e97b75e7777fb4a289f06193671b81e320a9
     linux:
-      amd64: 878f3c77cae21b9b63d0ea6c11454c0008d41652d2eb3d1844fdcf69cca6ae9e
-      arm64: f80a27f1247ad4353b6054ca9d7e13e2511bf70c0e28d85bc314d2177ec2b0d2
+      amd64: 96318c8f2f6ed8b0853b5fac50e22e400af6d8fb2699835e5a8b1663db65c6a9
+      arm64: 6f9b8d829fdead89b40feca901c5804826db94121abecdc6808052c3252e847b
   dev: true
   name: vendir
   repo: carvel-dev/vendir
   urlTemplate: https://github.com/carvel-dev/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.46.0
+  version: v0.46.1
 - checksums:
     linux:
       amd64: e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c

--- a/vendor/carvel.dev/vendir/pkg/vendir/config/data.go
+++ b/vendor/carvel.dev/vendir/pkg/vendir/config/data.go
@@ -6,6 +6,7 @@ package config
 const (
 	SecretK8sCorev1BasicAuthUsernameKey = "username"
 	SecretK8sCorev1BasicAuthPasswordKey = "password"
+	SecretK8sCorev1HTTPBearerTokenKey   = "token"
 
 	SecretK8sCoreV1SSHAuthPrivateKey = "ssh-privatekey"
 	SecretSSHAuthKnownHosts          = "ssh-knownhosts" // not part of k8s

--- a/vendor/carvel.dev/vendir/pkg/vendir/config/directory.go
+++ b/vendor/carvel.dev/vendir/pkg/vendir/config/directory.go
@@ -77,6 +77,11 @@ type DirectoryContentsGit struct {
 
 type DirectoryContentsGitVerification struct {
 	PublicKeysSecretRef *DirectoryContentsLocalRef `json:"publicKeysSecretRef,omitempty"`
+	// AllowLegacySignatures, under GODEBUG=fips140=only, downgrades a
+	// non-FIPS-approved signature algorithm (SHA-1, MD5, DSA) from an
+	// error to a warning instead of rejecting it.
+	// +optional
+	AllowLegacySignatures bool `json:"allowLegacySignatures,omitempty"`
 }
 
 type DirectoryContentsHg struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
-# carvel.dev/vendir v0.45.4
-## explicit; go 1.25.7
+# carvel.dev/vendir v0.46.1
+## explicit; go 1.26.5
 carvel.dev/vendir/pkg/vendir/config
 carvel.dev/vendir/pkg/vendir/version
 carvel.dev/vendir/pkg/vendir/versions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Bumps the Go toolchain to v1.26.5 and vendir to v0.46.1.
- `go.mod` / `cli/go.mod`: raise the required Go version to `1.26.5` & vendir to `v0.46.1`.
- `Dockerfile`: bump the `golang` builder base image from `1.26.3` to `1.26.5` to match — the base image must be updated in lockstep with `go.mod`, otherwise the toolchain-pinned build fails with `go: go.mod requires go >= 1.26.5 (running go 1.26.3; GOTOOLCHAIN=local)`.
- `hack/dependencies.yml`: refresh checksums for the `ytt` (v0.55.1 → v0.55.2), `kapp` (v0.65.3 → v0.65.4) and `vendir` (v0.46.0 → v0.46.1) dev tool releases pulled in by this bump.
- `vendor/carvel.dev/vendir/...` and `cli/vendor/carvel.dev/vendir/...`: update vendored vendir packages to v0.46.1.

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #

#### Does this PR introduce a user-facing change?
<!--


-->
```release-note
NONE
```

#### Additional Notes for your reviewer:
Routine dependency/toolchain bump; no functional/behavioral changes to kapp-controller itself. Verified locally that:
- go build succeeds against go.mod's Go 1.26.5 requirement.
- The updated ytt/vendir checksums in hack/dependencies.yml match the real release artifacts.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
