### PR TITLE
Fix[1603]: Update vendir to v0.46.2 (consumes fix for issue #1603)

### DIFF
--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: misspell
-        uses: reviewdog/action-misspell@v1.26.3
+        uses: reviewdog/action-misspell@ba7ac4030fa6812f8c8b2d4e516af8bc99553c32 #v1.28.0
         with:
-          fail_on_error: true
+          fail_level: error
           locale: "US"
           exclude: |
             ./vendor/*

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -50,6 +50,7 @@ jobs:
       with: 
         kubernetes-version: ${{ env.k8s_version }}
         driver: docker
+        container-runtime: docker
         start: true
         cpus: 3
         memory: 8192m

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	carvel.dev/kapp-controller v0.60.1-0.20260601134914-cb4fbdccc76a
-	carvel.dev/vendir v0.46.1
+	carvel.dev/vendir v0.46.2
 	github.com/cppforlife/cobrautil v0.0.0-20221130162803-acdfead391ef
 	github.com/cppforlife/color v1.9.1-0.20200716202919-6706ac40b835
 	github.com/cppforlife/go-cli-ui v0.0.0-20220520125801-e45d9169a663

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,7 +1,7 @@
 carvel.dev/kapp-controller v0.60.1-0.20260601134914-cb4fbdccc76a h1:8Xl5k4FZUV7rhQKRmTG8mU4h3X6TH49AfczkdhvaAY4=
 carvel.dev/kapp-controller v0.60.1-0.20260601134914-cb4fbdccc76a/go.mod h1:KO+hw0vgiGPtcUuPt1XTBeTUSegTi9YM58/KwauiqYg=
-carvel.dev/vendir v0.46.1 h1:bDYTvudX28aJ73KMSvwooaukl+474rEjKIjBy+a3Gus=
-carvel.dev/vendir v0.46.1/go.mod h1:CgF41YRwJcvCBbiMoppsrA/Jw3TUssH4b/ZKWX3t7kY=
+carvel.dev/vendir v0.46.2 h1:nAzLEJ6aCAPYLtG8pifI3CMshfImsME8XIpcG2J0JLw=
+carvel.dev/vendir v0.46.2/go.mod h1:CgF41YRwJcvCBbiMoppsrA/Jw3TUssH4b/ZKWX3t7kY=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/cli/vendor/modules.txt
+++ b/cli/vendor/modules.txt
@@ -48,7 +48,7 @@ carvel.dev/kapp-controller/pkg/reconciler
 carvel.dev/kapp-controller/pkg/reftracker
 carvel.dev/kapp-controller/pkg/satoken
 carvel.dev/kapp-controller/pkg/template
-# carvel.dev/vendir v0.46.1
+# carvel.dev/vendir v0.46.2
 ## explicit; go 1.26.5
 carvel.dev/vendir/pkg/vendir/config
 carvel.dev/vendir/pkg/vendir/version

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module carvel.dev/kapp-controller
 go 1.26.5
 
 require (
-	carvel.dev/vendir v0.46.1
+	carvel.dev/vendir v0.46.2
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/gogo/protobuf v1.3.2
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-carvel.dev/vendir v0.46.1 h1:bDYTvudX28aJ73KMSvwooaukl+474rEjKIjBy+a3Gus=
-carvel.dev/vendir v0.46.1/go.mod h1:CgF41YRwJcvCBbiMoppsrA/Jw3TUssH4b/ZKWX3t7kY=
+carvel.dev/vendir v0.46.2 h1:nAzLEJ6aCAPYLtG8pifI3CMshfImsME8XIpcG2J0JLw=
+carvel.dev/vendir v0.46.2/go.mod h1:CgF41YRwJcvCBbiMoppsrA/Jw3TUssH4b/ZKWX3t7kY=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=

--- a/hack/dependencies.yml
+++ b/hack/dependencies.yml
@@ -36,16 +36,16 @@
   version: v0.65.4
 - checksums:
     darwin:
-      amd64: 133871a31862e2ea14c55e7162d5227b3b9b54774376faf2aea3f8802dd5bf2b
-      arm64: b0ed7ffa337b4964e5a0b865b786e97b75e7777fb4a289f06193671b81e320a9
+      amd64: 92160571582d04e1da66a15e476d4f63b6ca894593c6b126b0d53bea8da0f58b
+      arm64: dd77c509214e3a7114d30de4b9a94ba09cdcb84230244589db10448d8c744662
     linux:
-      amd64: 96318c8f2f6ed8b0853b5fac50e22e400af6d8fb2699835e5a8b1663db65c6a9
-      arm64: 6f9b8d829fdead89b40feca901c5804826db94121abecdc6808052c3252e847b
+      amd64: 0b4bad28b765c4cbf0cc2234d0d420bcf2d352b58eb202e9c55263374f95bd71
+      arm64: bb0574c3aff6a5ae99801ceb3d63893917f763908700883bc1fbbcfed2ab6c9b
   dev: true
   name: vendir
   repo: carvel-dev/vendir
   urlTemplate: https://github.com/carvel-dev/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}
-  version: v0.46.1
+  version: v0.46.2
 - checksums:
     linux:
       amd64: e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# carvel.dev/vendir v0.46.1
+# carvel.dev/vendir v0.46.2
 ## explicit; go 1.26.5
 carvel.dev/vendir/pkg/vendir/config
 carvel.dev/vendir/pkg/vendir/version


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/carvel-dev/kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/carvel-dev/kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:

This PR bumps the vendir version to v0.46.2 to consume fix for issue #1603 
ref: https://github.com/carvel-dev/vendir/pull/465

#### Which issue(s) this PR fixes:
<!--
If no issue exists for this change, please create an issue and link it here.
-->
Fixes #1603 

NOTE: This change also updates the following 
- Added `container-runtime: docker` to handle minikube's default runtime changing to containerd (This is short term fix, long term goal will be to move completely to containerd) 
- reviewdog/action-misspell -> updated the version for action-misspell

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 

-->
```release-note
NA
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [-] Relevant tests are added or updated
- [-] Relevant docs in this repo added or updated
- [-] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [-] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
