### PR TITLE
Fix:[1852] Add TestK8APIEndpoints and run it across k8s v1.33-v1.37 in CI

### DIFF
--- a/.github/workflows/k8s-api-endpoints.yml
+++ b/.github/workflows/k8s-api-endpoints.yml
@@ -1,0 +1,101 @@
+name: K8s API Endpoints Compatibility
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  k8s-api-endpoints:
+    name: TestK8APIEndpoints (all k8s versions)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install kind + kubectl
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+          version: v0.33.0
+      - name: Install Carvel Tools
+        run: ./hack/install-deps.sh
+      - name: Resolve k8s versions kapp-controller supports
+        run: |
+          set -e -x
+          # Derive the minors to test from the client-go version already
+          # pinned in go.mod instead of hand-maintaining a version list here
+          # - it shifts automatically as dependency-updater.yml bumps go.mod.
+          # Covers the last 4 released minors plus the next (not-yet-pinned)
+          # one, wider than client-go's own +/-1 minor skew guarantee, since
+          # kapp-controller's CRD/aggregated-API surface tends to stay
+          # compatible well beyond that window in practice.
+          client_go_minor=$(grep -oE 'k8s\.io/client-go v0\.[0-9]+\.[0-9]+' go.mod | grep -oE '[0-9]+\.[0-9]+$' | cut -d. -f1)
+          minors=(v1.$((client_go_minor - 3)) v1.$((client_go_minor - 2)) v1.$((client_go_minor - 1)) v1.${client_go_minor} v1.$((client_go_minor + 1)))
+
+          # kindest/node images are cut by the kind maintainers on their own
+          # cadence, not one-for-one with every kubernetes/kubernetes patch
+          # tag (e.g. kubernetes/kubernetes had v1.33.13 with no matching
+          # kindest/node image yet), so the only accurate source for "which
+          # node images actually exist" is the registry itself.
+          url="https://hub.docker.com/v2/repositories/kindest/node/tags?page_size=100"
+          all_tags=""
+          while [ -n "$url" ] && [ "$url" != "null" ]; do
+            page=$(curl -sf "$url")
+            all_tags="$all_tags
+          $(echo "$page" | jq -r '.results[].name')"
+            url=$(echo "$page" | jq -r '.next')
+          done
+
+          versions=()
+          for m in "${minors[@]}"; do
+            latest=$(echo "$all_tags" | grep -E "^${m}\.[0-9]+$" | sort -V | tail -1)
+            if [ -z "$latest" ]; then
+              echo "::error::No kubernetes/kubernetes tag found for $m"
+              exit 1
+            fi
+            versions+=("$latest")
+          done
+          echo "Resolved versions: ${versions[*]}"
+          {
+            echo "K8S_VERSIONS<<EOF"
+            printf '%s\n' "${versions[@]}"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+      - name: Build kapp-controller image
+        run: |
+          set -e -x
+          source ./hack/version-util.sh
+          ytt -f config/config -f config/values-schema.yml -f config-dev -v dev.version="$(get_kappctrl_ver)+develop" | kbld -f- > kbld.out 2> kbldmeta.out
+          echo "KC_IMAGE=$(cat kbldmeta.out | tail -n 1 | sed 's/.*final: kapp-controller -> \(.*\)$/\1/p' | tail -n 1)" >> "$GITHUB_ENV"
+      - name: Run TestK8APIEndpoints across k8s versions
+        run: |
+          set -x
+          mkdir -p tmp
+          failed=()
+          while IFS= read -r version; do
+            [ -z "$version" ] && continue
+            echo "::group::TestK8APIEndpoints (kindest/node:${version})"
+            ok=true
+            kind create cluster --name kinder --image "kindest/node:${version}" || ok=false
+            if $ok; then kind load docker-image "$KC_IMAGE" --name kinder || ok=false; fi
+            if $ok; then kapp deploy -a kc -f kbld.out -c -y || ok=false; fi
+            if $ok; then
+              KAPPCTRL_E2E_NAMESPACE=kappctrl-test ./hack/test-e2e.sh -run TestK8APIEndpoints || ok=false
+            fi
+            if $ok; then
+              echo "TestK8APIEndpoints passed for kindest/node:${version}"
+            else
+              echo "::error::TestK8APIEndpoints FAILED for kindest/node:${version}"
+              failed+=("$version")
+            fi
+            kind delete cluster --name kinder || true
+            echo "::endgroup::"
+          done <<< "$K8S_VERSIONS"
+          if [ ${#failed[@]} -ne 0 ]; then
+            echo "::error::TestK8APIEndpoints failed for k8s version(s): ${failed[*]}"
+            exit 1
+          fi

--- a/test/e2e/kappcontroller/k8s_api_endpoints_test.go
+++ b/test/e2e/kappcontroller/k8s_api_endpoints_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package kappcontroller
+
+import (
+	"testing"
+	"time"
+
+	"carvel.dev/kapp-controller/test/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8APIEndpoints(t *testing.T) {
+	env := e2e.BuildEnv(t)
+	logger := e2e.Logger{}
+	kubectl := e2e.Kubectl{T: t, Namespace: env.Namespace, L: logger}
+
+	logger.Section("aggregated APIService is Available", func() {
+		require.Eventually(t, func() bool {
+			out, err := kubectl.RunWithOpts([]string{
+				"get", "apiservice", "v1alpha1.data.packaging.carvel.dev",
+				"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+			}, e2e.RunOpts{NoNamespace: true, AllowError: true})
+			return err == nil && out == "True"
+		}, 60*time.Second, 2*time.Second, "APIService v1alpha1.data.packaging.carvel.dev never became Available")
+	})
+
+	logger.Section("data.packaging.carvel.dev/v1alpha1 discovery", func() {
+		out, _ := kubectl.RunWithOpts([]string{"get", "--raw", "/apis/data.packaging.carvel.dev/v1alpha1"},
+			e2e.RunOpts{NoNamespace: true})
+		require.Contains(t, out, `"name":"packages"`)
+		require.Contains(t, out, `"name":"packagemetadatas"`)
+	})
+
+	logger.Section("packaging.carvel.dev/v1alpha1 CRD discovery", func() {
+		out, _ := kubectl.RunWithOpts([]string{"api-resources", "--api-group=packaging.carvel.dev", "-o", "name"},
+			e2e.RunOpts{NoNamespace: true})
+		require.Contains(t, out, "packageinstalls.packaging.carvel.dev")
+		require.Contains(t, out, "packagerepositories.packaging.carvel.dev")
+	})
+
+	logger.Section("kappctrl.k14s.io/v1alpha1 CRD discovery", func() {
+		out, _ := kubectl.RunWithOpts([]string{"api-resources", "--api-group=kappctrl.k14s.io", "-o", "name"},
+			e2e.RunOpts{NoNamespace: true})
+		require.Contains(t, out, "apps.kappctrl.k14s.io")
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `TestK8APIEndpoints`, an e2e test verifying that after deploying kapp-controller:
- the aggregated APIService `v1alpha1.data.packaging.carvel.dev` becomes `Available`
- `data.packaging.carvel.dev/v1alpha1` discovery exposes `packages` and `packagemetadatas`
- `packaging.carvel.dev` discovery exposes `packageinstalls` and `packagerepositories`
- `kappctrl.k14s.io` discovery exposes `apps`

This closes a gap where kapp-controller's CRD/aggregated-API registration had no dedicated test coverage, so a regression here (e.g. the aggregated APIService failing to become `Available` on a given apiserver version) could only be caught indirectly, if at all. This test runs on every PR via the existing "Kind Cluster E2E tests" `run-tests` job, alongside the rest of the e2e suite, against the default kind node image.

Adds a new `k8s-api-endpoints.yml` workflow, on a daily schedule plus `workflow_dispatch`, that runs `TestK8APIEndpoints` across the range of k8s minor versions kapp-controller supports. Compatibility drift from new k8s releases isn't a per-diff regression concern, so this runs separately from PRs rather than adding checks to every one, following the same schedule + `workflow_dispatch` idiom as `trivy-scan.yml`/`dependency-updater.yml`. The minors tested are derived from the `k8s.io/client-go` version pinned in `go.mod` (the last 4 released minors plus the next one), so the range shifts automatically as `dependency-updater.yml` bumps `go.mod` instead of being hand-maintained. The latest patch for each minor is resolved at run time from `kubernetes/kubernetes`'s tags (via `git ls-remote`, avoiding GitHub REST API rate limits). The job then loops over the resolved versions sequentially in a single job, creating and tearing down one kind cluster per version. A failure on one version doesn't stop the others: the loop runs through every version regardless, reports each failing k8s version via `::error::` annotations, and only fails the job once all versions have been attempted.

Sample CI run for this workflow : 
https://github.com/sameerforge/kapp-controller/actions/runs/34329006415/job/102392900710

#### Which issue(s) this PR fixes:
Fixes #1852

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional Notes for your reviewer:
- The `k8s-api-endpoints` job installs `kind/kubectl` once via `helm/kind-action@v1` (`install_only: true`, pinned to `v0.33.0` because the action's current default, `v0.31.0`, can't parse the containerd config v4 format that newer `kindest/node` images ship — this was breaking `kind load docker-image` for k8s v1.34+), builds the kapp-controller image once, then loops: `kind create cluster` → `kind load docker-image` → `kapp deploy` → run `TestK8APIEndpoints` → `kind delete cluster`, per resolved version.
- `run-tests` (full e2e suite) is untouched and keeps testing against the default/latest kind node image.

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [x] Relevant tests are added or updated
- [ ] Relevant docs in this repo added or updated
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
